### PR TITLE
feat(ui): M3 dynamic color (@ngguide/ui/theme)

### DIFF
--- a/.specs/m3-dynamic-color/design.md
+++ b/.specs/m3-dynamic-color/design.md
@@ -488,3 +488,10 @@ describe('M3ThemeService (TestBed + DOCUMENT)', () => {
 4. **Custom name equal to a core role** — rejected by validation (Req 5.5).
 5. **Server render then hydrate** — identical CSS string both sides → no theme flash (Req 10.3).
 6. **`#RGB` shorthand / uppercase hex** — accepted; normalized before `argbFromHex`.
+
+## Deviations
+
+Tracked during implementation (per the deviation protocol). None change the architecture or the Decisions table.
+
+- **Minor — Vitest `runnerConfig` for MCU (Group A, task 7).** `@material/material-color-utilities` is ESM-only and ships some extensionless relative imports (e.g. `color_spec_2025.js` → `./dynamic_color`). The Angular Vitest builder externalizes packages, so the theme specs failed to import MCU through raw Node ESM. Resolution: a small `libs/ui/vitest.config.ts` wired via the builder's supported `runnerConfig` option, inlining MCU (`ssr.noExternal` + `deps.optimizer.ssr.include`) so Vite/esbuild resolves it. This is the first test-runner config in the repo (CLAUDE.md notes the builder is otherwise zero-config) and is test-only — production build/runtime are unaffected (apps bundle MCU via esbuild, which resolves the imports). `vitest.config.ts` is added to `@nx/dependency-checks` `ignoredFiles`.
+- **Minor — ng-packagr `allowedNonPeerDependencies` (Group A, task 1/8).** Decision 2A ships MCU in `dependencies` (not `peerDependencies`). ng-packagr blocks non-peer runtime deps unless allow-listed, so `libs/ui/ng-package.json` gains `"allowedNonPeerDependencies": ["@material/material-color-utilities"]`. This is the canonical ng-packagr mechanism for Decision 2A and keeps MCU externalized into `dist/libs/ui/package.json`.

--- a/.specs/m3-dynamic-color/design.md
+++ b/.specs/m3-dynamic-color/design.md
@@ -1,0 +1,490 @@
+---
+created: 2026-05-29
+updated: 2026-05-29
+---
+
+# Design Document: M3 Dynamic Color
+
+## Overview
+
+Add a runtime dynamic-color system to `@ngguide/ui`, shipped as a new secondary entry point
+**`@ngguide/ui/theme`**. It generates a full M3 color scheme from a source color (plus optional
+custom colors) using `@material/material-color-utilities` (MCU) — the same `DynamicScheme` /
+`MaterialDynamicColors` path the static `m3-tokens` generator uses — and applies it by injecting a
+`<style>` element whose CSS mirrors the static `_color.generated.css` shape (`light-dark()` pairs
+under `[data-contrast]` scopes). An Angular provider (`provideM3Theme`) applies the configured scheme
+at bootstrap (server and browser) and a service swaps it at runtime. A pure, DOM-free generation core
+makes it SSR-safe; an SSR host is added to `apps/web` to verify Req 10 end-to-end.
+
+### Key Changes
+
+1. **New entry point `@ngguide/ui/theme`** exporting `provideM3Theme`, `M3ThemeService`, the scheme
+   generation/read API, and all public types.
+2. **MCU promoted to a runtime dependency** of `libs/ui` (`dependencies`); the role-enumeration logic
+   used by the build-time generator is reproduced in shipped library code so runtime output matches
+   the static token contract by construction.
+3. **Runtime `<style>` injection** via `RendererFactory2` + `DOCUMENT`, producing CSS identical in
+   shape to `m3-tokens` so OS light/dark auto-switch and `[data-contrast]` scopes keep working; the
+   injected element is appended after the static baseline so it overrides it.
+4. **Contrast-aware custom colors** derived through the canonical DynamicScheme algorithm (the custom
+   color seeds its own scheme; its primary family becomes the 4 custom roles), with optional
+   `Blend.harmonize` toward the source.
+5. **SSR host added to `apps/web`** (`@angular/ssr` + server entry + build options) to exercise
+   SSR-safety; the library itself stays framework-host-agnostic.
+
+### Decisions
+
+| Problem Area | Chosen Variant | Why chosen | Reference |
+|-------------|----------------|------------|-----------|
+| 1. Scheme generation engine | **1A** — `DynamicScheme` + `MaterialDynamicColors` | Same MCU API as the static generator → token contract matches by construction; all 9 variants + 3 contrasts from one code path; Effort Low / Risk Low | research.md §1 |
+| 2. Color-engine packaging | **2A** — MCU as `dependencies` | Works out-of-the-box for consumers; lowest risk; matches "ship a working theme API" goal | research.md §2 |
+| 3. Runtime token application | **3A** — injected `<style>` text | Reproduces the static CSS shape so `light-dark()` + `[data-contrast]` + OS switch survive; SSR-safe; reliably overrides baseline via document order | research.md §3 |
+| 4. Angular & SSR lifecycle | **4A** — `EnvironmentProviders` + bootstrap initializer + service | Theme in effect for first render on server and client; matches the pre-defined `provideM3Theme(): EnvironmentProviders` interface; runtime updates via injectable | research.md §4 |
+| 5. Custom-color modeling | **5B** — palette per color through the contrast pipeline | Only variant satisfying Req 5.4 (contrast-aware custom colors); consistent with 1A; harmonize is per-color | research.md §5 |
+
+Additional decisions (open questions resolved with the user during the Decision Pass):
+
+- **Entry-point placement:** a **new** secondary entry `@ngguide/ui/theme` (not the root entry), so
+  importing `GuiSize` from `@ngguide/ui` never pulls MCU into the bundle.
+- **SSR verification:** add a real **SSR host** to `apps/web` so Req 10 is verified end-to-end (not
+  only via DOM-free unit tests).
+
+### Spec-fidelity note (M3 ambiguity, documented per the strict-M3 rule)
+
+Official MCU `customColor()` produces custom-color roles at **fixed tones with no contrast
+adjustment** — M3 does not publish a contrast-adjusted custom-color table. Req 5.4 nonetheless
+requires custom colors to respond to contrast. To stay within the canonical algorithm rather than
+invent tone deltas, each custom color is treated as the **seed of its own `DynamicScheme`** (same
+variant, the selected `contrastLevel`, light/dark); its **primary family** —
+`primary` / `onPrimary` / `primaryContainer` / `onPrimaryContainer` — becomes the custom color's
+`color` / `on-color` / `color-container` / `on-color-container`. This reuses M3's own contrast-aware
+role math, so the values are spec-traceable. This interpretation is recorded here as the resolution
+of an M3 gap (see Open Questions in research.md).
+
+## Architecture
+
+### Component Diagram
+
+```mermaid
+graph TB
+    subgraph consumer["Consumer app (e.g. apps/web)"]
+        cfg["provideM3Theme(config)"]
+        picker["Brand picker / runtime caller"]
+    end
+
+    subgraph theme["@ngguide/ui/theme"]
+        prov["provideM3Theme<br/>(EnvironmentProviders)"]
+        init["env initializer"]
+        svc["M3ThemeService"]
+        engine["scheme engine<br/>generateScheme()"]
+        custom["custom-color engine<br/>(Blend.harmonize + DynamicScheme)"]
+        css["CSS builder<br/>buildCss()"]
+        applier["style applier<br/>(RendererFactory2 + DOCUMENT)"]
+        types["public types + hex validation"]
+    end
+
+    subgraph mcu["@material/material-color-utilities (runtime dep)"]
+        ds["DynamicScheme / Variant"]
+        mdc["MaterialDynamicColors"]
+        hct["Hct / argbFromHex / hexFromArgb"]
+        blend["Blend.harmonize / TonalPalette"]
+    end
+
+    subgraph contract["m3-tokens contract"]
+        baseline["theme.css (static --md-sys-color-*)"]
+    end
+
+    cfg --> prov --> init --> svc
+    picker --> svc
+    svc --> engine --> custom
+    engine --> ds & mdc & hct
+    custom --> blend & ds & mdc
+    svc --> css --> applier
+    applier -. "injects <style> after" .-> baseline
+    engine -. "same role enumeration as" .-> baseline
+    prov -. exposes .- types
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant App as App bootstrap
+    participant Prov as provideM3Theme
+    participant Init as env initializer
+    participant Svc as M3ThemeService
+    participant Eng as scheme engine
+    participant MCU as MCU
+    participant Doc as DOCUMENT (<head>)
+
+    App->>Prov: providers: [provideM3Theme(config)]
+    Prov->>Init: register config + initializer
+    App->>Init: bootstrap (server AND client)
+    Init->>Svc: init()
+    Svc->>Eng: generateScheme(config)
+    Eng->>MCU: DynamicScheme(seed, variant, contrast, isDark) x {light,dark} x {standard,medium,high}
+    MCU-->>Eng: ARGB per role (+ per custom color)
+    Eng-->>Svc: GeneratedScheme (role -> {light,dark} per contrast)
+    Svc->>Svc: buildCss(scheme, mode)
+    Svc->>Doc: create/replace <style> after baseline
+    Note over Doc: SSR: serialized into server HTML → identical on hydration
+
+    rect rgb(245,240,255)
+    note right of Svc: later — runtime change
+    App->>Svc: setTheme(newConfig)
+    Svc->>Eng: generateScheme(newConfig)
+    Svc->>Doc: replace <style> text
+    end
+```
+
+## Components and Interfaces
+
+### Public types
+
+```typescript
+// Path: libs/ui/theme/src/types.ts
+
+/** M3 scheme variants (maps 1:1 to MCU's Variant enum). */
+export type M3SchemeVariant =
+  | 'monochrome' | 'neutral' | 'tonal-spot' | 'vibrant' | 'expressive'
+  | 'fidelity' | 'content' | 'rainbow' | 'fruit-salad';
+
+/** M3 contrast levels (map to MCU contrastLevel 0 / 0.5 / 1). */
+export type M3Contrast = 'standard' | 'medium' | 'high';
+
+/** Active-mode policy. 'auto' follows the OS via color-scheme + light-dark(). */
+export type M3Mode = 'light' | 'dark' | 'auto';
+
+/** A named brand color folded into the scheme as its own role set. */
+export interface M3CustomColor {
+  /** Identifier used to build role names: --md-sys-color-<name>, -on-<name>, … */
+  name: string;
+  /** Source hex for this color. */
+  value: string;
+  /** Blend the hue toward the source color (M3 harmonize). Default: true. */
+  harmonize?: boolean;
+}
+
+/** Configuration accepted by provideM3Theme and M3ThemeService.setTheme. */
+export interface M3ThemeConfig {
+  /** Source/seed hex color. Required. */
+  sourceColor: string;
+  /** Default: 'tonal-spot'. */
+  variant?: M3SchemeVariant;
+  /** Default: 'standard'. */
+  contrast?: M3Contrast;
+  /** Default: 'auto'. */
+  mode?: M3Mode;
+  /** Optional extended colors. */
+  customColors?: M3CustomColor[];
+}
+
+/** The four roles of one color family, as hex. */
+export interface M3ColorGroup {
+  color: string;
+  onColor: string;
+  colorContainer: string;
+  onColorContainer: string;
+}
+
+/** Flat role→hex map for one (mode, contrast), incl. custom roles. Returned by resolve(). */
+export type M3ResolvedRoles = Record<string, string>; // key = role name WITHOUT --md-sys-color- prefix
+```
+
+### Scheme engine (Decision 1A)
+
+Pure, DOM-free (Req 10.1). Reproduces the static generator's role enumeration so names match the
+contract (Req 11).
+
+```typescript
+// Path: libs/ui/theme/src/engine.ts
+import {
+  argbFromHex, hexFromArgb, Hct, DynamicScheme, Variant,
+  MaterialDynamicColors, type DynamicColor,
+} from '@material/material-color-utilities';
+import type { M3ThemeConfig, M3Contrast, M3SchemeVariant } from './types';
+
+const VARIANT_MAP: Record<M3SchemeVariant, Variant> = {
+  'monochrome': Variant.MONOCHROME, 'neutral': Variant.NEUTRAL,
+  'tonal-spot': Variant.TONAL_SPOT, 'vibrant': Variant.VIBRANT,
+  'expressive': Variant.EXPRESSIVE, 'fidelity': Variant.FIDELITY,
+  'content': Variant.CONTENT, 'rainbow': Variant.RAINBOW,
+  'fruit-salad': Variant.FRUIT_SALAD,
+};
+const CONTRAST_MAP: Record<M3Contrast, number> = { standard: 0, medium: 0.5, high: 1 };
+const CONTRAST_LEVELS: M3Contrast[] = ['standard', 'medium', 'high'];
+
+/** kebab-case fragment, e.g. "on-primary" — identical to the build-time generator. */
+export function camelToKebab(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/** Enumerate every M3 role exposed by MaterialDynamicColors, excluding *PaletteKeyColor. */
+export function coreRoles(): { token: string; dynamicColor: DynamicColor }[];
+
+/** Per-role light/dark hex pair. */
+export interface RolePair { light: string; dark: string; }
+
+/** role(token) -> {light,dark} for one contrast level. */
+export type ScopeRoles = Record<string, RolePair>;
+
+/** Full computed scheme: per contrast level, all core + custom roles. */
+export interface GeneratedScheme {
+  standard: ScopeRoles;
+  medium: ScopeRoles;
+  high: ScopeRoles;
+}
+
+/** Build one MCU DynamicScheme. */
+function buildScheme(sourceArgb: number, variant: M3SchemeVariant, contrast: M3Contrast, isDark: boolean): DynamicScheme;
+
+/** Pure generation: seed + custom colors → all roles for all 3 contrasts, light+dark. */
+export function generateScheme(config: M3ThemeConfig): GeneratedScheme;
+```
+
+Core-role generation, per `(contrast, mode)`: `MaterialDynamicColors[role].getArgb(scheme)` →
+`hexFromArgb`. Custom-role generation (Decision 5B), per custom color `c`:
+
+```
+seed   = argbFromHex(c.value)
+seed'  = (c.harmonize ?? true) ? Blend.harmonize(seed, sourceArgb) : seed
+For each (contrast, mode):
+  cs   = DynamicScheme(seed', variant, contrast, isDark)
+  color           = hex(MaterialDynamicColors.primary.getArgb(cs))
+  on-color        = hex(MaterialDynamicColors.onPrimary.getArgb(cs))
+  color-container = hex(MaterialDynamicColors.primaryContainer.getArgb(cs))
+  on-color-container = hex(MaterialDynamicColors.onPrimaryContainer.getArgb(cs))
+Emitted token names (Req 5.5, no collision with core roles):
+  --md-sys-color-<name>, --md-sys-color-on-<name>,
+  --md-sys-color-<name>-container, --md-sys-color-on-<name>-container
+```
+
+### CSS builder (Decision 3A)
+
+```typescript
+// Path: libs/ui/theme/src/css-builder.ts
+import type { GeneratedScheme } from './engine';
+import type { M3Mode } from './types';
+
+/**
+ * Serialize a GeneratedScheme to CSS text identical in shape to _color.generated.css:
+ *   :root,[data-contrast='standard'] { color-scheme: <scheme>; --md-sys-color-*: light-dark(L,D); }
+ *   [data-contrast='medium'] { … }
+ *   [data-contrast='high'] { … }
+ * `mode` controls the :root color-scheme: 'auto' → "light dark", 'light' → "light", 'dark' → "dark".
+ */
+export function buildCss(scheme: GeneratedScheme, mode: M3Mode): string;
+```
+
+Forcing mode is expressed purely via `color-scheme` on `:root`; `light-dark()` then resolves to the
+forced side (Req 4.3). `'auto'` keeps `light dark` so the OS decides (Req 4.2).
+
+### Style applier (Decision 3A + 4A, SSR-safe)
+
+```typescript
+// Path: libs/ui/theme/src/style-applier.ts
+import { Injectable, RendererFactory2, inject, DOCUMENT } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class M3StyleApplier {
+  private readonly doc = inject(DOCUMENT);
+  private readonly renderer = inject(RendererFactory2).createRenderer(null, null);
+  private styleEl: HTMLStyleElement | null = null;
+
+  /** Create-or-replace a single managed <style> at the end of <head> (overrides baseline). */
+  apply(css: string): void;
+}
+```
+
+`RendererFactory2.createRenderer(null, null)` works on both platforms; on the server
+`@angular/platform-server` serializes the appended `<style>` into the HTML, giving identical first
+paint and no hydration shift (Req 10.2, 10.3). Appending at the end of `<head>` places it after the
+statically imported `theme.css`, so equal-specificity `:root` rules win (Req 6.5). A single element is
+reused; re-applying replaces its text (Req 6.3).
+
+### Theme service (Decision 4A)
+
+```typescript
+// Path: libs/ui/theme/src/theme.service.ts
+import { Injectable, signal, inject } from '@angular/core';
+import type { M3ThemeConfig, M3Contrast, M3ResolvedRoles } from './types';
+import { generateScheme, type GeneratedScheme } from './engine';
+import { buildCss } from './css-builder';
+import { M3StyleApplier } from './style-applier';
+
+@Injectable({ providedIn: 'root' })
+export class M3ThemeService {
+  private readonly applier = inject(M3StyleApplier);
+  private readonly _config = signal<M3ThemeConfig | null>(null);
+  private _scheme: GeneratedScheme | null = null;
+
+  /** Current config (read-only signal). */
+  readonly config = this._config.asReadonly();
+
+  /** Apply a config (validates input, generates, injects CSS). Req 6, 7.3. */
+  setTheme(config: M3ThemeConfig): void;
+
+  /** Internal: called by the bootstrap initializer with the provided config. */
+  init(config: M3ThemeConfig): void;
+
+  /**
+   * Read computed values without needing them applied (Req 8).
+   * Returns flat role→hex for a specific mode + contrast (defaults: light, config.contrast).
+   */
+  resolve(opts?: { mode?: 'light' | 'dark'; contrast?: M3Contrast }): M3ResolvedRoles;
+}
+```
+
+### Provider (Decision 4A — matches the pre-defined shared interface)
+
+```typescript
+// Path: libs/ui/theme/src/provide-theme.ts
+import { makeEnvironmentProviders, provideEnvironmentInitializer, inject, type EnvironmentProviders } from '@angular/core';
+import type { M3ThemeConfig } from './types';
+import { M3ThemeService } from './theme.service';
+import { validateConfig } from './validate';
+
+/** Configure M3 dynamic color at bootstrap. Applies on server AND client (Req 7.2, 10). */
+export function provideM3Theme(config: M3ThemeConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideEnvironmentInitializer(() => {
+      validateConfig(config);                 // fail fast (Req 9)
+      inject(M3ThemeService).init(config);
+    }),
+  ]);
+}
+```
+
+Generation + application are synchronous, so `provideEnvironmentInitializer` (sync) is used rather
+than `provideAppInitializer` (async). `M3ThemeService` is `providedIn: 'root'`.
+
+### Input validation (Req 9)
+
+```typescript
+// Path: libs/ui/theme/src/validate.ts
+/** Parse a hex color to ARGB; throw a descriptive Error if invalid. */
+export function parseHex(input: string, label: string): number;
+/** Validate sourceColor + every customColor.value; throw naming the offender. Req 9.1–9.3. */
+export function validateConfig(config: M3ThemeConfig): void;
+```
+
+`parseHex` validates `#RGB` / `#RRGGBB` (and `#RRGGBBAA` reduced to RGB) before calling
+`argbFromHex`, raising e.g. `Error("M3 dynamic color: invalid sourceColor '#zzz'")` or
+`… invalid custom color "brand-success" value 'nope'`. No silent fallback (Req 9.3).
+
+### Barrel + packaging
+
+```typescript
+// Path: libs/ui/theme/src/index.ts
+export * from './types';
+export { provideM3Theme } from './provide-theme';
+export { M3ThemeService } from './theme.service';
+export { generateScheme, type GeneratedScheme } from './engine';
+```
+
+`libs/ui/theme/ng-package.json` = `{ "lib": { "entryFile": "src/index.ts" } }`;
+`tsconfig.base.json` paths gains `"@ngguide/ui/theme": ["libs/ui/theme/src/index.ts"]`;
+`libs/ui/project.json` test `include` gains the theme specs; `libs/ui/package.json` gains
+`"dependencies": { "@material/material-color-utilities": "^0.4.0" }` (Decision 2A — ng-packagr
+externalizes it into `dist/libs/ui/package.json`). `eslint.config.mjs` `@nx/dependency-checks` will
+now require MCU declared (satisfied by the new `dependencies` entry).
+
+### SSR host for `apps/web` (verification scaffolding)
+
+Add `@angular/ssr` + `@angular/platform-server`; create `apps/web/src/main.server.ts` (Angular 21
+form, passing `BootstrapContext` — NG0401), `apps/web/src/app/app.config.server.ts`
+(`provideServerRendering()` merged with `appConfig`), `apps/web/tsconfig.server.json`; set
+`server` / `ssr` / `outputMode: 'server'` on the `@angular/build:application` build target and wire
+`apps/web` to call `provideM3Theme(...)` so SSR output carries the dynamic `<style>`.
+
+## Data Models
+
+### `GeneratedScheme` (internal)
+
+```typescript
+interface RolePair { light: string; dark: string; }          // hex per OS mode
+type ScopeRoles = Record<string, RolePair>;                  // role name -> pair
+interface GeneratedScheme {                                  // one per config
+  standard: ScopeRoles;                                      // contrastLevel 0
+  medium: ScopeRoles;                                        // contrastLevel 0.5
+  high: ScopeRoles;                                          // contrastLevel 1
+}
+```
+
+## Data Flow Completeness
+
+This feature introduces no persisted entities; the "layers" are the runtime pipeline from config to
+applied CSS. Trace for the two data shapes that flow end-to-end:
+
+| Field/Entity | Public type | Generation | CSS serialization | Application | Read API |
+|--------------|-------------|------------|-------------------|-------------|----------|
+| core role value | `M3ThemeConfig` → roles | `engine.ts generateScheme()` | `css-builder.ts buildCss()` | `style-applier.ts apply()` | `theme.service.ts resolve()` |
+| custom color (4 roles) | `M3CustomColor` | `engine.ts` (Blend.harmonize + DynamicScheme primary family) | `css-builder.ts` (`--md-sys-color-<name>*`) | `style-applier.ts apply()` | `theme.service.ts resolve()` |
+| forced mode | `M3Mode` | N/A (mode is not a generation input; both light+dark always computed) | `css-builder.ts` (`:root { color-scheme }`) | `style-applier.ts apply()` | `resolve({mode})` |
+| contrast level | `M3Contrast` | `engine.ts` (3 scopes always computed) | `css-builder.ts` (`[data-contrast]` blocks) | `style-applier.ts apply()` | `resolve({contrast})` |
+
+All four reach every layer. No persistence/migration layer applies (N/A — runtime-only feature).
+
+## Error Handling
+
+| Error | Trigger | Behaviour / message |
+|-------|---------|---------------------|
+| Invalid source color | `sourceColor` not parseable hex | Throw `Error("M3 dynamic color: invalid sourceColor '<v>'")` at bootstrap/`setTheme` (Req 9.1). No fallback (9.3). |
+| Invalid custom color | a `customColors[].value` not parseable | Throw `Error("M3 dynamic color: invalid custom color \"<name>\" value '<v>'")` (Req 9.2). |
+| Unknown variant | `variant` not in `M3SchemeVariant` | Compile-time (typed union); at runtime defaults to `tonal-spot` only if undefined. |
+| No DOM at apply time | server with a serializable document | No-op-safe: Renderer2 + serialized `<style>`; never throws (Req 10.2). |
+| Duplicate custom name collides with a core role | e.g. custom name `"primary"` | Reject in `validateConfig` with a descriptive error (protects Req 5.5). |
+
+## Testing Strategy
+
+### Approach
+
+Native Angular Vitest (zoneless), specs registered in `libs/ui/project.json` `test.include`. The
+engine/CSS/validation are pure functions → fast unit tests. The applier/service are tested via
+`TestBed` with the real `DOCUMENT`. SSR-safety is unit-tested by exercising the DOM-free engine and
+asserting the applier appends a serializable `<style>`; the `apps/web` SSR host provides an
+end-to-end smoke check.
+
+### Unit Tests
+
+```typescript
+describe('generateScheme', () => {
+  it('produces every core role name present in the static contract (Req 11)', () => {
+    const roles = Object.keys(generateScheme({ sourceColor: '#6750A4' }).standard);
+    // assert equality against the role set parsed from _color.generated.css
+  });
+
+  it('matches the static baseline for the baseline seed + tonal-spot + standard', () => {
+    const s = generateScheme({ sourceColor: '#6750A4' }).standard;
+    expect(s['primary'].light).toBe('#65558f');   // value from _color.generated.css
+    expect(s['primary'].dark).toBe('#cfbdfe');
+  });
+
+  it('varies output by variant and by contrast', () => { /* vibrant ≠ tonal-spot; high ≠ standard */ });
+
+  it('emits 4 contrast-aware roles per custom color, harmonized by default (Req 5)', () => { /* … */ });
+});
+
+describe('buildCss', () => {
+  it('emits light-dark() pairs, color-scheme, and 3 [data-contrast] scopes', () => { /* … */ });
+  it("forces color-scheme for mode 'light'/'dark' and uses 'light dark' for 'auto' (Req 4)", () => { /* … */ });
+});
+
+describe('validateConfig', () => {
+  it('throws naming the offending sourceColor / custom color (Req 9)', () => { /* … */ });
+});
+
+describe('M3ThemeService (TestBed + DOCUMENT)', () => {
+  it('injects a <style> after baseline and replaces it on setTheme (Req 6)', () => { /* … */ });
+  it('resolve() returns role→hex equal to applied values (Req 8)', () => { /* … */ });
+});
+```
+
+### Edge Cases
+
+1. **`setTheme` called repeatedly** — single `<style>` reused; old values fully replaced (Req 6.3).
+2. **No `provideM3Theme`** — nothing injected; static baseline remains (Req 6.4).
+3. **Forced mode + OS change** — forced `color-scheme` wins; OS change ignored (Req 4.3).
+4. **Custom name equal to a core role** — rejected by validation (Req 5.5).
+5. **Server render then hydrate** — identical CSS string both sides → no theme flash (Req 10.3).
+6. **`#RGB` shorthand / uppercase hex** — accepted; normalized before `argbFromHex`.

--- a/.specs/m3-dynamic-color/requirements.md
+++ b/.specs/m3-dynamic-color/requirements.md
@@ -1,0 +1,232 @@
+---
+status: DRAFT
+created: 2026-05-29
+updated: 2026-05-29
+---
+
+# Requirements Document
+
+## Introduction
+
+`@ngguide/ui` already ships a complete **static** M3 token system (spec `m3-tokens`): the
+`--md-sys-color-*` roles are pre-generated from a single fixed baseline seed and shipped as CSS.
+This spec adds **dynamic color** — the ability to generate a full M3 color scheme from an
+*arbitrary* source color (and optional custom brand colors) at runtime, using the M3 HCT /
+tonal-palette algorithm, and to apply that scheme by writing the same `--md-sys-color-*` token
+contract the components already style against.
+
+The outcome: a consuming Angular app can theme the entire UI Kit from a brand seed color, pick any
+M3 scheme variant and contrast level, add harmonized custom colors, switch light/dark via the OS,
+and read the computed scheme values programmatically — all while staying strictly within the M3
+color specification (no invented roles, no improvised blends).
+
+## Glossary
+
+- **Source color (seed):** A single color (expressed as a hex string) from which the entire scheme
+  is derived.
+- **Custom color (extended color):** An additional named color (e.g. a brand "success" color) that
+  is folded into the scheme as its own set of M3 roles, alongside the source-derived roles.
+- **HCT:** The M3 color space (Hue, Chroma, Tone) used to derive tonal palettes from a source color.
+- **Tonal palette:** A set of tones (0–100) for a given hue/chroma, from which color roles are mapped.
+- **Color role:** A semantic M3 token (e.g. `primary`, `on-primary`, `surface-container-high`,
+  `outline-variant`) that components reference. The full set is defined by the **token contract**.
+- **Token contract:** The canonical set of `--md-sys-color-*` CSS custom-property names defined by
+  the `m3-tokens` spec. Dynamic color writes values for exactly these names.
+- **Scheme variant:** One of the M3-defined generation strategies — Tonal Spot, Vibrant, Expressive,
+  Neutral, Monochrome, Fidelity, Content, Rainbow, Fruit Salad.
+- **Contrast level:** One of the M3 contrast settings — standard, medium, high — affecting tone
+  selection for accessibility.
+- **Harmonization:** The M3 operation that rotates a custom color's hue toward the source color's hue
+  so it sits cohesively within the scheme.
+- **Scheme:** The complete computed mapping of every color role to a concrete color value, for a
+  given (source color, variant, contrast, mode) combination.
+- **Apply / runtime application:** Writing the computed scheme as `--md-sys-color-*` values onto the
+  document so the live UI re-themes.
+
+## Requirements
+
+### Requirement 1: Generate a scheme from a source color
+
+**User Story:** As an app developer, I want to generate a complete M3 color scheme from a single
+source color, so that the whole UI Kit can be themed from one brand seed.
+
+#### Acceptance Criteria
+
+1. THE system SHALL accept a single source color, expressed as a hex string, as the basis for scheme
+   generation.
+2. THE system SHALL derive color values using the M3 HCT / tonal-palette algorithm as published at
+   m3.material.io — no other color-derivation method.
+3. THE system SHALL produce a value for every color role defined in the `m3-tokens` token contract,
+   with no role omitted and no role added beyond that contract (custom-color roles per Requirement 5
+   excepted).
+4. THE system SHALL produce, for a given input, color values identical to the M3 reference algorithm
+   for that same input (so output is verifiable against M3, not improvised).
+
+### Requirement 2: Select any M3 scheme variant
+
+**User Story:** As an app developer, I want to choose which M3 scheme variant is used, so that I can
+match the intended expressiveness of my brand.
+
+#### Acceptance Criteria
+
+1. THE system SHALL support every M3 scheme variant: Tonal Spot, Vibrant, Expressive, Neutral,
+   Monochrome, Fidelity, Content, Rainbow, and Fruit Salad.
+2. WHEN no variant is specified THEN the system SHALL use Tonal Spot, matching the static
+   `m3-tokens` baseline.
+3. WHEN a variant is specified THEN the system SHALL generate role values according to that variant's
+   M3 definition.
+4. THE system SHALL NOT expose any scheme variant that is not part of the published M3 specification.
+
+### Requirement 3: Select a contrast level
+
+**User Story:** As an app developer, I want to choose an M3 contrast level, so that the theme can meet
+the contrast needs of my users.
+
+#### Acceptance Criteria
+
+1. THE system SHALL support the M3 contrast levels: standard, medium, and high.
+2. WHEN no contrast level is specified THEN the system SHALL use standard.
+3. WHEN a contrast level is specified THEN the system SHALL adjust the generated role tones according
+   to that level's M3 definition.
+
+### Requirement 4: Light and dark schemes with OS-driven switching
+
+**User Story:** As an end user, I want the theme to follow my device's light/dark preference, so that
+the app matches my system without the developer wiring extra logic.
+
+#### Acceptance Criteria
+
+1. WHEN a scheme is generated and applied THEN the system SHALL produce both the light and the dark
+   role values for the same source color, variant, and contrast level.
+2. WHEN both light and dark values are applied AND the developer has not forced a fixed mode THEN the
+   active mode SHALL follow the operating-system / browser light-dark preference, and SHALL change
+   when that preference changes, without the developer re-invoking generation.
+3. WHEN the developer forces a fixed mode (light or dark) THEN the system SHALL apply that mode
+   regardless of the operating-system preference.
+4. THE light/dark switching behavior SHALL be consistent with the `m3-tokens` static baseline so that
+   a dynamic scheme and the static baseline behave the same way with respect to mode.
+
+### Requirement 5: Custom (extended) colors
+
+**User Story:** As an app developer, I want to add named brand colors to the scheme, so that
+non-primary brand colors (e.g. a "success" green) are themed cohesively with the rest of the UI.
+
+#### Acceptance Criteria
+
+1. THE system SHALL accept zero or more custom colors, each with a name and a hex value.
+2. WHEN a custom color is provided THEN the system SHALL emit its full M3 role set — the base color
+   role, its on-color role, its container role, and its on-container role — for both light and dark.
+3. THE system SHALL allow each custom color to opt into or out of harmonization toward the source
+   color independently, per the M3 custom-color specification.
+4. WHEN a contrast level is selected THEN the system SHALL apply that contrast level to custom-color
+   roles in the same way it applies to core roles.
+5. THE custom-color role names SHALL be derived from the custom color's name in a consistent,
+   documented pattern, and SHALL NOT collide with or overwrite any core token-contract role.
+
+### Requirement 6: Apply a scheme globally at runtime
+
+**User Story:** As an app developer, I want an applied scheme to re-theme my whole app, so that every
+component using the token contract reflects the brand instantly.
+
+#### Acceptance Criteria
+
+1. WHEN a scheme is applied THEN the system SHALL write the computed values to the `--md-sys-color-*`
+   token-contract names at the document root scope.
+2. WHEN a scheme is applied THEN every component that styles against the token contract SHALL reflect
+   the new scheme without any change to that component.
+3. WHEN a scheme is applied over a previously applied scheme THEN the system SHALL fully replace the
+   prior dynamic values.
+4. WHEN no scheme has been applied THEN the static `m3-tokens` baseline SHALL remain in effect.
+5. THE applied dynamic values SHALL override the static baseline for the roles they set.
+
+### Requirement 7: Configure dynamic color at application startup
+
+**User Story:** As an app developer, I want to declare my theme once when the app boots, so that the
+app starts already themed from my brand seed.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a way to configure dynamic color at application bootstrap with at least:
+   a source color, an optional variant, an optional contrast level, an optional fixed mode, and
+   optional custom colors.
+2. WHEN the application starts with a dynamic-color configuration THEN the configured scheme SHALL be
+   in effect for the first render the user sees.
+3. THE system SHALL provide a way to change the active scheme after startup (e.g. a brand-color
+   picker), and applying the change SHALL re-theme the running app.
+
+### Requirement 8: Read computed scheme values programmatically
+
+**User Story:** As an app developer, I want to read the generated color values directly, so that I can
+use them outside CSS (charts, canvas, exporting a theme).
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a way to obtain the computed mapping of color role to color value for a
+   generated scheme, without requiring it to be applied to the document.
+2. THE returned mapping SHALL cover every core role and every custom-color role for the requested
+   mode(s) and contrast level.
+3. THE returned color values SHALL equal the values that would be written to the token contract when
+   applying the same scheme.
+
+### Requirement 9: Fail fast on invalid color input
+
+**User Story:** As an app developer, I want misconfigured colors to be reported immediately, so that I
+catch theming mistakes at development time instead of shipping a broken theme.
+
+#### Acceptance Criteria
+
+1. WHEN the source color is not a parseable color value THEN the system SHALL raise a descriptive
+   error identifying the offending input.
+2. WHEN a custom color's value is not a parseable color value THEN the system SHALL raise a
+   descriptive error identifying which custom color is invalid.
+3. THE system SHALL NOT silently substitute a default color for an invalid input.
+
+### Requirement 10: Server-side rendering safety
+
+**User Story:** As an app developer using server-side rendering, I want dynamic color to work without
+a browser, so that my server-rendered pages are themed and do not crash.
+
+#### Acceptance Criteria
+
+1. THE system SHALL compute a scheme (Requirements 1–5, 8) without requiring a browser DOM.
+2. WHEN running in an environment without a DOM THEN applying a scheme SHALL NOT throw, and SHALL
+   degrade gracefully (no error, no broken render).
+3. WHEN the same configuration is used on the server and in the browser THEN the resulting scheme
+   values SHALL be identical, so there is no visible theme shift on hydration.
+
+### Requirement 11: Token-contract fidelity
+
+**User Story:** As a maintainer, I want dynamic color to use exactly the same role names as the static
+tokens, so that switching between static and dynamic theming requires no component changes.
+
+#### Acceptance Criteria
+
+1. THE core role names written/returned by dynamic color SHALL be exactly the `--md-sys-color-*` names
+   defined by the `m3-tokens` token contract — same spelling, same set.
+2. THE system SHALL NOT introduce a core color role that is absent from the `m3-tokens` contract, and
+   SHALL NOT omit one that is present.
+3. WHEN the `m3-tokens` contract changes THEN any divergence in the dynamic-color role set SHALL be
+   detectable (so the two stay in lockstep).
+
+## Constraints
+
+- **Must consume the existing `m3-tokens` token contract** — dynamic color writes/returns the exact
+  `--md-sys-color-*` role names already shipped; it does not redefine the static token files.
+- **Must be SSR-safe** consistent with the rest of `@ngguide/ui` (Angular SSR / no-DOM rendering).
+- **Strict M3 adherence** — scheme generation, variants, contrast, custom-color roles, and
+  harmonization must trace to m3.material.io. No invented roles, blends, variants, or values. Where
+  M3 is ambiguous, document the open question rather than improvising.
+
+## Non-functional Requirements
+
+- **Accessibility:** Generated schemes at the **standard** contrast level SHALL meet WCAG 2.1 AA
+  contrast for text/background role pairings in both light and dark, as guaranteed by the M3
+  algorithm; the **medium** and **high** levels SHALL provide progressively higher contrast per M3.
+- **Determinism:** For a given (source color, variant, contrast, mode, custom colors) input, the
+  computed scheme SHALL be deterministic — identical inputs always yield identical outputs.
+
+## Superseded Behaviors
+
+- **Static-only theming (single fixed baseline seed from `m3-tokens`)** → EXTENDED (not removed) by
+  this spec. The static baseline remains the default when no dynamic scheme is configured
+  (Requirement 6.4); dynamic color overrides it at runtime when used (Requirement 6.5).

--- a/.specs/m3-dynamic-color/research.md
+++ b/.specs/m3-dynamic-color/research.md
@@ -1,0 +1,471 @@
+---
+created: 2026-05-29
+updated: 2026-05-29
+---
+
+# Research: M3 Dynamic Color
+
+## Problem Statement
+
+`@ngguide/ui` ships a **static** M3 token system (`m3-tokens`): `--md-sys-color-*` roles pre-generated
+from one fixed seed at build time and emitted as CSS using `light-dark()` pairs under
+`[data-contrast]` scopes. This spec adds **runtime dynamic color** — an Angular API that generates a
+full M3 scheme from an arbitrary source color (plus optional custom colors), across all 9 M3 scheme
+variants and 3 contrast levels, and applies it by writing the *same* token contract to the document,
+SSR-safely. The research below catalogues the meaningfully-distinct ways to build each part. No
+decisions are made here — `spec:design` picks one variant per area.
+
+Grounding facts that shape every area (verified against the installed code, not memory):
+
+- The color algorithm library **`@material/material-color-utilities` (MCU) v0.4.0 is already in the
+  repo**, but only as a **root `devDependency`** used by the build-time generator
+  `libs/ui/tooling/generate-color-tokens.mts`. `libs/ui/package.json` declares **only `@angular/core`
+  as a peer** and **no runtime deps**; ng-packagr externalizes third-party deps, so runtime use of
+  MCU requires adding it to `libs/ui/package.json`. [mcu-pkg][libui-pkg]
+- The static generator already uses the **`DynamicScheme` / `MaterialDynamicColors` / `Hct`** path
+  (49 roles, 2025 M3 spec) — dynamic color can reuse the identical role enumeration so the contract
+  matches by construction. [gen-mts]
+- **`apps/web` has no SSR today** (CSR-only; no `@angular/ssr`, no server target) and the repo uses
+  **zero** `DOCUMENT` / `Renderer2` / `PLATFORM_ID` / `afterNextRender` anywhere. The library must
+  still be SSR-*safe* per Req 10, so SSR handling is greenfield. [web-proj][no-dom]
+- App bootstrap is **zoneless**, `ApplicationConfig.providers` only, **no `APP_INITIALIZER`** in use
+  yet. [app-config]
+
+## Problem Areas
+
+### 1. Scheme generation engine
+
+_Related requirements: 1.1–1.4, 2.1–2.4, 3.1–3.3_
+
+How the `--md-sys-color-*` ARGB values are computed for a (source, variant, contrast, mode) tuple.
+
+#### Variant A: MCU `DynamicScheme` + `MaterialDynamicColors` (low-level)
+
+**How it works:** `new DynamicScheme({ sourceColorHct: Hct.fromInt(argb), variant: Variant.X,
+contrastLevel, isDark })`, then enumerate roles via `MaterialDynamicColors.<role>.getArgb(scheme)` —
+exactly the enumeration the static generator already performs, but at runtime with an arbitrary seed.
+The `Variant` enum carries all 9 M3 variants; `contrastLevel` is a number (M3 uses 0 / 0.5 / 1 for
+standard / medium / high). [mcu-dynamicscheme][mcu-variant][gen-mts]
+
+**Pros:**
+- Produces the full 2025 M3 role set, identical mechanism to `m3-tokens` → contract matches by
+  construction (Req 11).
+- All 9 variants and all 3 contrast levels from one code path; no per-variant branching.
+- Reuses already-proven role-enumeration logic from `generate-color-tokens.mts`.
+
+**Cons:**
+- Requires our own loop to assemble light + dark + contrast scopes (no one-call convenience).
+- Couples us to the `DynamicScheme` options-object shape (stable in 0.4.0, but evolving upstream).
+
+**Effort:** Low | **Risk:** Low
+**Codebase fit:** Same MCU API family already used in `libs/ui/tooling/generate-color-tokens.mts:14-22,65-71`; would move that knowledge from build-time tooling into shipped library code.
+**Evidence:** `DynamicScheme({sourceColorHct,variant,contrastLevel,isDark})` constructor and `Variant` enum (9 values) confirmed in installed 0.4.0 d.ts. [mcu-dynamicscheme][mcu-variant]
+
+#### Variant B: MCU per-variant `Scheme*` subclasses (positional)
+
+**How it works:** Map each variant to its subclass — `SchemeTonalSpot`, `SchemeVibrant`,
+`SchemeExpressive`, `SchemeNeutral`, `SchemeMonochrome`, `SchemeFidelity`, `SchemeContent`,
+`SchemeRainbow`, `SchemeFruitSalad` — each `new SchemeX(sourceColorHct, isDark, contrastLevel)`, then
+the same `MaterialDynamicColors` enumeration. This is the exact call shape the current generator uses
+(`new SchemeTonalSpot(hct, isDark, contrast)`). [gen-mts][mcu-schemefiles]
+
+**Pros:**
+- Byte-for-byte the construction style already in the repo generator.
+- Each subclass is a thin wrapper over `DynamicScheme`, so output equals Variant A.
+
+**Cons:**
+- Needs an explicit 9-entry variant→class lookup map to satisfy Req 2.
+- Upstream `main` documents the positional subclass constructors as **deprecated** in favour of the
+  `DynamicScheme` options object; 0.4.0 still ships them, but choosing this path adopts an API the
+  upstream is moving away from. [mcu-migrate]
+
+**Effort:** Low | **Risk:** Medium (deprecation trajectory)
+**Codebase fit:** Identical to `generate-color-tokens.mts:66`.
+**Evidence:** All 9 `scheme_*.js` files present in installed 0.4.0; `SchemeExpressive(sourceColorHct, isDark, contrastLevel, specVersion?, platform?)` signature confirmed; upstream migration note marks positional constructors deprecated. [mcu-schemefiles][mcu-migrate]
+
+#### Variant C: MCU `themeFromSourceColor` + `Theme` convenience
+
+**How it works:** `themeFromSourceColor(argb, customColors)` returns a `Theme` with `schemes.light` /
+`schemes.dark` and `customColors`. Pair with MCU's `applyTheme(theme, {target, dark})` to write CSS
+vars. One call covers seed + custom colors + light/dark. [mcu-themeutils]
+
+**Pros:**
+- Single high-level call; custom colors handled by the same helper (Req 5 base roles).
+- Least code to reach a first working theme.
+
+**Cons:**
+- `Theme.schemes` is typed as the **legacy `Scheme`** (2021-era role set), **not**
+  `MaterialDynamicColors` — its role set does **not** match the `m3-tokens` 2025 contract (Req 11
+  violation). [mcu-themeutils]
+- **No contrast-level parameter** anywhere in `themeFromSourceColor` / `customColor` → cannot satisfy
+  Req 3 or Req 5.4.
+- `applyTheme` writes a **single mode** (`dark?: boolean`) to a DOM `target` — not `light-dark()`
+  pairs — so OS auto-switch (Req 4.2) and SSR-safety (Req 10) don't come for free.
+
+**Effort:** Low | **Risk:** High (contract + contrast mismatch)
+**Codebase fit:** Diverges from the `DynamicScheme`/`MaterialDynamicColors` path the static tokens use.
+**Evidence:** `Theme.schemes: {light: Scheme; dark: Scheme}`, `themeFromSourceColor(source, customColors?)`, and `applyTheme(theme, {dark?, target?, brightnessSuffix?, paletteTones?})` confirmed in installed 0.4.0 `utils/theme_utils.d.ts`; no contrast parameter present. [mcu-themeutils]
+
+### 2. Color-engine packaging
+
+_Related requirements: 7.1, Constraints (consume contract, ship MCU), NFR (bundle)_
+
+How MCU reaches the consumer's app, and which entry point exposes the new API.
+
+#### Variant A: MCU as a `dependencies` entry of `@ngguide/ui`
+
+**How it works:** Add `@material/material-color-utilities` to `libs/ui/package.json` `dependencies`.
+ng-packagr keeps it external but declares it, so package managers install it transitively. [libui-pkg][ngpkg]
+
+**Pros:**
+- Consumers get a working theme API with no extra install step.
+- Version pinned by the library; predictable behaviour.
+
+**Cons:**
+- Adds a hard transitive runtime dep to every consumer, even those who only use static tokens.
+- MCU ships ESM with extensionless internal imports; must confirm it resolves under consumer bundlers
+  (it's `type: module`, `sideEffects` unset). [mcu-pkg]
+
+**Effort:** Low | **Risk:** Low
+**Codebase fit:** New runtime dep; today `libs/ui` has none. dependency-checks rule currently only
+ignores `tooling/**`, so a shipped import will be enforced to appear here. [eslint-depcheck]
+**Evidence:** `libs/ui/package.json` has no `dependencies`; published `dist` only gains `tslib`; ng-packagr externalizes deps. [libui-pkg][ngpkg]
+
+#### Variant B: MCU as a `peerDependencies` entry
+
+**How it works:** Declare MCU as a peer (+ `peerDependenciesMeta` optional if static-only use should
+stay install-free). Consumers using dynamic color install MCU themselves. [libui-pkg]
+
+**Pros:**
+- No forced dep for static-only consumers (if marked optional).
+- Single MCU instance in the consumer tree; matches what `@nx/dependency-checks` nudged toward during
+  `m3-tokens`.
+
+**Cons:**
+- Dynamic-color users must add MCU manually or hit an unmet-peer error.
+- Version-skew risk between what we generate against and what the consumer installs.
+
+**Effort:** Low | **Risk:** Medium (consumer install friction / skew)
+**Codebase fit:** Mirrors the existing `@angular/core` peer pattern in `libs/ui/package.json`.
+**Evidence:** Current peer-only declaration in `libs/ui/package.json`. [libui-pkg]
+
+#### Variant C: Vendor a tree-shaken MCU subset into the library
+
+**How it works:** Copy only the needed MCU modules (HCT, DynamicScheme, MaterialDynamicColors, blend)
+into `libs/ui`, dropping quantizer/image code we don't use, and ship them as library source.
+
+**Pros:**
+- Zero external runtime dep; smallest, fully-controlled surface.
+- No consumer install step and no version skew.
+
+**Cons:**
+- Manual maintenance + drift from upstream M3 algorithm updates (works against the strict-M3
+  "trace to canonical algorithm" principle).
+- Apache-2.0 attribution/license obligations to carry.
+
+**Effort:** High | **Risk:** Medium
+**Codebase fit:** No precedent for vendored third-party source in the repo.
+**Evidence:** MCU is modular ESM (`export * from './...'` per submodule), so a subset is mechanically
+extractable. [mcu-pkg][mcu-index]
+
+> **Entry-point placement (cross-cutting sub-decision, see Open Questions):** the API can live in the
+> existing root entry `@ngguide/ui` (alongside `GuiSize`) or in a new secondary entry point
+> (e.g. `@ngguide/ui/theme`). A separate entry keeps MCU out of the root barrel so importing `GuiSize`
+> never pulls the color engine. Adding an entry point is mechanical: `ng-package.json` + `src/index.ts`
+> + a `tsconfig.base.json` path + a spec listed in `libs/ui/project.json` test `include`. [entrypoint]
+
+### 3. Runtime token-application mechanism
+
+_Related requirements: 4.1–4.4, 6.1–6.5_
+
+How computed values reach the document so the live UI re-themes, preserving OS-driven light/dark and
+contrast scopes.
+
+#### Variant A: Inject a `<style>` element with generated CSS text
+
+**How it works:** Build CSS text identical in shape to `_color.generated.css` —
+`:root,[data-contrast='standard']{ color-scheme: light dark; --md-sys-color-*: light-dark(L,D); }`
+plus `[data-contrast='medium'|'high']` blocks — and inject it as a `<style>` (created via Renderer2 /
+the document token) into `<head>`. Replacing the element's text re-themes. [m3-tokens-css][ng-ssr-style]
+
+**Pros:**
+- Mirrors the static `m3-tokens` output exactly → OS auto-switch via `light-dark()` and `[data-contrast]`
+  scopes work unchanged (Req 4.2, 4.4, 3).
+- SSR-safe: a `<style>` rendered on the server carries tokens into the first paint, identical to client
+  (Req 10.2, 10.3).
+- One element fully replaces prior dynamic values (Req 6.3).
+
+**Cons:**
+- Must serialize CSS text (slightly more work than setting properties).
+- Specificity: `:root` injected styles must reliably override the statically-imported baseline (Req 6.5)
+  — ordering/scope needs care.
+
+**Effort:** Medium | **Risk:** Low
+**Codebase fit:** Same CSS structure as `libs/ui/src/styles/tokens/_color.generated.css`; needs the
+repo's first `DOCUMENT`/`Renderer2` usage.
+**Evidence:** Static output uses `light-dark()` + `color-scheme` + `[data-contrast]` scopes; Renderer2
+`<style>` injection is the documented SSR-safe approach. [m3-tokens-css][ng-ssr-style]
+
+#### Variant B: Set inline custom properties on the document root
+
+**How it works:** For each role call `documentElement.style.setProperty('--md-sys-color-x',
+'light-dark(L,D)')`. Inline values can still carry `light-dark()` so OS switching survives. [m3-tokens-css]
+
+**Pros:**
+- No CSS-text serialization; direct property writes.
+- Inline values beat stylesheet values in the cascade → reliably overrides the baseline (Req 6.5).
+
+**Cons:**
+- Inline styles can't express `[data-contrast]` **selector scopes** — switching contrast means
+  recomputing and rewriting all properties rather than toggling an attribute (works against Req 3's
+  scope model).
+- Setting CSS custom properties via the **server** document `style` has a known Angular SSR failure;
+  needs a guard/fallback (Req 10.2). [ng-universal-2163]
+
+**Effort:** Medium | **Risk:** Medium (SSR + contrast-scope handling)
+**Codebase fit:** Greenfield DOM access; no scope-attribute reuse.
+**Evidence:** angular/universal#2163 documents server-side `setProperty` on the injected document
+throwing; `light-dark()` is valid as an inline custom-property value. [ng-universal-2163][m3-tokens-css]
+
+#### Variant C: Constructable stylesheet via `adoptedStyleSheets`
+
+**How it works:** Build a `CSSStyleSheet`, `replaceSync()` the generated CSS, and push it to
+`document.adoptedStyleSheets`. Re-theme by replacing the sheet's contents. [mdn-adopted]
+
+**Pros:**
+- Clean, single owned stylesheet; cheap atomic replacement; no extra DOM nodes.
+- Same CSS shape as Variant A, so OS switching + contrast scopes work.
+
+**Cons:**
+- `adoptedStyleSheets` / Constructable Stylesheets are **browser-only** — unavailable in the SSR DOM,
+  so server rendering needs a `<style>` fallback anyway (Req 10). [mdn-adopted]
+- Adds a capability check + dual path.
+
+**Effort:** Medium | **Risk:** Medium (SSR gap)
+**Codebase fit:** Greenfield; no current stylesheet manipulation.
+**Evidence:** MDN documents `adoptedStyleSheets` as a browser Document API (Constructable Stylesheets);
+not part of server DOM. [mdn-adopted]
+
+### 4. Angular integration & SSR lifecycle
+
+_Related requirements: 7.1–7.3, 10.1–10.3_
+
+The shape of `provideM3Theme`, how the initial scheme is applied at bootstrap (incl. server), and how
+runtime updates happen.
+
+#### Variant A: `EnvironmentProviders` + bootstrap initializer + update service
+
+**How it works:** `provideM3Theme(config)` returns `EnvironmentProviders` bundling (a) the config as a
+token, (b) an environment/app initializer that computes the scheme and applies it (Area 3) during
+bootstrap — on both server and client — and (c) an injectable service exposing a method/signal to
+swap the scheme at runtime (Req 7.3). [ng-env-providers][app-config]
+
+**Pros:**
+- Theme is in effect for first render on server and client (Req 7.2, 10.3).
+- Matches the pre-defined shared interface `provideM3Theme(): EnvironmentProviders` in `plan.md`.
+- Runtime updates via a normal injectable, zoneless-friendly (signal-driven).
+
+**Cons:**
+- Initializer must run the engine eagerly at bootstrap (small cost on the critical path).
+- Needs careful SSR/browser branching inside one provider.
+
+**Effort:** Medium | **Risk:** Low
+**Codebase fit:** Extends the existing `ApplicationConfig.providers` pattern; introduces the repo's
+first initializer + injectable service. [app-config]
+**Evidence:** `EnvironmentProviders` + initializer is the standard Angular standalone provider pattern;
+current app uses plain providers with no initializer. [ng-env-providers][app-config]
+
+#### Variant B: Config token + component-driven application (`afterNextRender`)
+
+**How it works:** `provideM3Theme(config)` only registers the config; a directive/component (or the
+service called from one) applies the scheme in `afterNextRender`, i.e. browser-only.
+
+**Pros:**
+- Simplest provider; no bootstrap-time work.
+- Naturally browser-scoped (sidesteps server DOM concerns).
+
+**Cons:**
+- Nothing themed during SSR → first server paint uses the static baseline, then the client re-themes →
+  **visible theme shift on hydration** (conflicts with Req 10.3).
+- Application timing tied to a component being rendered.
+
+**Effort:** Low | **Risk:** High (Req 10.3 hydration shift)
+**Codebase fit:** Would be the repo's first `afterNextRender` use; no SSR contribution.
+**Evidence:** `afterNextRender` runs only in the browser by design; no server-side token emission. [needs investigation — exact hydration-shift behaviour to be confirmed in design]
+
+#### Variant C: Bootstrap initializer + `TransferState` hand-off
+
+**How it works:** Like Variant A, but the server stores the computed scheme in `TransferState`; the
+client reads it instead of recomputing, guaranteeing identical server/client values. [ng-transferstate]
+
+**Pros:**
+- Strongest guarantee of identical server/client scheme (Req 10.3), and skips a client-side recompute.
+
+**Cons:**
+- Extra moving part; MCU generation is deterministic anyway (same inputs → same outputs), so the
+  recompute it avoids may be unnecessary.
+- More to test/maintain for marginal benefit when inputs are static config.
+
+**Effort:** High | **Risk:** Low
+**Codebase fit:** No current `TransferState` usage.
+**Evidence:** `TransferState` is Angular's server→client data channel; determinism of MCU output makes
+the transfer optional rather than required. [ng-transferstate]
+
+### 5. Custom-color modeling
+
+_Related requirements: 5.1–5.5_
+
+How named custom colors become role sets, with harmonization and contrast.
+
+#### Variant A: MCU `customColor()` helper
+
+**How it works:** For each `{ value, name, blend }`, call `customColor(sourceArgb, customColor)` →
+`CustomColorGroup` with `light`/`dark` `ColorGroup`s (`color`, `onColor`, `colorContainer`,
+`onColorContainer`). `blend` is the harmonize toggle. [mcu-themeutils]
+
+**Pros:**
+- Exactly the 4 roles × light/dark required (Req 5.2), with built-in harmonize (Req 5.3); least code.
+- Canonical M3 helper for custom colors.
+
+**Cons:**
+- **No contrast-level support** — `customColor()` takes no contrast argument, so custom roles stay at
+  standard contrast and **cannot satisfy Req 5.4**.
+
+**Effort:** Low | **Risk:** Medium (fails Req 5.4 as-is)
+**Codebase fit:** Same MCU library already in use.
+**Evidence:** `customColor(source, color): CustomColorGroup`, `CustomColor = {value,name,blend}`,
+`CustomColorGroup = {color, value, light, dark}` confirmed in 0.4.0; no contrast parameter. [mcu-themeutils]
+
+#### Variant B: Tonal palette per custom color through the core contrast pipeline
+
+**How it works:** Optionally harmonize the custom hue with `Blend.harmonize(customArgb, sourceArgb)`,
+build a `TonalPalette` from it, then select tones for `color`/`on-color`/`container`/`on-container`
+through the **same DynamicScheme + contrast logic** used for core roles, so custom roles respond to
+standard/medium/high. [mcu-blend][mcu-dynamicscheme]
+
+**Pros:**
+- Custom roles obey the selected contrast level (Req 5.4) and the same light/dark mechanism as core
+  roles (Req 5.2), fully consistent with the core engine.
+- Harmonize is an explicit per-color toggle (Req 5.3).
+
+**Cons:**
+- More code: we own the tone-selection mapping for custom roles rather than calling one helper.
+- Must define and document the role-name derivation from `name` without colliding with core roles
+  (Req 5.5).
+
+**Effort:** Medium | **Risk:** Low
+**Codebase fit:** Builds on the same `DynamicScheme`/`Hct`/palette APIs as Area 1 Variant A/B.
+**Evidence:** `Blend.harmonize(designColor, sourceColor)` and `TonalPalette` exist in 0.4.0; contrast
+flows only through `DynamicScheme`, not `customColor()`. [mcu-blend][mcu-themeutils][mcu-dynamicscheme]
+
+#### Variant C: `DynamicScheme` palette-override slots
+
+**How it works:** Pass `primaryPalette` / `secondaryPalette` / `tertiaryPalette` etc. in
+`DynamicSchemeOptions` to substitute palettes for a brand color. [mcu-dynamicscheme]
+
+**Pros:**
+- Native to the scheme; contrast-aware automatically.
+
+**Cons:**
+- **Overrides core roles** rather than adding *new named* roles — does not model "additional named
+  custom colors" (Req 5.1/5.2) and would clash with Req 5.5's no-collision rule.
+
+**Effort:** Low | **Risk:** High (wrong fit for additive custom colors)
+**Codebase fit:** Same options object as Area 1 Variant A.
+**Evidence:** `DynamicSchemeOptions` exposes `primaryPalette?`…`errorPalette?` override slots — for
+replacing core palettes, not adding roles. [mcu-dynamicscheme]
+
+## Variant Catalogue at a glance
+
+| Problem Area | Variant | Effort | Risk | Codebase fit |
+|-------------|---------|--------|------|--------------|
+| 1. Generation engine | A. `DynamicScheme` + `MaterialDynamicColors` | Low | Low | Same API as static generator |
+| 1. Generation engine | B. Per-variant `Scheme*` subclasses | Low | Medium | Exact current generator call shape; upstream-deprecated |
+| 1. Generation engine | C. `themeFromSourceColor` + `applyTheme` | Low | High | Legacy role set; no contrast |
+| 2. Packaging | A. MCU as `dependencies` | Low | Low | First runtime dep |
+| 2. Packaging | B. MCU as `peerDependencies` | Low | Medium | Mirrors `@angular/core` peer |
+| 2. Packaging | C. Vendor MCU subset | High | Medium | No vendoring precedent |
+| 3. Token application | A. Injected `<style>` text | Medium | Low | Same CSS shape as `_color.generated.css` |
+| 3. Token application | B. Inline props on `:root` | Medium | Medium | Can't scope `[data-contrast]`; SSR caveat |
+| 3. Token application | C. `adoptedStyleSheets` | Medium | Medium | Browser-only; needs SSR fallback |
+| 4. Angular/SSR lifecycle | A. Providers + bootstrap initializer + service | Medium | Low | Extends `ApplicationConfig` |
+| 4. Angular/SSR lifecycle | B. Config token + `afterNextRender` | Low | High | Hydration shift (Req 10.3) |
+| 4. Angular/SSR lifecycle | C. Initializer + `TransferState` | High | Low | Optional given deterministic output |
+| 5. Custom colors | A. MCU `customColor()` helper | Low | Medium | No contrast (Req 5.4) |
+| 5. Custom colors | B. Palette-per-color via contrast pipeline | Medium | Low | Builds on Area 1 A/B |
+| 5. Custom colors | C. Palette-override slots | Low | High | Overrides core, not additive |
+
+## Cross-area dependencies
+
+- **Area 1/C (`themeFromSourceColor`) forces Area 3 toward MCU `applyTheme`** and conflicts with the
+  token contract (Req 11), contrast (Req 3), and the `light-dark()` OS-switch model (Req 4) — picking
+  it effectively rules out the contrast-aware paths in Areas 3 and 5.
+- **Area 5/B (contrast-aware custom colors) requires Area 1/A or 1/B** (low-level `DynamicScheme`),
+  because contrast flows only through `DynamicScheme`, never through the `customColor()` helper.
+- **Area 3/C (`adoptedStyleSheets`) and Area 4/B (`afterNextRender`) both leave SSR uncovered** — if
+  Req 10 is taken strictly, each needs a server-side `<style>` fallback (Area 3/A) regardless.
+- **Area 3/A pairs naturally with Area 4/A**: a server-rendered `<style>` is what makes the bootstrap
+  initializer produce identical first paint on server and client.
+
+## Codebase Insights
+
+- `libs/ui/tooling/generate-color-tokens.mts:14-22,51-63,65-71` already enumerates 49 roles via
+  `MaterialDynamicColors` + `getArgb` and emits `--md-sys-color-<kebab>: light-dark(L,D)` — runtime
+  generation is largely a relocation of this logic into shipped code with a dynamic seed.
+- `libs/ui/src/styles/tokens/_color.generated.css` defines the exact CSS shape to reproduce:
+  `:root,[data-contrast='standard']` + `[data-contrast='medium'|'high']` + `[data-theme]` overrides.
+- `libs/ui/package.json` ships **no runtime deps** and only the `./styles/theme.css` export; adding the
+  API means new `dependencies`/`peer` + possibly a new entry point + `tsconfig.base.json` path +
+  `libs/ui/project.json` test `include` entry.
+- `libs/ui/eslint.config.mjs` `@nx/dependency-checks` ignores only `tooling/**`; a **shipped** MCU
+  import will be enforced to be declared in `libs/ui/package.json`.
+- No `DOCUMENT`/`Renderer2`/`PLATFORM_ID`/`afterNextRender`/`TransferState` anywhere yet; whichever
+  application + SSR variant is chosen introduces the first such usage.
+- `apps/web` is CSR-only, so end-to-end SSR verification of Req 10 has **no host to run in** today —
+  see Open Questions.
+
+## Sources
+
+- [mcu-pkg] `node_modules/@material/material-color-utilities/package.json` (v0.4.0; `type:module`, no `sideEffects`) — read 2026-05-29
+- [mcu-index] `node_modules/@material/material-color-utilities/index.d.ts` (submodule re-exports) — read 2026-05-29
+- [mcu-dynamicscheme] `node_modules/@material/material-color-utilities/dynamiccolor/dynamic_scheme.d.ts` (`DynamicSchemeOptions`, `constructor(args)`, palette-override slots) — read 2026-05-29
+- [mcu-variant] `node_modules/@material/material-color-utilities/dynamiccolor/variant.d.ts` (9-value `Variant` enum) — read 2026-05-29
+- [mcu-schemefiles] `node_modules/@material/material-color-utilities/scheme/scheme_*.d.ts` (all 9 variant subclasses; `SchemeExpressive(sourceColorHct,isDark,contrastLevel,specVersion?,platform?)`) — read 2026-05-29
+- [mcu-themeutils] `node_modules/@material/material-color-utilities/utils/theme_utils.d.ts` (`CustomColor`, `CustomColorGroup`, `Theme` with legacy `Scheme`, `themeFromSourceColor`, `customColor`, `applyTheme`) — read 2026-05-29
+- [mcu-blend] `node_modules/@material/material-color-utilities/blend/blend.d.ts` (`Blend.harmonize`) — read 2026-05-29
+- [mcu-migrate] https://github.com/material-foundation/material-color-utilities/blob/main/_autodocs/api-reference/schemes.md — fetched 2026-05-29 (context7: /material-foundation/material-color-utilities; positional `SchemeTonalSpot` deprecated in favour of `DynamicScheme`)
+- [gen-mts] `libs/ui/tooling/generate-color-tokens.mts:14-22,51-71` — read 2026-05-29
+- [m3-tokens-css] `libs/ui/src/styles/tokens/_color.generated.css` (light-dark() + `[data-contrast]` scopes + `color-scheme`) — read 2026-05-29
+- [libui-pkg] `libs/ui/package.json` (peer-only `@angular/core`, no runtime deps, `./styles/theme.css` export) — read 2026-05-29
+- [eslint-depcheck] `libs/ui/eslint.config.mjs` (`@nx/dependency-checks` ignoredFiles incl. `tooling/**`) — read 2026-05-29
+- [ngpkg] `dist/libs/ui/package.json` (ng-packagr externalizes deps; only injects `tslib`) — read 2026-05-29
+- [app-config] `apps/web/src/app/app.config.ts` (zoneless, no initializer) + `apps/web/src/main.ts` — read 2026-05-29
+- [web-proj] `apps/web/project.json` (no SSR/server target) — read 2026-05-29
+- [no-dom] repo-wide search: no `DOCUMENT`/`Renderer2`/`PLATFORM_ID`/`afterNextRender` — searched 2026-05-29
+- [entrypoint] `libs/ui/button/ng-package.json`, `libs/ui/button/src/index.ts`, `tsconfig.base.json:17-22`, `libs/ui/project.json` test `include` — read 2026-05-29
+- [ng-ssr-style] https://medium.com/@piyalidas.it/angular-theme-integration-using-dynamically-load-css-1617147799bf — fetched 2026-05-29 (Renderer2 `<style>` injection as SSR-safe pattern)
+- [ng-universal-2163] https://github.com/angular/universal/issues/2163 — fetched 2026-05-29 (server-side `style.setProperty` on injected document throws)
+- [mdn-adopted] https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets — fetched 2026-05-29 (browser Document API)
+- [ng-env-providers] Angular `EnvironmentProviders` / standalone provider pattern — context7 Angular docs, fetched 2026-05-29
+- [ng-transferstate] Angular `TransferState` server→client hydration data — context7 Angular docs, fetched 2026-05-29
+
+## Open Questions
+
+- [ ] **Entry-point placement:** root `@ngguide/ui` vs a new secondary entry (e.g. `@ngguide/ui/theme`)
+  for the dynamic-color API. Affects whether importing `GuiSize` pulls MCU. (Decide in `spec:design`.)
+- [ ] **SSR verification host:** `apps/web` is CSR-only, so Req 10 can't be exercised end-to-end today.
+  Does this spec add a minimal SSR harness/target, or assert SSR-safety via unit tests of the
+  DOM-agnostic generation path only? (Scope decision for `spec:design`/`spec:tasks`.)
+- [ ] **Custom-role naming scheme:** exact `--md-sys-color-<name>-*` derivation and collision rule with
+  core roles (Req 5.5) — to be specified in design.
+- [ ] **Baseline-override guarantee:** confirm injected `:root` styles reliably override the statically
+  imported `theme.css` for the same roles (Req 6.5) given import order; pin the mechanism in design.
+- [ ] **Exact document/Renderer access API** (Angular 21 `DOCUMENT` token source + Renderer2 vs direct)
+  — confirm against installed `@angular/core`/`@angular/common` in design rather than assume.
+
+## Next Steps
+
+`spec:design m3-dynamic-color` will pick one variant per problem area and produce the technical design.
+
+If new directions surface during design, run `spec:research m3-dynamic-color` again — it will extend
+this catalogue rather than overwrite it.

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -59,7 +59,7 @@ nothing imports yet; the static baseline and existing entry points are unchanged
   - Apply the selected contrast level to custom roles like core roles (Req 5.4)
   - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
 
-- [ ] 5. Implement input validation
+- [x] 5. Implement input validation
   - Create `libs/ui/theme/src/validate.ts`: `parseHex(input,label)` (accept `#RGB`/`#RRGGBB`,
     normalize, throw descriptive `Error` otherwise) and `validateConfig(config)` validating
     `sourceColor` + each `customColors[].value`, and rejecting custom names that collide with a core

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -117,7 +117,7 @@ Adds the DOM/runtime layer: `<style>` applier, theme service, and the `provideM3
     `inject(M3ThemeService).init(config)` (Decision 4A; applies on server and client, Req 7.2, 10.1)
   - _Requirements: 7.1, 7.2, 9.1, 9.2, 10.1_
 
-- [ ] 12. Finalize the public barrel and docs
+- [x] 12. Finalize the public barrel and docs
   - Update `libs/ui/theme/src/index.ts` to export `./types`, `provideM3Theme`, `M3ThemeService`,
     `generateScheme`/`GeneratedScheme`
   - Add `libs/ui/theme/README.md` documenting `provideM3Theme`, runtime `setTheme`, `resolve`,

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -111,7 +111,7 @@ Adds the DOM/runtime layer: `<style>` applier, theme service, and the `provideM3
     equal to applied values (Req 8)
   - _Requirements: 6.2, 6.3, 7.3, 8.1, 8.2, 8.3_
 
-- [ ] 11. Implement `provideM3Theme`
+- [x] 11. Implement `provideM3Theme`
   - Create `libs/ui/theme/src/provide-theme.ts`: `provideM3Theme(config): EnvironmentProviders` via
     `makeEnvironmentProviders` + `provideEnvironmentInitializer` that calls `validateConfig` then
     `inject(M3ThemeService).init(config)` (Decision 4A; applies on server and client, Req 7.2, 10.1)

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -104,7 +104,7 @@ Adds the DOM/runtime layer: `<style>` applier, theme service, and the `provideM3
     Req 10.2)
   - _Requirements: 6.1, 6.3, 6.5, 10.2_
 
-- [ ] 10. Implement the theme service
+- [x] 10. Implement the theme service
   - Create `libs/ui/theme/src/theme.service.ts`: `M3ThemeService` (`providedIn:'root'`) with
     `init(config)`, `setTheme(config)` (validate → `generateScheme` → `buildCss` → `applier.apply`),
     `config` signal, and `resolve({mode?,contrast?})` returning flat role→hex incl. custom roles

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -50,7 +50,7 @@ nothing imports yet; the static baseline and existing entry points are unchanged
   - Ensure role-name enumeration matches the build-time generator so the contract holds (Req 11)
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 11.1, 11.2_
 
-- [ ] 4. Implement contrast-aware custom-color generation
+- [x] 4. Implement contrast-aware custom-color generation
   - Extend `engine.ts`: for each `M3CustomColor`, optionally `Blend.harmonize(value, source)`, then
     seed a per-color `DynamicScheme` (same variant + contrast + mode) and map its primary family to
     `--md-sys-color-<name>` / `-on-<name>` / `-<name>-container` / `-on-<name>-container`

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -96,7 +96,7 @@ Adds the DOM/runtime layer: `<style>` applier, theme service, and the `provideM3
 `TestBed` tests, and finalizes the public barrel. Blast radius: *safe* — additive; no app calls
 `provideM3Theme` yet, so the static baseline still governs. Depends on Group A.
 
-- [ ] 9. Implement the SSR-safe style applier
+- [x] 9. Implement the SSR-safe style applier
   - Create `libs/ui/theme/src/style-applier.ts`: `M3StyleApplier` (`providedIn:'root'`) injecting
     `DOCUMENT` (from `@angular/core`) and `RendererFactory2.createRenderer(null,null)`; `apply(css)`
     creates-or-replaces a single managed `<style>` at the end of `<head>` (Decision 3A; overrides

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -1,0 +1,207 @@
+---
+created: 2026-05-29
+updated: 2026-05-29
+---
+
+# Implementation Plan: M3 Dynamic Color
+
+## Overview
+
+Add runtime M3 dynamic color to `@ngguide/ui` as a new secondary entry point `@ngguide/ui/theme`:
+a DOM-free scheme engine over `@material/material-color-utilities`, an injected-`<style>` applier that
+mirrors the static `m3-tokens` CSS shape, and an Angular `provideM3Theme` provider + `M3ThemeService`.
+A demo-only SSR host is added to `apps/web` to verify SSR-safety.
+
+The plan is split into 3 groups in dependency order. Each group is independently mergeable — build,
+tests, and runtime behaviour stay green with only that group (and earlier ones) applied. The whole
+feature is **purely additive**: `provideM3Theme` is opt-in, the static token baseline is untouched, so
+nothing existing changes — there are no cutovers.
+
+## Tasks
+
+### Group A — Theme entry point + generation core (new feature surface)
+
+Stands up the `@ngguide/ui/theme` entry point and all **pure, DOM-free** logic (types, engine, custom
+colors, validation, CSS serialization) with unit tests. Blast radius: *safe* — a new entry point that
+nothing imports yet; the static baseline and existing entry points are unchanged.
+
+- [x] 1. Scaffold the `@ngguide/ui/theme` secondary entry point and promote MCU to a runtime dep
+  - Create `libs/ui/theme/ng-package.json` = `{ "lib": { "entryFile": "src/index.ts" } }`
+  - Create `libs/ui/theme/src/index.ts` (temporary placeholder export; finalized in task 8)
+  - Add `"@ngguide/ui/theme": ["libs/ui/theme/src/index.ts"]` to `tsconfig.base.json` `paths`
+  - Add `@material/material-color-utilities` to `libs/ui/package.json` **`dependencies`** (`^0.4.0`)
+    so ng-packagr externalizes it into `dist/libs/ui/package.json` (Decision 2A)
+  - Move `@material/material-color-utilities` from root `devDependencies` is NOT required; keep root
+    entry as-is — only `libs/ui/package.json` needs the runtime declaration
+  - Confirm `@nx/dependency-checks` in `libs/ui/eslint.config.mjs` is satisfied by the new
+    `dependencies` entry (no `ignoredFiles` change needed for shipped `src/**`)
+  - _Requirements: 7.1, 11.1_
+
+- [ ] 2. Define public types
+  - Create `libs/ui/theme/src/types.ts` with `M3SchemeVariant` (9 values), `M3Contrast`, `M3Mode`,
+    `M3CustomColor`, `M3ThemeConfig`, `M3ColorGroup`, `M3ResolvedRoles` (per design "Public types")
+  - _Requirements: 1.1, 2.1, 3.1, 4.1, 5.1, 7.1_
+
+- [ ] 3. Implement the core scheme engine
+  - Create `libs/ui/theme/src/engine.ts`: `camelToKebab`, `coreRoles()` (enumerate
+    `MaterialDynamicColors`, exclude `*PaletteKeyColor`), `VARIANT_MAP`, `CONTRAST_MAP`,
+    `buildScheme()`, and `generateScheme()` producing `{standard,medium,high}` × role × `{light,dark}`
+    via `DynamicScheme` + `MaterialDynamicColors[role].getArgb` + `hexFromArgb` (Decision 1A)
+  - Ensure role-name enumeration matches the build-time generator so the contract holds (Req 11)
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 11.1, 11.2_
+
+- [ ] 4. Implement contrast-aware custom-color generation
+  - Extend `engine.ts`: for each `M3CustomColor`, optionally `Blend.harmonize(value, source)`, then
+    seed a per-color `DynamicScheme` (same variant + contrast + mode) and map its primary family to
+    `--md-sys-color-<name>` / `-on-<name>` / `-<name>-container` / `-on-<name>-container`
+    (Decision 5B; the documented M3-gap resolution)
+  - Default `harmonize` to `true`; honour per-color override (Req 5.3)
+  - Apply the selected contrast level to custom roles like core roles (Req 5.4)
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+
+- [ ] 5. Implement input validation
+  - Create `libs/ui/theme/src/validate.ts`: `parseHex(input,label)` (accept `#RGB`/`#RRGGBB`,
+    normalize, throw descriptive `Error` otherwise) and `validateConfig(config)` validating
+    `sourceColor` + each `customColors[].value`, and rejecting custom names that collide with a core
+    role (protects Req 5.5). No silent fallback.
+  - _Requirements: 9.1, 9.2, 9.3, 5.5_
+
+- [ ] 6. Implement the CSS builder
+  - Create `libs/ui/theme/src/css-builder.ts`: `buildCss(scheme, mode)` emitting
+    `:root,[data-contrast='standard']{ color-scheme: <mode>; --md-sys-color-*: light-dark(L,D); }`
+    plus `[data-contrast='medium'|'high']` blocks, identical in shape to `_color.generated.css`;
+    `mode` → `color-scheme` (`auto`→`light dark`, else forced) (Decision 3A, Req 4)
+  - _Requirements: 3.1, 3.3, 4.1, 4.2, 4.3, 4.4, 6.1_
+
+- [ ] 7. Unit-test the pure core
+  - Create `libs/ui/theme/src/engine.spec.ts`, `css-builder.spec.ts`, `validate.spec.ts`
+  - Assert: role-name set equals the names in `libs/ui/src/styles/tokens/_color.generated.css`
+    (Req 11.3); baseline seed `#6750A4` tonal-spot/standard yields `primary` `light #65558f` /
+    `dark #cfbdfe`; output varies by variant and contrast; 4 harmonized contrast-aware roles per
+    custom color; `buildCss` emits `light-dark()`, `color-scheme`, and 3 `[data-contrast]` scopes and
+    forces mode correctly; `validateConfig` throws naming the offender
+  - Register all three specs in `libs/ui/project.json` `test.options.include`
+  - _Requirements: 1.4, 2.3, 3.2, 4.2, 4.3, 5.2, 5.4, 9.1, 9.2, 11.3_
+
+- [ ] 8. Checkpoint — Group A verification
+  - Run new tests: `pnpm exec nx test ui`
+  - Run `pnpm exec nx lint ui` and `pnpm exec nx build ui` (entry point builds; MCU externalized in
+    `dist/libs/ui/package.json`)
+  - Confirm `main` still builds/tests with only Group A applied; the new entry point is importable but
+    referenced by nothing else yet
+
+### Group B — Angular integration (new feature surface)
+
+Adds the DOM/runtime layer: `<style>` applier, theme service, and the `provideM3Theme` provider, with
+`TestBed` tests, and finalizes the public barrel. Blast radius: *safe* — additive; no app calls
+`provideM3Theme` yet, so the static baseline still governs. Depends on Group A.
+
+- [ ] 9. Implement the SSR-safe style applier
+  - Create `libs/ui/theme/src/style-applier.ts`: `M3StyleApplier` (`providedIn:'root'`) injecting
+    `DOCUMENT` (from `@angular/core`) and `RendererFactory2.createRenderer(null,null)`; `apply(css)`
+    creates-or-replaces a single managed `<style>` at the end of `<head>` (Decision 3A; overrides
+    baseline via document order, Req 6.5; replace-in-place, Req 6.3; no throw without a browser DOM,
+    Req 10.2)
+  - _Requirements: 6.1, 6.3, 6.5, 10.2_
+
+- [ ] 10. Implement the theme service
+  - Create `libs/ui/theme/src/theme.service.ts`: `M3ThemeService` (`providedIn:'root'`) with
+    `init(config)`, `setTheme(config)` (validate → `generateScheme` → `buildCss` → `applier.apply`),
+    `config` signal, and `resolve({mode?,contrast?})` returning flat role→hex incl. custom roles
+    equal to applied values (Req 8)
+  - _Requirements: 6.2, 6.3, 7.3, 8.1, 8.2, 8.3_
+
+- [ ] 11. Implement `provideM3Theme`
+  - Create `libs/ui/theme/src/provide-theme.ts`: `provideM3Theme(config): EnvironmentProviders` via
+    `makeEnvironmentProviders` + `provideEnvironmentInitializer` that calls `validateConfig` then
+    `inject(M3ThemeService).init(config)` (Decision 4A; applies on server and client, Req 7.2, 10.1)
+  - _Requirements: 7.1, 7.2, 9.1, 9.2, 10.1_
+
+- [ ] 12. Finalize the public barrel and docs
+  - Update `libs/ui/theme/src/index.ts` to export `./types`, `provideM3Theme`, `M3ThemeService`,
+    `generateScheme`/`GeneratedScheme`
+  - Add `libs/ui/theme/README.md` documenting `provideM3Theme`, runtime `setTheme`, `resolve`,
+    custom colors + harmonize, and the import path
+  - _Requirements: 7.1, 7.3, 8.1_
+
+- [ ] 13. Test the Angular layer
+  - Create `libs/ui/theme/src/theme.service.spec.ts` (TestBed + real `DOCUMENT`): asserts a `<style>`
+    is injected after baseline, `setTheme` replaces it, `resolve()` equals applied values, and
+    `provideM3Theme` applies the configured scheme at init; invalid config throws
+  - Register the spec in `libs/ui/project.json` `test.options.include`
+  - _Requirements: 6.2, 6.3, 6.5, 7.2, 7.3, 8.2, 8.3, 9.1_
+
+- [ ] 14. Checkpoint — Group B verification
+  - Run `pnpm exec nx run-many -t lint test build -p ui`
+  - Confirm `@ngguide/ui/theme` exports the full API and `dist/libs/ui` builds with the `theme` entry
+    point and MCU declared; static baseline behaviour unchanged when `provideM3Theme` is unused
+
+### Group C — SSR host + dogfood in apps/web (verification)
+
+Adds server-side rendering to the demo app and wires `provideM3Theme` to verify Req 10 end-to-end.
+Blast radius: *safe* — `apps/web` is the unpublished demo host; release/verdaccio config is untouched.
+Depends on Group B.
+
+- [ ] 15. Add SSR build wiring to `apps/web`
+  - Install `@angular/ssr` and `@angular/platform-server` (`^21`) at the workspace root
+  - Add `server` / `ssr` / `outputMode: 'server'` options to the `@angular/build:application` build
+    target in `apps/web/project.json`; create `apps/web/tsconfig.server.json`
+  - _Requirements: 10.1, 10.2_
+
+- [ ] 16. Add the server bootstrap
+  - Create `apps/web/src/main.server.ts` (Angular 21 form: `const bootstrap = (context) =>
+    bootstrapApplication(App, serverConfig, context); export default bootstrap;` — NG0401) and
+    `apps/web/src/app/app.config.server.ts` merging `provideServerRendering()` with `appConfig`
+  - _Requirements: 10.1, 10.2, 10.3_
+
+- [ ] 17. Dogfood `provideM3Theme` in `apps/web`
+  - Add `provideM3Theme({ sourceColor, variant, contrast, mode, customColors })` to
+    `apps/web/src/app/app.config.ts`, plus a minimal demo control that calls
+    `M3ThemeService.setTheme(...)` at runtime (Req 7.3) to exercise re-theming
+  - _Requirements: 7.1, 7.2, 7.3_
+
+- [ ] 18. Verify SSR-safety end-to-end
+  - Build/serve the SSR target; confirm the server-rendered HTML `<head>` contains the dynamic
+    `<style>` with `--md-sys-color-*: light-dark(...)` and that the client hydrates with no theme
+    flash (identical CSS string) (Req 10.2, 10.3)
+  - Optionally add a server-render smoke spec if feasible in the harness
+  - _Requirements: 10.1, 10.2, 10.3_
+
+- [ ] 19. Final checkpoint — everything green
+  - `pnpm exec nx run-many -t lint test build` green for `ui` and `web`
+  - All 11 requirements traceable to a shipped task (see Notes); static-only consumers unaffected
+    (Req 6.4); `@ngguide/ui` root import (`GuiSize`) does not pull MCU
+
+## Notes
+
+### Scope boundaries
+
+- **Image/content-based color extraction is out of scope** (Req decisions): only hex seed + named
+  custom colors. MCU `themeFromImage` is intentionally unused.
+- **Scoped-subtree theming is out of scope**: application is global (document root) only (Req 6.1).
+- **Release / verdaccio / Nx release config unchanged** (project constraint). The SSR additions touch
+  only the unpublished `apps/web` demo host.
+
+### Requirement traceability
+
+- Req 1, 2, 3 → tasks 3, 7 (engine + tests)
+- Req 4 → tasks 6, 7 (CSS builder)
+- Req 5 → tasks 4, 5, 7 (custom colors + collision validation)
+- Req 6 → tasks 6, 9, 10, 13 (build + apply + override + replace)
+- Req 7 → tasks 10, 11, 12, 17 (service + provider + dogfood)
+- Req 8 → tasks 10, 13 (`resolve`)
+- Req 9 → tasks 5, 11, 13 (validation, fail-fast)
+- Req 10 → tasks 9, 11, 15, 16, 18 (SSR-safe applier + host verification)
+- Req 11 → tasks 1, 3, 7 (MCU runtime dep + same enumeration + parity test)
+
+### Codebase verification findings
+
+- `@angular/ssr` and `@angular/platform-server` are **not installed** — task 15 adds them. `apps/web`
+  is CSR-only today (`apps/web/project.json` has no `server`/`ssr` options).
+- MCU is currently a **root `devDependency`** only; task 1 adds it to `libs/ui/package.json`
+  `dependencies`. ng-packagr externalizes deps (only `tslib` is auto-injected today).
+- The repo has **no** existing `DOCUMENT`/`Renderer2`/`PLATFORM_ID` usage — Group B introduces the
+  first; verified `DOCUMENT`, `RendererFactory2`, `makeEnvironmentProviders`,
+  `provideEnvironmentInitializer` all exist in installed `@angular/core` 21.2.9.
+- Secondary-entry specs are not auto-discovered — tasks 7 and 13 must add each spec to
+  `libs/ui/project.json` `test.options.include`.

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -167,7 +167,7 @@ Depends on Group B.
   - Optionally add a server-render smoke spec if feasible in the harness
   - _Requirements: 10.1, 10.2, 10.3_
 
-- [ ] 19. Final checkpoint — everything green
+- [x] 19. Final checkpoint — everything green
   - `pnpm exec nx run-many -t lint test build` green for `ui` and `web`
   - All 11 requirements traceable to a shipped task (see Notes); static-only consumers unaffected
     (Req 6.4); `@ngguide/ui` root import (`GuiSize`) does not pull MCU

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -42,7 +42,7 @@ nothing imports yet; the static baseline and existing entry points are unchanged
     `M3CustomColor`, `M3ThemeConfig`, `M3ColorGroup`, `M3ResolvedRoles` (per design "Public types")
   - _Requirements: 1.1, 2.1, 3.1, 4.1, 5.1, 7.1_
 
-- [ ] 3. Implement the core scheme engine
+- [x] 3. Implement the core scheme engine
   - Create `libs/ui/theme/src/engine.ts`: `camelToKebab`, `coreRoles()` (enumerate
     `MaterialDynamicColors`, exclude `*PaletteKeyColor`), `VARIANT_MAP`, `CONTRAST_MAP`,
     `buildScheme()`, and `generateScheme()` producing `{standard,medium,high}` × role × `{light,dark}`

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -124,14 +124,14 @@ Adds the DOM/runtime layer: `<style>` applier, theme service, and the `provideM3
     custom colors + harmonize, and the import path
   - _Requirements: 7.1, 7.3, 8.1_
 
-- [ ] 13. Test the Angular layer
+- [x] 13. Test the Angular layer
   - Create `libs/ui/theme/src/theme.service.spec.ts` (TestBed + real `DOCUMENT`): asserts a `<style>`
     is injected after baseline, `setTheme` replaces it, `resolve()` equals applied values, and
     `provideM3Theme` applies the configured scheme at init; invalid config throws
   - Register the spec in `libs/ui/project.json` `test.options.include`
   - _Requirements: 6.2, 6.3, 6.5, 7.2, 7.3, 8.2, 8.3, 9.1_
 
-- [ ] 14. Checkpoint — Group B verification
+- [x] 14. Checkpoint — Group B verification
   - Run `pnpm exec nx run-many -t lint test build -p ui`
   - Confirm `@ngguide/ui/theme` exports the full API and `dist/libs/ui` builds with the `theme` entry
     point and MCU declared; static baseline behaviour unchanged when `provideM3Theme` is unused

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -66,7 +66,7 @@ nothing imports yet; the static baseline and existing entry points are unchanged
     role (protects Req 5.5). No silent fallback.
   - _Requirements: 9.1, 9.2, 9.3, 5.5_
 
-- [ ] 6. Implement the CSS builder
+- [x] 6. Implement the CSS builder
   - Create `libs/ui/theme/src/css-builder.ts`: `buildCss(scheme, mode)` emitting
     `:root,[data-contrast='standard']{ color-scheme: <mode>; --md-sys-color-*: light-dark(L,D); }`
     plus `[data-contrast='medium'|'high']` blocks, identical in shape to `_color.generated.css`;

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -73,7 +73,7 @@ nothing imports yet; the static baseline and existing entry points are unchanged
     `mode` → `color-scheme` (`auto`→`light dark`, else forced) (Decision 3A, Req 4)
   - _Requirements: 3.1, 3.3, 4.1, 4.2, 4.3, 4.4, 6.1_
 
-- [ ] 7. Unit-test the pure core
+- [x] 7. Unit-test the pure core
   - Create `libs/ui/theme/src/engine.spec.ts`, `css-builder.spec.ts`, `validate.spec.ts`
   - Assert: role-name set equals the names in `libs/ui/src/styles/tokens/_color.generated.css`
     (Req 11.3); baseline seed `#6750A4` tonal-spot/standard yields `primary` `light #65558f` /
@@ -83,7 +83,7 @@ nothing imports yet; the static baseline and existing entry points are unchanged
   - Register all three specs in `libs/ui/project.json` `test.options.include`
   - _Requirements: 1.4, 2.3, 3.2, 4.2, 4.3, 5.2, 5.4, 9.1, 9.2, 11.3_
 
-- [ ] 8. Checkpoint — Group A verification
+- [x] 8. Checkpoint — Group A verification
   - Run new tests: `pnpm exec nx test ui`
   - Run `pnpm exec nx lint ui` and `pnpm exec nx build ui` (entry point builds; MCU externalized in
     `dist/libs/ui/package.json`)

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -142,25 +142,25 @@ Adds server-side rendering to the demo app and wires `provideM3Theme` to verify 
 Blast radius: *safe* — `apps/web` is the unpublished demo host; release/verdaccio config is untouched.
 Depends on Group B.
 
-- [ ] 15. Add SSR build wiring to `apps/web`
+- [x] 15. Add SSR build wiring to `apps/web`
   - Install `@angular/ssr` and `@angular/platform-server` (`^21`) at the workspace root
   - Add `server` / `ssr` / `outputMode: 'server'` options to the `@angular/build:application` build
     target in `apps/web/project.json`; create `apps/web/tsconfig.server.json`
   - _Requirements: 10.1, 10.2_
 
-- [ ] 16. Add the server bootstrap
+- [x] 16. Add the server bootstrap
   - Create `apps/web/src/main.server.ts` (Angular 21 form: `const bootstrap = (context) =>
     bootstrapApplication(App, serverConfig, context); export default bootstrap;` — NG0401) and
     `apps/web/src/app/app.config.server.ts` merging `provideServerRendering()` with `appConfig`
   - _Requirements: 10.1, 10.2, 10.3_
 
-- [ ] 17. Dogfood `provideM3Theme` in `apps/web`
+- [x] 17. Dogfood `provideM3Theme` in `apps/web`
   - Add `provideM3Theme({ sourceColor, variant, contrast, mode, customColors })` to
     `apps/web/src/app/app.config.ts`, plus a minimal demo control that calls
     `M3ThemeService.setTheme(...)` at runtime (Req 7.3) to exercise re-theming
   - _Requirements: 7.1, 7.2, 7.3_
 
-- [ ] 18. Verify SSR-safety end-to-end
+- [x] 18. Verify SSR-safety end-to-end
   - Build/serve the SSR target; confirm the server-rendered HTML `<head>` contains the dynamic
     `<style>` with `--md-sys-color-*: light-dark(...)` and that the client hydrates with no theme
     flash (identical CSS string) (Req 10.2, 10.3)

--- a/.specs/m3-dynamic-color/tasks.md
+++ b/.specs/m3-dynamic-color/tasks.md
@@ -37,7 +37,7 @@ nothing imports yet; the static baseline and existing entry points are unchanged
     `dependencies` entry (no `ignoredFiles` change needed for shipped `src/**`)
   - _Requirements: 7.1, 11.1_
 
-- [ ] 2. Define public types
+- [x] 2. Define public types
   - Create `libs/ui/theme/src/types.ts` with `M3SchemeVariant` (9 values), `M3Contrast`, `M3Mode`,
     `M3CustomColor`, `M3ThemeConfig`, `M3ColorGroup`, `M3ResolvedRoles` (per design "Public types")
   - _Requirements: 1.1, 2.1, 3.1, 4.1, 5.1, 7.1_

--- a/.specs/m3-dynamic-color/test-plan.md
+++ b/.specs/m3-dynamic-color/test-plan.md
@@ -168,7 +168,7 @@ Where a generated value is asserted, the **M3 reference** is the committed stati
       and the colliding `--md-sys-color-*` role. No silent overwrite of a core role.
     - _Requirements: 5.5_
 
-- [!] 6. Global runtime application
+- [x] 6. Global runtime application
   - [x] 6.1 Applied scheme writes the token contract at document root
     - **Preconditions:** Demo app running with default config.
     - **Steps:**
@@ -183,7 +183,7 @@ Where a generated value is asserted, the **M3 reference** is the committed stati
       2. Observe the rendered buttons/fabs.
     - **Expected:** Component colors change to the new scheme immediately; no component code changed.
     - _Requirements: 6.2_
-  - [!] 6.3 Re-applying fully replaces prior dynamic values
+  - [x] 6.3 Re-applying fully replaces prior dynamic values
     - **Preconditions:** Demo app; DevTools.
     - **Steps:**
       1. Apply seed A, note `--md-sys-color-primary` and that exactly one `style[data-m3-dynamic]` exists.
@@ -191,7 +191,6 @@ Where a generated value is asserted, the **M3 reference** is the committed stati
     - **Expected:** Still exactly one `style[data-m3-dynamic]` element; its text is fully replaced
       (primary now reflects seed B; no stale seed-A values linger).
     - _Requirements: 6.3_
-    - **FAILED:** After SSR + client hydration there are **two** identical `style[data-m3-dynamic]` elements (SSR-serialized + client-injected), not one — the client `M3StyleApplier` does not adopt the server-serialized `<style>`, so it appends a duplicate. Re-applying at runtime correctly reuses the client element (count stays 2, never grows) and the last/winning element is fully replaced, so override and re-theme work and there is **no visual shift** (both elements are byte-identical). The defect is the duplicate element only — it violates the design's "single managed `<style>`". Suggested fix: have the applier query an existing `style[data-m3-dynamic]` on first `apply()` and adopt it.
   - [x] 6.4 No dynamic config → static baseline remains
     - **Preconditions:** A page/app that imports the baseline `theme.css` but does NOT call `provideM3Theme`.
     - **Steps:**
@@ -334,6 +333,8 @@ Where a generated value is asserted, the **M3 reference** is the committed stati
 
 ## Summary
 - Total: 30 tests
-- Passed: 29
-- Failed: 1 (6.3 — SSR/hydration duplicate `<style>`)
+- Passed: 30
+- Failed: 0
 - Skipped: 0
+
+_Note: 6.3 initially failed (SSR + client hydration produced two identical `<style data-m3-dynamic>` elements). Fixed — the applier now adopts the server-serialized `<style>` on first `apply()`; re-tested: single element after hydration, runtime re-theme reuses it, no visual shift._

--- a/.specs/m3-dynamic-color/test-plan.md
+++ b/.specs/m3-dynamic-color/test-plan.md
@@ -1,0 +1,339 @@
+---
+created: 2026-05-29
+updated: 2026-05-29
+---
+
+# Manual Test Plan: M3 Dynamic Color
+
+## Overview
+
+Validates the `@ngguide/ui/theme` dynamic-color system against its requirements: scheme
+generation from a seed color, all 9 M3 variants, 3 contrast levels, light/dark with
+OS-driven switching, harmonized contrast-aware custom colors, global runtime application
+over the static baseline, bootstrap + runtime configuration, programmatic read, fail-fast
+validation, SSR-safety, and token-contract fidelity.
+
+Tests are derived from `requirements.md` (R1–R11), not the implementation. Each case is
+reproducible by an external observer — through the demo app (`apps/web`), a browser
+DevTools session, the SSR build output, or a throwaway script that imports the public API.
+Where a generated value is asserted, the **M3 reference** is the committed static contract
+`libs/ui/src/styles/tokens/_color.generated.css` (same seed `#6750A4`, same algorithm), so
+"correct" means "equals the M3 reference", never "looks right".
+
+## Prerequisites
+
+- Repo installed: `pnpm install`; Node 20.11+; commands prefixed with `pnpm exec`, `NX_NO_CLOUD=true`.
+- A modern browser with DevTools (Elements + Computed styles + an OS/browser light-dark toggle).
+- Ability to run the demo app: `pnpm exec nx serve web` (CSR) and to build/serve the SSR
+  target: `pnpm exec nx build web` then `node dist/apps/web/server/server.mjs` (defaults to
+  `http://localhost:4000`).
+- For API-level checks, a scratch script (run via `pnpm exec jiti <file>.mts`) that imports
+  from `@ngguide/ui/theme` — e.g. `generateScheme`, and a TestBed harness for `M3ThemeService`.
+- Reference file open for value comparison: `libs/ui/src/styles/tokens/_color.generated.css`.
+- The demo app dogfoods `provideM3Theme({ sourceColor: '#6750A4', variant: 'tonal-spot',
+  contrast: 'standard', mode: 'auto', customColors: [{ name: 'brand-success', value: '#2e7d32' }] })`
+  and renders "Brand seed" buttons that call `M3ThemeService.setTheme(...)`.
+
+## Test Scenarios
+
+- [x] 1. Scheme generation from a source color
+  - [x] 1.1 Generate a full scheme from a hex seed
+    - **Preconditions:** Scratch script can call `generateScheme({ sourceColor: '#6750A4' })`.
+    - **Steps:**
+      1. Call `generateScheme({ sourceColor: '#6750A4' })`.
+      2. Inspect the returned object's `standard` scope keys.
+    - **Expected:** A value is produced for every core role; each role has a `{ light, dark }`
+      hex pair. No role is empty/undefined.
+    - _Requirements: 1.1, 1.3_
+  - [x] 1.2 Output equals the M3 reference algorithm
+    - **Preconditions:** `_color.generated.css` open for comparison (seed `#6750A4`, tonal-spot, standard).
+    - **Steps:**
+      1. Call `generateScheme({ sourceColor: '#6750A4' })` (defaults: tonal-spot, standard).
+      2. Read `standard['primary']`, `standard['on-primary']`, `standard['surface-container-high']`.
+      3. Compare against the `--md-sys-color-*: light-dark(L, D)` values in the reference file.
+    - **Expected:** `primary` = `light #65558f` / `dark #cfbdfe`; the other sampled roles match
+      the reference file exactly (light and dark).
+    - _Requirements: 1.2, 1.4_
+  - [x] 1.3 Determinism — identical input yields identical output
+    - **Preconditions:** Scratch script.
+    - **Steps:**
+      1. Call `generateScheme` twice with the exact same config (incl. variant, contrast, custom colors).
+      2. Deep-compare the two results.
+    - **Expected:** The two outputs are byte-for-byte identical.
+    - _Requirements: NFR Determinism, 1.4_
+
+- [x] 2. Scheme variants
+  - [x] 2.1 Default variant is Tonal Spot
+    - **Preconditions:** Scratch script.
+    - **Steps:**
+      1. Call `generateScheme({ sourceColor: '#6750A4' })` (no variant).
+      2. Compare `standard['primary']` to the reference file value.
+    - **Expected:** Equals the tonal-spot baseline (`light #65558f` / `dark #cfbdfe`).
+    - _Requirements: 2.2_
+  - [x] 2.2 All nine variants are accepted and distinct
+    - **Preconditions:** Scratch script.
+    - **Steps:**
+      1. For each of `monochrome, neutral, tonal-spot, vibrant, expressive, fidelity, content,
+         rainbow, fruit-salad`, call `generateScheme({ sourceColor: '#6750A4', variant })`.
+      2. Record `standard['primary'].light` for each.
+    - **Expected:** All nine calls succeed; at least several variants produce different `primary`
+      values from tonal-spot (e.g. `vibrant` ≠ `tonal-spot`). No call throws.
+    - _Requirements: 2.1, 2.3_
+  - [x] 2.3 No non-M3 variant is exposed
+    - **Preconditions:** TypeScript scratch file.
+    - **Steps:**
+      1. Attempt to type `variant: 'rainbow-sherbet'` (a made-up name) in an `M3ThemeConfig`.
+    - **Expected:** TypeScript rejects it; only the nine M3 variant strings are assignable.
+    - _Requirements: 2.4_
+
+- [x] 3. Contrast levels
+  - [x] 3.1 Default contrast is standard
+    - **Preconditions:** Scratch script.
+    - **Steps:**
+      1. Call `generateScheme({ sourceColor: '#6750A4' })`.
+      2. Compare its `standard` scope to the standard scope in the reference file.
+    - **Expected:** Values match the reference's standard (`:root`) scope.
+    - _Requirements: 3.2_
+  - [x] 3.2 Medium and high adjust tones
+    - **Preconditions:** Scratch script + reference file (which has all three scopes).
+    - **Steps:**
+      1. Call `generateScheme({ sourceColor: '#6750A4' })`.
+      2. Compare `standard`, `medium`, `high` scopes to each other and to the reference's
+         `[data-contrast='medium']` / `[data-contrast='high']` blocks.
+    - **Expected:** `medium` ≠ `standard` ≠ `high`; each scope matches the corresponding reference block.
+    - _Requirements: 3.1, 3.3_
+
+- [x] 4. Light/dark and OS-driven switching
+  - [x] 4.1 Both light and dark are emitted for one config
+    - **Preconditions:** Demo app running (`nx serve web`); DevTools open.
+    - **Steps:**
+      1. Inspect `<head>` for the `style[data-m3-dynamic]` element.
+      2. Read a few `--md-sys-color-*` declarations.
+    - **Expected:** Each declaration is `light-dark(<lightHex>, <darkHex>)` — both sides present.
+    - _Requirements: 4.1_
+  - [x] 4.2 Active mode follows the OS preference (auto)
+    - **Preconditions:** Demo app running with default config (`mode: 'auto'`).
+    - **Steps:**
+      1. Set OS/browser to light; observe the app and a computed `--md-sys-color-surface` value.
+      2. Switch OS/browser to dark without reloading.
+    - **Expected:** UI re-themes to the dark side automatically; the dynamic `<style>` has
+      `color-scheme: light dark` on `:root`; no developer re-invocation needed.
+    - _Requirements: 4.2_
+  - [x] 4.3 Forced mode overrides the OS
+    - **Preconditions:** Demo app; temporarily set `provideM3Theme({ ..., mode: 'dark' })` (or call
+      `setTheme` with `mode: 'dark'`).
+    - **Steps:**
+      1. Apply a config with `mode: 'dark'`.
+      2. Toggle the OS preference between light and dark.
+    - **Expected:** App stays dark regardless of OS; the `:root` `color-scheme` is `dark`.
+      Repeat with `mode: 'light'` → stays light (`color-scheme: light`).
+    - _Requirements: 4.3_
+  - [x] 4.4 Mode behaviour matches the static baseline
+    - **Preconditions:** A page using only the static baseline (no `provideM3Theme`) and the demo app.
+    - **Steps:**
+      1. Compare light/dark switching of the static baseline vs a dynamic `auto` scheme.
+    - **Expected:** Both follow the OS via `light-dark()` + `color-scheme` identically.
+    - _Requirements: 4.4_
+
+- [x] 5. Custom (extended) colors
+  - [x] 5.1 Each custom color emits four roles, light + dark
+    - **Preconditions:** Demo app running (default config has `brand-success`).
+    - **Steps:**
+      1. In DevTools, search the dynamic `<style>` for `brand-success`.
+    - **Expected:** Present: `--md-sys-color-brand-success`, `--md-sys-color-on-brand-success`,
+      `--md-sys-color-brand-success-container`, `--md-sys-color-on-brand-success-container`,
+      each as a `light-dark(L, D)` pair.
+    - _Requirements: 5.1, 5.2_
+  - [x] 5.2 Harmonization is on by default and toggleable
+    - **Preconditions:** Scratch script.
+    - **Steps:**
+      1. `generateScheme({ sourceColor: '#6750A4', customColors: [{ name: 'brand', value: '#00FF00' }] })`.
+      2. `generateScheme({ sourceColor: '#6750A4', customColors: [{ name: 'brand', value: '#00FF00', harmonize: false }] })`.
+      3. Compare `standard['brand'].light` between the two.
+    - **Expected:** Default (harmonized) value differs from the `harmonize: false` value
+      (hue rotated toward the source). With `harmonize: false`, the value reflects the raw `#00FF00` family.
+    - _Requirements: 5.3_
+  - [x] 5.3 Custom roles respond to contrast
+    - **Preconditions:** Scratch script.
+    - **Steps:**
+      1. `generateScheme` with one custom color, then read `standard['brand']` vs `high['brand']`.
+    - **Expected:** The custom role's value differs across contrast scopes, like core roles.
+    - _Requirements: 5.4_
+  - [x] 5.4 Custom name collision with a core role is rejected
+    - **Preconditions:** Scratch script / app bootstrap.
+    - **Steps:**
+      1. Configure a custom color named `primary` (collides directly).
+      2. Configure a custom color named `surface` (derives `on-surface`, a core role).
+    - **Expected:** Both fail fast with a descriptive error naming the offending custom color
+      and the colliding `--md-sys-color-*` role. No silent overwrite of a core role.
+    - _Requirements: 5.5_
+
+- [!] 6. Global runtime application
+  - [x] 6.1 Applied scheme writes the token contract at document root
+    - **Preconditions:** Demo app running with default config.
+    - **Steps:**
+      1. In DevTools Elements, confirm a single `style[data-m3-dynamic]` at the end of `<head>`.
+      2. Confirm it declares `--md-sys-color-*` under `:root` / `[data-contrast]` scopes.
+    - **Expected:** The dynamic `<style>` is present at document-root scope with the contract names.
+    - _Requirements: 6.1_
+  - [x] 6.2 Components reflect the scheme with no component changes
+    - **Preconditions:** Demo app; buttons/fabs rendered.
+    - **Steps:**
+      1. Click a "Brand seed" button with a clearly different seed (e.g. `#B3261E`).
+      2. Observe the rendered buttons/fabs.
+    - **Expected:** Component colors change to the new scheme immediately; no component code changed.
+    - _Requirements: 6.2_
+  - [!] 6.3 Re-applying fully replaces prior dynamic values
+    - **Preconditions:** Demo app; DevTools.
+    - **Steps:**
+      1. Apply seed A, note `--md-sys-color-primary` and that exactly one `style[data-m3-dynamic]` exists.
+      2. Apply seed B.
+    - **Expected:** Still exactly one `style[data-m3-dynamic]` element; its text is fully replaced
+      (primary now reflects seed B; no stale seed-A values linger).
+    - _Requirements: 6.3_
+    - **FAILED:** After SSR + client hydration there are **two** identical `style[data-m3-dynamic]` elements (SSR-serialized + client-injected), not one — the client `M3StyleApplier` does not adopt the server-serialized `<style>`, so it appends a duplicate. Re-applying at runtime correctly reuses the client element (count stays 2, never grows) and the last/winning element is fully replaced, so override and re-theme work and there is **no visual shift** (both elements are byte-identical). The defect is the duplicate element only — it violates the design's "single managed `<style>`". Suggested fix: have the applier query an existing `style[data-m3-dynamic]` on first `apply()` and adopt it.
+  - [x] 6.4 No dynamic config → static baseline remains
+    - **Preconditions:** A page/app that imports the baseline `theme.css` but does NOT call `provideM3Theme`.
+    - **Steps:**
+      1. Load it; inspect `<head>`.
+    - **Expected:** No `style[data-m3-dynamic]`; `--md-sys-color-*` come from the static baseline; UI renders themed.
+    - _Requirements: 6.4_
+  - [x] 6.5 Dynamic values override the static baseline
+    - **Preconditions:** Demo app (imports baseline AND uses `provideM3Theme`); pick a seed whose
+      `primary` differs from the baseline (e.g. `#00629D`).
+    - **Steps:**
+      1. Apply the differing seed.
+      2. In DevTools Computed, read the resolved `--md-sys-color-primary` on `:root`.
+    - **Expected:** The computed value equals the dynamic (seed) value, not the baseline — the
+      dynamic `<style>` wins by document order.
+    - _Requirements: 6.5_
+
+- [x] 7. Configuration at startup and runtime
+  - [x] 7.1 Configurable at bootstrap with all options
+    - **Preconditions:** Demo app `app.config.ts` with `provideM3Theme({...})`.
+    - **Steps:**
+      1. Confirm the config accepts `sourceColor`, `variant`, `contrast`, `mode`, `customColors`.
+      2. Start the app.
+    - **Expected:** App starts; the configured scheme is in effect.
+    - _Requirements: 7.1_
+  - [x] 7.2 Configured scheme is present on first render
+    - **Preconditions:** Demo app (CSR) and SSR build.
+    - **Steps:**
+      1. CSR: hard-reload; before any interaction, inspect `<head>` for the dynamic `<style>`.
+      2. Note that no flash of an unstyled/baseline-only theme is visible.
+    - **Expected:** The dynamic `<style>` exists from the first painted frame; first render is already themed.
+    - _Requirements: 7.2_
+  - [x] 7.3 Scheme can be changed after startup
+    - **Preconditions:** Demo app running.
+    - **Steps:**
+      1. Click each "Brand seed" button in turn.
+    - **Expected:** The running app re-themes each time (`M3ThemeService.setTheme` applied live).
+    - _Requirements: 7.3_
+
+- [x] 8. Programmatic read of computed values
+  - [x] 8.1 Read role→value mapping without applying
+    - **Preconditions:** TestBed harness or running app with `M3ThemeService` injected and a theme set.
+    - **Steps:**
+      1. Call `resolve({ mode: 'light', contrast: 'standard' })`.
+      2. Read `roles['primary']` and a custom role.
+    - **Expected:** A flat role→hex map covering every core role and every custom role for that mode/contrast.
+    - _Requirements: 8.1, 8.2_
+  - [x] 8.2 Read values equal the applied values
+    - **Preconditions:** App with a theme applied; DevTools.
+    - **Steps:**
+      1. Get `resolve({ mode: 'light' })['primary']`.
+      2. Compare to the light side of `--md-sys-color-primary` in the applied `<style>` and to the
+         DevTools computed value under a light `color-scheme`.
+    - **Expected:** All three agree.
+    - _Requirements: 8.3_
+
+- [x] 9. Fail-fast on invalid input
+  - [x] 9.1 Invalid source color throws a descriptive error
+    - **Preconditions:** App bootstrap or `setTheme`.
+    - **Steps:**
+      1. Configure `sourceColor: '#zzz'` (and separately `'not-a-color'`).
+    - **Expected:** Throws an error identifying `sourceColor` and the offending value; the app does
+      not start themed with a substituted color.
+    - _Requirements: 9.1, 9.3_
+  - [x] 9.2 Invalid custom color throws, naming which one
+    - **Preconditions:** `setTheme`.
+    - **Steps:**
+      1. Configure `customColors: [{ name: 'brand', value: 'nope' }]`.
+    - **Expected:** Throws an error naming the custom color `brand` and the invalid value.
+    - _Requirements: 9.2_
+  - [x] 9.3 No silent default substitution
+    - **Preconditions:** `setTheme` with an invalid `sourceColor`.
+    - **Steps:**
+      1. Apply the invalid config; inspect whether any `style[data-m3-dynamic]` was written.
+    - **Expected:** No scheme is applied (the call threw before applying); nothing falls back to a default seed.
+    - _Requirements: 9.3_
+  - [x] 9.4 Valid shorthand / uppercase hex is accepted
+    - **Preconditions:** Scratch script.
+    - **Steps:**
+      1. Generate with `sourceColor: '#abc'` and with `'#AABBCC'`.
+    - **Expected:** Both succeed; `#abc` normalizes to the same scheme as `#aabbcc`.
+    - _Requirements: 9.1 (boundary), 1.1_
+
+- [x] 10. Server-side rendering safety
+  - [x] 10.1 Scheme computes without a DOM
+    - **Preconditions:** SSR build (`nx build web`).
+    - **Steps:**
+      1. Build the `web` SSR target.
+      2. Observe the build prerenders the index route without error.
+    - **Expected:** Build succeeds; the server bootstrap runs `provideM3Theme` and generates the scheme
+      with no browser DOM.
+    - _Requirements: 10.1_
+  - [x] 10.2 Applying on the server does not throw; HTML carries the theme
+    - **Preconditions:** SSR build output present (`dist/apps/web/browser/index.html`).
+    - **Steps:**
+      1. Open the prerendered `index.html`.
+      2. Search for `data-m3-dynamic`, `--md-sys-color-primary`, and `color-scheme`.
+    - **Expected:** The `<style data-m3-dynamic>` is serialized into the server HTML with
+      `--md-sys-color-primary: light-dark(#65558f, #cfbdfe)` and `color-scheme: light dark`. No render error.
+    - _Requirements: 10.2_
+  - [x] 10.3 No theme shift on hydration
+    - **Preconditions:** SSR server running (`node dist/apps/web/server/server.mjs`).
+    - **Steps:**
+      1. Load `http://localhost:4000/` with cache disabled; watch the first paint through hydration.
+      2. Compare the server `--md-sys-color-*` values to the client-applied ones.
+    - **Expected:** Identical CSS both sides; no visible flash/recolor when the client hydrates.
+    - _Requirements: 10.3_
+
+- [x] 11. Token-contract fidelity
+  - [x] 11.1 Core role names exactly match the static contract
+    - **Preconditions:** Scratch script + `_color.generated.css`.
+    - **Steps:**
+      1. Collect `Object.keys(generateScheme({ sourceColor: '#6750A4' }).standard)`.
+      2. Collect the unique `--md-sys-color-<token>` names from the reference file.
+      3. Compare the two sets.
+    - **Expected:** The sets are equal — same spelling, same membership (49 core roles), none added/omitted.
+    - _Requirements: 11.1, 11.2_
+  - [x] 11.2 Divergence from the contract is detectable
+    - **Preconditions:** The parity unit test exists (`engine.spec.ts`).
+    - **Steps:**
+      1. Run `pnpm exec nx test ui`.
+      2. (Optional) Temporarily add a fake role to the reference file and re-run.
+    - **Expected:** The suite passes against the real contract; an artificial divergence makes the
+      parity test fail — so drift between dynamic and static role sets is caught.
+    - _Requirements: 11.3_
+
+- [x] 12. Accessibility (non-functional)
+  - [x] 12.1 Standard contrast meets WCAG AA for key pairings
+    - **Preconditions:** Demo app with default (`standard`) contrast; a contrast-ratio checker.
+    - **Steps:**
+      1. Measure contrast for `on-primary` vs `primary`, `on-surface` vs `surface`,
+         `on-primary-container` vs `primary-container`, in light and dark.
+    - **Expected:** Each text/background pairing meets WCAG 2.1 AA, as guaranteed by the M3 algorithm.
+    - _Requirements: NFR Accessibility_
+  - [x] 12.2 Medium/high progressively increase contrast
+    - **Preconditions:** Scratch script + contrast checker.
+    - **Steps:**
+      1. Measure `on-surface` vs `surface` contrast at `standard`, `medium`, `high`.
+    - **Expected:** Contrast ratio is non-decreasing standard → medium → high.
+    - _Requirements: NFR Accessibility, 3.3_
+
+## Summary
+- Total: 30 tests
+- Passed: 29
+- Failed: 1 (6.3 — SSR/hydration duplicate `<style>`)
+- Skipped: 0

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -13,6 +13,11 @@
         "outputPath": "dist/apps/web",
         "index": "apps/web/src/index.html",
         "browser": "apps/web/src/main.ts",
+        "server": "apps/web/src/main.server.ts",
+        "outputMode": "server",
+        "ssr": {
+          "entry": "apps/web/src/server.ts"
+        },
         "tsConfig": "apps/web/tsconfig.app.json",
         "assets": [
           {

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -77,7 +77,8 @@
     "test": {
       "executor": "@nx/angular:unit-test",
       "options": {
-        "tsConfig": "apps/web/tsconfig.spec.json"
+        "tsConfig": "apps/web/tsconfig.spec.json",
+        "runnerConfig": "apps/web/vitest.config.ts"
       }
     },
     "serve-static": {

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1,6 +1,15 @@
 <div class="w-full h-lvh flex justify-center items-center bg-lines">
   <div class="flex flex-col gap-2 w-max p-20">
     <div class="flex flex-row gap-2 items-center">
+      <span class="text-sm">Brand seed:</span>
+      @for (seed of brandSeeds; track seed) {
+        <button gui-button size="sm" variant="filled" (click)="applyBrand(seed)">
+          {{ seed }}
+        </button>
+      }
+    </div>
+
+    <div class="flex flex-row gap-2 items-center">
       <div>
         <div
           class="p-2 border rounded-full w-8 h-8 flex items-center justify-center"

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { GuiSize } from '@ngguide/ui';
+import { M3ThemeService } from '@ngguide/ui/theme';
 
 import { ButtonComponent, GuiButtonVariant } from '@ngguide/ui/button';
 import { FabComponent, GuiFabColor } from '@ngguide/ui/fab';
@@ -13,6 +14,22 @@ import { IconComponent } from '@ngguide/ui/icon';
   styleUrl: './app.component.css',
 })
 export class AppComponent {
+  private readonly theme = inject(M3ThemeService);
+
+  /** Demo brand seeds to exercise runtime re-theming (Req 7.3). */
+  readonly brandSeeds = ['#6750A4', '#00629D', '#B3261E'];
+
+  /** Re-theme the running app from a brand seed color. */
+  applyBrand(seed: string): void {
+    this.theme.setTheme({
+      sourceColor: seed,
+      variant: 'tonal-spot',
+      contrast: 'standard',
+      mode: 'auto',
+      customColors: [{ name: 'brand-success', value: '#2e7d32' }],
+    });
+  }
+
   sizes: GuiSize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
   variants: GuiButtonVariant[] = [
     'filled',

--- a/apps/web/src/app/app.config.server.ts
+++ b/apps/web/src/app/app.config.server.ts
@@ -1,0 +1,9 @@
+import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering } from '@angular/ssr';
+import { appConfig } from './app.config';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering()],
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -3,8 +3,21 @@ import {
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideM3Theme } from '@ngguide/ui/theme';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZonelessChangeDetection(), provideRouter(appRoutes)],
+  providers: [
+    provideZonelessChangeDetection(),
+    provideRouter(appRoutes),
+    // Dogfood M3 dynamic color: theme the whole UI Kit from a brand seed.
+    // Runs on both server and client, so SSR output carries the dynamic tokens.
+    provideM3Theme({
+      sourceColor: '#6750A4',
+      variant: 'tonal-spot',
+      contrast: 'standard',
+      mode: 'auto',
+      customColors: [{ name: 'brand-success', value: '#2e7d32' }],
+    }),
+  ],
 };

--- a/apps/web/src/main.server.ts
+++ b/apps/web/src/main.server.ts
@@ -1,0 +1,8 @@
+import { bootstrapApplication, BootstrapContext } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { config } from './app/app.config.server';
+
+const bootstrap = (context: BootstrapContext) =>
+  bootstrapApplication(AppComponent, config, context);
+
+export default bootstrap;

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,0 +1,43 @@
+import {
+  AngularNodeAppEngine,
+  createNodeRequestHandler,
+  isMainModule,
+  writeResponseToNodeResponse,
+} from '@angular/ssr/node';
+import express from 'express';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+const browserDistFolder = join(serverDistFolder, '../browser');
+
+const app = express();
+const angularApp = new AngularNodeAppEngine();
+
+/** Serve static browser assets. */
+app.use(
+  express.static(browserDistFolder, {
+    maxAge: '1y',
+    index: false,
+    redirect: false,
+  }),
+);
+
+/** All other requests are handled by Angular SSR. */
+app.use((req, res, next) => {
+  angularApp
+    .handle(req)
+    .then((response) =>
+      response ? writeResponseToNodeResponse(response, res) : next(),
+    )
+    .catch(next);
+});
+
+if (isMainModule(import.meta.url)) {
+  const port = process.env['PORT'] || 4000;
+  app.listen(port, () => {
+    console.log(`Node Express server listening on http://localhost:${port}`);
+  });
+}
+
+export const reqHandler = createNodeRequestHandler(app);

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -2,10 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": [],
+    "types": ["node"],
     "moduleResolution": "bundler"
   },
-  "files": ["src/main.ts"],
+  "files": ["src/main.ts", "src/main.server.ts", "src/server.ts"],
   "include": ["src/**/*.d.ts"],
   "exclude": [
     "jest.config.ts",

--- a/apps/web/tsconfig.server.json
+++ b/apps/web/tsconfig.server.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc/server",
+    "types": ["node"]
+  },
+  "files": ["src/main.server.ts", "src/server.ts"]
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Advanced Vitest config for `web`'s `@nx/angular:unit-test` target (wired via
+ * `runnerConfig`). The Angular Vitest builder still auto-initializes TestBed,
+ * `globals`, jsdom, and zoneless support on top of this.
+ *
+ * `web` specs transitively import `@material/material-color-utilities` (through
+ * `@ngguide/ui/theme` used by `AppComponent`). MCU is ESM-only with extensionless
+ * relative imports; inlining it routes MCU through Vite's esbuild pipeline so the
+ * specs resolve it. See `libs/ui/vitest.config.ts` for the same rationale.
+ */
+export default defineConfig({
+  optimizeDeps: {
+    include: ['@material/material-color-utilities'],
+  },
+  ssr: {
+    noExternal: ['@material/material-color-utilities'],
+  },
+  test: {
+    server: {
+      deps: {
+        inline: [/@material\/material-color-utilities/],
+      },
+    },
+    deps: {
+      optimizer: {
+        ssr: {
+          enabled: true,
+          include: ['@material/material-color-utilities'],
+        },
+      },
+    },
+  },
+});

--- a/libs/ui/eslint.config.mjs
+++ b/libs/ui/eslint.config.mjs
@@ -16,6 +16,7 @@ export default [
             '{projectRoot}/src/**/*.spec.ts',
             '{projectRoot}/tooling/**',
             '{projectRoot}/vite.config.mts',
+            '{projectRoot}/vitest.config.ts',
           ],
         },
       ],

--- a/libs/ui/ng-package.json
+++ b/libs/ui/ng-package.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/libs/ui",
+  "allowedNonPeerDependencies": ["@material/material-color-utilities"],
   "lib": {
     "entryFile": "src/index.ts"
   },

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -4,6 +4,9 @@
   "peerDependencies": {
     "@angular/core": "^21.0.0"
   },
+  "dependencies": {
+    "@material/material-color-utilities": "^0.4.0"
+  },
   "sideEffects": false,
   "exports": {
     "./styles/theme.css": {

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -38,10 +38,14 @@
       "executor": "@nx/angular:unit-test",
       "options": {
         "tsConfig": "libs/ui/tsconfig.spec.json",
+        "runnerConfig": "libs/ui/vitest.config.ts",
         "include": [
           "../button/src/button.spec.ts",
           "../fab/src/fab.spec.ts",
           "../icon/src/icon.spec.ts",
+          "../theme/src/engine.spec.ts",
+          "../theme/src/css-builder.spec.ts",
+          "../theme/src/validate.spec.ts",
           "../tooling/generate-color-tokens.spec.ts"
         ]
       }

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -46,6 +46,7 @@
           "../theme/src/engine.spec.ts",
           "../theme/src/css-builder.spec.ts",
           "../theme/src/validate.spec.ts",
+          "../theme/src/theme.service.spec.ts",
           "../tooling/generate-color-tokens.spec.ts"
         ]
       }

--- a/libs/ui/theme/README.md
+++ b/libs/ui/theme/README.md
@@ -1,0 +1,65 @@
+# @ngguide/ui/theme
+
+Secondary entry point of `@ngguide/ui`. Import it from `@ngguide/ui/theme`.
+
+Runtime **M3 dynamic color**: generate a full Material Design 3 color scheme from a
+source color (the HCT / tonal-palette algorithm via
+[`@material/material-color-utilities`](https://www.npmjs.com/package/@material/material-color-utilities))
+and apply it as the same `--md-sys-color-*` token contract the components already style
+against. The static `m3-tokens` baseline remains the default until you opt in.
+
+## Configure at bootstrap
+
+```ts
+import { provideM3Theme } from '@ngguide/ui/theme';
+
+bootstrapApplication(App, {
+  providers: [
+    provideM3Theme({
+      sourceColor: '#6750A4', // required (hex seed)
+      variant: 'tonal-spot',  // default 'tonal-spot' — any of the 9 M3 variants
+      contrast: 'standard',   // 'standard' | 'medium' | 'high'
+      mode: 'auto',           // 'auto' (follow OS) | 'light' | 'dark'
+      customColors: [
+        { name: 'brand-success', value: '#2e7d32' /* harmonize: true by default */ },
+      ],
+    }),
+  ],
+});
+```
+
+The configured scheme is applied on the server and the client, so it is in effect for the
+first render. An invalid `sourceColor` or custom-color value throws at bootstrap (fail-fast).
+
+## Change the theme at runtime
+
+```ts
+import { M3ThemeService } from '@ngguide/ui/theme';
+
+const theme = inject(M3ThemeService);
+theme.setTheme({ sourceColor: '#00629D', variant: 'vibrant' }); // re-themes the running app
+```
+
+## Read computed values
+
+```ts
+const roles = theme.resolve({ mode: 'light', contrast: 'standard' });
+roles['primary'];            // e.g. '#65558f'
+roles['brand-success'];      // custom-color role
+```
+
+`resolve()` returns a flat role→hex map (keys without the `--md-sys-color-` prefix),
+equal to the values applied to the token contract for that mode/contrast.
+
+## Custom colors
+
+Each custom color emits four roles — `--md-sys-color-<name>`, `--md-sys-color-on-<name>`,
+`--md-sys-color-<name>-container`, `--md-sys-color-on-<name>-container` — for both light and
+dark and at the selected contrast level. By default the color's hue is **harmonized** toward
+the source color; set `harmonize: false` to keep the raw hue. A custom `name` whose derived
+roles would collide with a core role (e.g. `surface` → `on-surface`) is rejected.
+
+## Variants
+
+`monochrome`, `neutral`, `tonal-spot` (default), `vibrant`, `expressive`, `fidelity`,
+`content`, `rainbow`, `fruit-salad` — exactly the published M3 scheme variants.

--- a/libs/ui/theme/ng-package.json
+++ b/libs/ui/theme/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/ui/theme/src/css-builder.spec.ts
+++ b/libs/ui/theme/src/css-builder.spec.ts
@@ -1,0 +1,23 @@
+import { generateScheme } from './engine';
+import { buildCss } from './css-builder';
+
+const scheme = generateScheme({ sourceColor: '#6750A4' });
+
+describe('buildCss', () => {
+  it('emits light-dark() pairs, color-scheme, and 3 [data-contrast] scopes (Req 4, 6)', () => {
+    const css = buildCss(scheme, 'auto');
+    expect(css).toContain('light-dark(');
+    expect(css).toContain('color-scheme:');
+    expect(css).toContain("[data-contrast='standard']");
+    expect(css).toContain("[data-contrast='medium']");
+    expect(css).toContain("[data-contrast='high']");
+    expect(css).toContain('--md-sys-color-primary: light-dark(#65558f, #cfbdfe);');
+  });
+
+  it("uses 'light dark' for 'auto' and forces a single side otherwise (Req 4.2, 4.3)", () => {
+    expect(buildCss(scheme, 'auto')).toContain('color-scheme: light dark;');
+    expect(buildCss(scheme, 'light')).toContain('color-scheme: light;');
+    expect(buildCss(scheme, 'light')).not.toContain('color-scheme: light dark;');
+    expect(buildCss(scheme, 'dark')).toContain('color-scheme: dark;');
+  });
+});

--- a/libs/ui/theme/src/css-builder.ts
+++ b/libs/ui/theme/src/css-builder.ts
@@ -1,0 +1,47 @@
+/**
+ * Serialize a `GeneratedScheme` to CSS text identical in shape to the static
+ * `_color.generated.css` (Decision 3A): `light-dark()` pairs under
+ * `[data-contrast]` scopes, with `color-scheme` on `:root`. Because the shape
+ * matches the baseline, OS light/dark auto-switch and the `[data-contrast]`
+ * scopes keep working unchanged (Req 4, Req 6).
+ */
+import type { GeneratedScheme, ScopeRoles } from './engine';
+import type { M3Mode } from './types';
+
+/** `'auto'` → `"light dark"` (OS decides); `'light'`/`'dark'` force one side. */
+function colorScheme(mode: M3Mode): string {
+  if (mode === 'light') return 'light';
+  if (mode === 'dark') return 'dark';
+  return 'light dark';
+}
+
+function emitScope(
+  selector: string,
+  roles: ScopeRoles,
+  withColorScheme: boolean,
+  mode: M3Mode,
+): string {
+  const lines: string[] = [`${selector} {`];
+  if (withColorScheme) {
+    lines.push(`  color-scheme: ${colorScheme(mode)};`);
+  }
+  for (const [token, pair] of Object.entries(roles)) {
+    lines.push(`  --md-sys-color-${token}: light-dark(${pair.light}, ${pair.dark});`);
+  }
+  lines.push('}');
+  return lines.join('\n');
+}
+
+/**
+ * Build the full CSS for a generated scheme. `mode` controls only the `:root`
+ * `color-scheme`; `light-dark()` then resolves to the forced side when a mode
+ * is forced (Req 4.3), or follows the OS for `'auto'` (Req 4.2).
+ */
+export function buildCss(scheme: GeneratedScheme, mode: M3Mode): string {
+  const blocks = [
+    emitScope(":root,\n[data-contrast='standard']", scheme.standard, true, mode),
+    emitScope("[data-contrast='medium']", scheme.medium, false, mode),
+    emitScope("[data-contrast='high']", scheme.high, false, mode),
+  ];
+  return blocks.join('\n\n') + '\n';
+}

--- a/libs/ui/theme/src/engine.spec.ts
+++ b/libs/ui/theme/src/engine.spec.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { generateScheme } from './engine';
+
+/** Parse the unique `--md-sys-color-<token>` names from the committed contract. */
+function contractRoleNames(): Set<string> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const cssPath = join(here, '../../src/styles/tokens/_color.generated.css');
+  const css = readFileSync(cssPath, 'utf8');
+  const names = new Set<string>();
+  for (const m of css.matchAll(/--md-sys-color-([a-z0-9-]+):/g)) {
+    names.add(m[1]);
+  }
+  return names;
+}
+
+describe('generateScheme', () => {
+  it('produces exactly the core role names in the static contract (Req 11.3)', () => {
+    const generated = new Set(Object.keys(generateScheme({ sourceColor: '#6750A4' }).standard));
+    const contract = contractRoleNames();
+    expect(generated).toEqual(contract);
+  });
+
+  it('matches the static baseline for #6750A4 / tonal-spot / standard (Req 1.4)', () => {
+    const s = generateScheme({ sourceColor: '#6750A4' }).standard;
+    expect(s['primary'].light).toBe('#65558f');
+    expect(s['primary'].dark).toBe('#cfbdfe');
+  });
+
+  it('varies output by variant (Req 2.3)', () => {
+    const tonal = generateScheme({ sourceColor: '#6750A4', variant: 'tonal-spot' }).standard;
+    const vibrant = generateScheme({ sourceColor: '#6750A4', variant: 'vibrant' }).standard;
+    expect(vibrant['primary'].light).not.toBe(tonal['primary'].light);
+  });
+
+  it('varies output by contrast level (Req 3.3)', () => {
+    const s = generateScheme({ sourceColor: '#6750A4' });
+    expect(JSON.stringify(s.standard)).not.toBe(JSON.stringify(s.high));
+  });
+
+  it('emits 4 contrast-aware roles per custom color, harmonized by default (Req 5)', () => {
+    const harmonized = generateScheme({
+      sourceColor: '#6750A4',
+      customColors: [{ name: 'brand', value: '#00FF00' }],
+    }).standard;
+
+    expect(harmonized['brand']).toBeTruthy();
+    expect(harmonized['on-brand']).toBeTruthy();
+    expect(harmonized['brand-container']).toBeTruthy();
+    expect(harmonized['on-brand-container']).toBeTruthy();
+
+    const raw = generateScheme({
+      sourceColor: '#6750A4',
+      customColors: [{ name: 'brand', value: '#00FF00', harmonize: false }],
+    }).standard;
+
+    // Harmonization rotates the hue toward the source → a different value.
+    expect(harmonized['brand'].light).not.toBe(raw['brand'].light);
+  });
+});

--- a/libs/ui/theme/src/engine.ts
+++ b/libs/ui/theme/src/engine.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure, DOM-free M3 scheme generation (Decision 1A).
+ *
+ * Reproduces the build-time generator's role enumeration
+ * (`tooling/generate-color-tokens.mts`) so the runtime output matches the
+ * static `_color.generated.css` token contract by construction (Req 11). For a
+ * `tonal-spot` scheme this produces values identical to `SchemeTonalSpot`,
+ * because `new DynamicScheme({ variant: TONAL_SPOT, … })` resolves the same
+ * palettes (same default platform `'phone'` + specVersion `'2021'`).
+ */
+import {
+  argbFromHex,
+  hexFromArgb,
+  Hct,
+  DynamicScheme,
+  Variant,
+  MaterialDynamicColors,
+  type DynamicColor,
+} from '@material/material-color-utilities';
+import type { M3ThemeConfig, M3Contrast, M3SchemeVariant } from './types';
+
+const VARIANT_MAP: Record<M3SchemeVariant, Variant> = {
+  monochrome: Variant.MONOCHROME,
+  neutral: Variant.NEUTRAL,
+  'tonal-spot': Variant.TONAL_SPOT,
+  vibrant: Variant.VIBRANT,
+  expressive: Variant.EXPRESSIVE,
+  fidelity: Variant.FIDELITY,
+  content: Variant.CONTENT,
+  rainbow: Variant.RAINBOW,
+  'fruit-salad': Variant.FRUIT_SALAD,
+};
+
+const CONTRAST_MAP: Record<M3Contrast, number> = {
+  standard: 0,
+  medium: 0.5,
+  high: 1,
+};
+
+const CONTRAST_LEVELS: M3Contrast[] = ['standard', 'medium', 'high'];
+
+/**
+ * `*PaletteKeyColor` roles are internal to the dynamic-color algorithm and are
+ * NOT part of the published `--md-sys-color-*` contract — excluding them keeps
+ * the runtime role set equal to the static contract (Req 11.2).
+ */
+const EXCLUDED_ROLE_SUFFIX = 'PaletteKeyColor';
+
+/** kebab-case fragment, e.g. `"on-primary"` — identical to the build-time generator. */
+export function camelToKebab(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/** A single M3 role: its token-name fragment and the MCU `DynamicColor` resolver. */
+export interface CoreRole {
+  /** kebab-case token fragment, e.g. `"on-primary"`, `"surface-container-low"`. */
+  token: string;
+  dynamicColor: DynamicColor;
+}
+
+/**
+ * Enumerate every M3 role exposed by `MaterialDynamicColors`, excluding
+ * `*PaletteKeyColor`. Same enumeration as `tooling/generate-color-tokens.mts`,
+ * so the role-name set matches the committed token contract (Req 11).
+ */
+export function coreRoles(): CoreRole[] {
+  const mdc = MaterialDynamicColors as unknown as Record<string, unknown>;
+  return Object.keys(mdc)
+    .filter((key) => !key.endsWith(EXCLUDED_ROLE_SUFFIX))
+    .map((key) => ({ key, value: mdc[key] }))
+    .filter(
+      (entry): entry is { key: string; value: DynamicColor } =>
+        entry.value != null &&
+        typeof (entry.value as DynamicColor).getArgb === 'function',
+    )
+    .map(({ key, value }) => ({ token: camelToKebab(key), dynamicColor: value }))
+    .sort((a, b) => a.token.localeCompare(b.token));
+}
+
+/** Per-role light/dark hex pair. */
+export interface RolePair {
+  light: string;
+  dark: string;
+}
+
+/** role(token) -> {light,dark} for one contrast level. */
+export type ScopeRoles = Record<string, RolePair>;
+
+/** Full computed scheme: per contrast level, all core + custom roles. */
+export interface GeneratedScheme {
+  standard: ScopeRoles;
+  medium: ScopeRoles;
+  high: ScopeRoles;
+}
+
+/** Build one MCU `DynamicScheme` (default platform `'phone'`, spec `'2021'`). */
+function buildScheme(
+  sourceArgb: number,
+  variant: M3SchemeVariant,
+  contrast: M3Contrast,
+  isDark: boolean,
+): DynamicScheme {
+  return new DynamicScheme({
+    sourceColorHct: Hct.fromInt(sourceArgb),
+    variant: VARIANT_MAP[variant],
+    contrastLevel: CONTRAST_MAP[contrast],
+    isDark,
+  });
+}
+
+/** All core roles for one contrast level, as light/dark pairs. */
+function coreScopeRoles(
+  sourceArgb: number,
+  variant: M3SchemeVariant,
+  contrast: M3Contrast,
+): ScopeRoles {
+  const light = buildScheme(sourceArgb, variant, contrast, false);
+  const dark = buildScheme(sourceArgb, variant, contrast, true);
+  const out: ScopeRoles = {};
+  for (const { token, dynamicColor } of coreRoles()) {
+    out[token] = {
+      light: hexFromArgb(dynamicColor.getArgb(light)),
+      dark: hexFromArgb(dynamicColor.getArgb(dark)),
+    };
+  }
+  return out;
+}
+
+/**
+ * Pure generation: seed (+ custom colors) → all roles for all 3 contrasts,
+ * light + dark. Assumes `config.sourceColor` / custom values are already valid
+ * hex (validation lives in `validate.ts` and runs before this in the service).
+ */
+export function generateScheme(config: M3ThemeConfig): GeneratedScheme {
+  const variant = config.variant ?? 'tonal-spot';
+  const sourceArgb = argbFromHex(config.sourceColor);
+
+  const scheme = {} as GeneratedScheme;
+  for (const contrast of CONTRAST_LEVELS) {
+    scheme[contrast] = coreScopeRoles(sourceArgb, variant, contrast);
+  }
+  return scheme;
+}

--- a/libs/ui/theme/src/engine.ts
+++ b/libs/ui/theme/src/engine.ts
@@ -15,9 +15,15 @@ import {
   DynamicScheme,
   Variant,
   MaterialDynamicColors,
+  Blend,
   type DynamicColor,
 } from '@material/material-color-utilities';
-import type { M3ThemeConfig, M3Contrast, M3SchemeVariant } from './types';
+import type {
+  M3ThemeConfig,
+  M3Contrast,
+  M3SchemeVariant,
+  M3CustomColor,
+} from './types';
 
 const VARIANT_MAP: Record<M3SchemeVariant, Variant> = {
   monochrome: Variant.MONOCHROME,
@@ -127,6 +133,58 @@ function coreScopeRoles(
 }
 
 /**
+ * The `primary` family of `MaterialDynamicColors`, used as the contrast-aware
+ * source of a custom color's four roles (Decision 5B). Resolved via the
+ * deprecated-but-present static `DynamicColor` properties — the same access the
+ * build-time generator relies on.
+ */
+const MDC_STATIC = MaterialDynamicColors as unknown as Record<string, DynamicColor>;
+const PRIMARY_FAMILY = {
+  /** custom `<name>`           ← primary */
+  color: 'primary',
+  /** custom `on-<name>`        ← onPrimary */
+  onColor: 'onPrimary',
+  /** custom `<name>-container` ← primaryContainer */
+  colorContainer: 'primaryContainer',
+  /** custom `on-<name>-container` ← onPrimaryContainer */
+  onColorContainer: 'onPrimaryContainer',
+} as const;
+
+/**
+ * The four custom-color roles for one contrast level (Decision 5B, the
+ * documented M3-gap resolution): the custom color seeds its own
+ * `DynamicScheme` (optionally harmonized toward the source), and its primary
+ * family becomes `<name>` / `on-<name>` / `<name>-container` /
+ * `on-<name>-container`. Contrast is applied exactly as for core roles (Req 5.4).
+ */
+function customColorRoles(
+  custom: M3CustomColor,
+  sourceArgb: number,
+  variant: M3SchemeVariant,
+  contrast: M3Contrast,
+): ScopeRoles {
+  const seed = argbFromHex(custom.value);
+  const harmonize = custom.harmonize ?? true;
+  const seedArgb = harmonize ? Blend.harmonize(seed, sourceArgb) : seed;
+
+  const light = buildScheme(seedArgb, variant, contrast, false);
+  const dark = buildScheme(seedArgb, variant, contrast, true);
+
+  const pair = (mdcKey: string): RolePair => ({
+    light: hexFromArgb(MDC_STATIC[mdcKey].getArgb(light)),
+    dark: hexFromArgb(MDC_STATIC[mdcKey].getArgb(dark)),
+  });
+
+  const name = custom.name;
+  return {
+    [name]: pair(PRIMARY_FAMILY.color),
+    [`on-${name}`]: pair(PRIMARY_FAMILY.onColor),
+    [`${name}-container`]: pair(PRIMARY_FAMILY.colorContainer),
+    [`on-${name}-container`]: pair(PRIMARY_FAMILY.onColorContainer),
+  };
+}
+
+/**
  * Pure generation: seed (+ custom colors) → all roles for all 3 contrasts,
  * light + dark. Assumes `config.sourceColor` / custom values are already valid
  * hex (validation lives in `validate.ts` and runs before this in the service).
@@ -134,10 +192,15 @@ function coreScopeRoles(
 export function generateScheme(config: M3ThemeConfig): GeneratedScheme {
   const variant = config.variant ?? 'tonal-spot';
   const sourceArgb = argbFromHex(config.sourceColor);
+  const customColors = config.customColors ?? [];
 
   const scheme = {} as GeneratedScheme;
   for (const contrast of CONTRAST_LEVELS) {
-    scheme[contrast] = coreScopeRoles(sourceArgb, variant, contrast);
+    const roles = coreScopeRoles(sourceArgb, variant, contrast);
+    for (const custom of customColors) {
+      Object.assign(roles, customColorRoles(custom, sourceArgb, variant, contrast));
+    }
+    scheme[contrast] = roles;
   }
   return scheme;
 }

--- a/libs/ui/theme/src/index.ts
+++ b/libs/ui/theme/src/index.ts
@@ -1,0 +1,2 @@
+// Public barrel for @ngguide/ui/theme. Finalized in task 12.
+export {};

--- a/libs/ui/theme/src/index.ts
+++ b/libs/ui/theme/src/index.ts
@@ -1,2 +1,4 @@
-// Public barrel for @ngguide/ui/theme. Finalized in task 12.
-export {};
+export * from './types';
+export { provideM3Theme } from './provide-theme';
+export { M3ThemeService } from './theme.service';
+export { generateScheme, type GeneratedScheme } from './engine';

--- a/libs/ui/theme/src/provide-theme.ts
+++ b/libs/ui/theme/src/provide-theme.ts
@@ -1,0 +1,27 @@
+import {
+  makeEnvironmentProviders,
+  provideEnvironmentInitializer,
+  inject,
+  type EnvironmentProviders,
+} from '@angular/core';
+import type { M3ThemeConfig } from './types';
+import { M3ThemeService } from './theme.service';
+import { validateConfig } from './validate';
+
+/**
+ * Configure M3 dynamic color at application bootstrap. The configured scheme is
+ * applied on both the server and the client, so it is in effect for the first
+ * render (Req 7.2, Req 10).
+ *
+ * Generation + application are synchronous, so a (sync)
+ * `provideEnvironmentInitializer` is used rather than the async
+ * `provideAppInitializer`. Invalid config fails fast at bootstrap (Req 9).
+ */
+export function provideM3Theme(config: M3ThemeConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideEnvironmentInitializer(() => {
+      validateConfig(config);
+      inject(M3ThemeService).init(config);
+    }),
+  ]);
+}

--- a/libs/ui/theme/src/style-applier.ts
+++ b/libs/ui/theme/src/style-applier.ts
@@ -1,0 +1,33 @@
+import { Injectable, RendererFactory2, inject, DOCUMENT } from '@angular/core';
+
+/**
+ * Applies dynamic-color CSS by maintaining a single `<style>` element at the
+ * end of `<head>` (Decision 3A). SSR-safe: `RendererFactory2.createRenderer`
+ * works on both platforms, and on the server `@angular/platform-server`
+ * serializes the appended element into the HTML — giving identical first paint
+ * and no hydration shift (Req 10.2, 10.3). Appending after the statically
+ * imported baseline lets equal-specificity `:root` rules win (Req 6.5); the
+ * element is reused, so re-applying replaces its text (Req 6.3).
+ */
+@Injectable({ providedIn: 'root' })
+export class M3StyleApplier {
+  private readonly doc = inject(DOCUMENT);
+  private readonly renderer = inject(RendererFactory2).createRenderer(null, null);
+  private styleEl: HTMLStyleElement | null = null;
+
+  /** Create-or-replace the managed `<style>` with `css`. Never throws (Req 10.2). */
+  apply(css: string): void {
+    const head = this.doc.head;
+    if (!head) {
+      // No document head (extremely degraded host) — degrade gracefully.
+      return;
+    }
+    if (!this.styleEl) {
+      const el = this.renderer.createElement('style') as HTMLStyleElement;
+      this.renderer.setAttribute(el, 'data-m3-dynamic', '');
+      this.renderer.appendChild(head, el);
+      this.styleEl = el;
+    }
+    this.renderer.setProperty(this.styleEl, 'textContent', css);
+  }
+}

--- a/libs/ui/theme/src/style-applier.ts
+++ b/libs/ui/theme/src/style-applier.ts
@@ -23,10 +23,22 @@ export class M3StyleApplier {
       return;
     }
     if (!this.styleEl) {
-      const el = this.renderer.createElement('style') as HTMLStyleElement;
-      this.renderer.setAttribute(el, 'data-m3-dynamic', '');
-      this.renderer.appendChild(head, el);
-      this.styleEl = el;
+      // On the client, a server-serialized `<style data-m3-dynamic>` may already
+      // be in <head> (from SSR). Adopt it instead of appending a duplicate, so a
+      // single managed element survives hydration (Req 6.3, 10.3). Any extras are
+      // dropped to converge on exactly one.
+      const existing = head.querySelectorAll<HTMLStyleElement>('style[data-m3-dynamic]');
+      if (existing.length > 0) {
+        this.styleEl = existing[existing.length - 1];
+        for (let i = 0; i < existing.length - 1; i++) {
+          this.renderer.removeChild(head, existing[i]);
+        }
+      } else {
+        const el = this.renderer.createElement('style') as HTMLStyleElement;
+        this.renderer.setAttribute(el, 'data-m3-dynamic', '');
+        this.renderer.appendChild(head, el);
+        this.styleEl = el;
+      }
     }
     this.renderer.setProperty(this.styleEl, 'textContent', css);
   }

--- a/libs/ui/theme/src/theme.service.spec.ts
+++ b/libs/ui/theme/src/theme.service.spec.ts
@@ -59,6 +59,23 @@ describe('M3ThemeService (TestBed + DOCUMENT)', () => {
     doc = TestBed.inject(DOCUMENT);
     expect(() => svc.setTheme({ sourceColor: '#zzz' })).toThrow(/sourceColor/);
   });
+
+  it('adopts a pre-existing SSR <style> instead of duplicating it (Req 6.3 / hydration)', () => {
+    doc = TestBed.inject(DOCUMENT);
+    // Simulate the server-serialized dynamic style already present after SSR.
+    const ssr = doc.createElement('style');
+    ssr.setAttribute('data-m3-dynamic', '');
+    ssr.textContent = '/* serialized by SSR */';
+    doc.head.appendChild(ssr);
+
+    const svc = TestBed.inject(M3ThemeService);
+    svc.setTheme({ sourceColor: '#6750A4' });
+
+    const styles = dynamicStyles(doc);
+    expect(styles.length).toBe(1); // adopted, not duplicated
+    expect(styles[0]).toBe(ssr); // same node reused
+    expect(styles[0].textContent).toContain('--md-sys-color-primary');
+  });
 });
 
 describe('provideM3Theme', () => {

--- a/libs/ui/theme/src/theme.service.spec.ts
+++ b/libs/ui/theme/src/theme.service.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/core';
+import { M3ThemeService } from './theme.service';
+import { provideM3Theme } from './provide-theme';
+
+function dynamicStyles(doc: Document): HTMLStyleElement[] {
+  return Array.from(doc.head.querySelectorAll('style[data-m3-dynamic]'));
+}
+
+describe('M3ThemeService (TestBed + DOCUMENT)', () => {
+  let doc: Document;
+
+  afterEach(() => {
+    // Clean DOM between tests — the jsdom document persists across specs.
+    for (const el of dynamicStyles(doc ?? document)) {
+      el.remove();
+    }
+  });
+
+  it('injects a <style> at the end of <head> on setTheme (Req 6)', () => {
+    const svc = TestBed.inject(M3ThemeService);
+    doc = TestBed.inject(DOCUMENT);
+
+    svc.setTheme({ sourceColor: '#6750A4' });
+
+    const styles = dynamicStyles(doc);
+    expect(styles.length).toBe(1);
+    expect(styles[0]).toBe(doc.head.lastElementChild);
+    expect(styles[0].textContent).toContain('--md-sys-color-primary: light-dark(#65558f, #cfbdfe);');
+  });
+
+  it('reuses the single <style> and replaces its text on re-apply (Req 6.3)', () => {
+    const svc = TestBed.inject(M3ThemeService);
+    doc = TestBed.inject(DOCUMENT);
+
+    svc.setTheme({ sourceColor: '#6750A4' });
+    const first = dynamicStyles(doc)[0].textContent;
+    svc.setTheme({ sourceColor: '#00629D', variant: 'vibrant' });
+
+    const styles = dynamicStyles(doc);
+    expect(styles.length).toBe(1);
+    expect(styles[0].textContent).not.toBe(first);
+  });
+
+  it('resolve() returns role→hex equal to the applied values (Req 8)', () => {
+    const svc = TestBed.inject(M3ThemeService);
+    doc = TestBed.inject(DOCUMENT);
+
+    svc.setTheme({ sourceColor: '#6750A4' });
+    const roles = svc.resolve({ mode: 'light', contrast: 'standard' });
+
+    expect(roles['primary']).toBe('#65558f');
+    // The applied CSS carries this exact light value.
+    expect(dynamicStyles(doc)[0].textContent).toContain(`light-dark(${roles['primary']},`);
+  });
+
+  it('setTheme fails fast on invalid input (Req 9)', () => {
+    const svc = TestBed.inject(M3ThemeService);
+    doc = TestBed.inject(DOCUMENT);
+    expect(() => svc.setTheme({ sourceColor: '#zzz' })).toThrow(/sourceColor/);
+  });
+});
+
+describe('provideM3Theme', () => {
+  it('applies the configured scheme at bootstrap (Req 7.2)', () => {
+    TestBed.configureTestingModule({
+      providers: [provideM3Theme({ sourceColor: '#6750A4', variant: 'tonal-spot' })],
+    });
+
+    const svc = TestBed.inject(M3ThemeService);
+    const doc = TestBed.inject(DOCUMENT);
+
+    expect(svc.config()?.sourceColor).toBe('#6750A4');
+    const styles = Array.from(doc.head.querySelectorAll('style[data-m3-dynamic]'));
+    expect(styles.length).toBeGreaterThanOrEqual(1);
+    expect(styles.at(-1)?.textContent).toContain('--md-sys-color-primary: light-dark(#65558f, #cfbdfe);');
+
+    for (const el of styles) el.remove();
+  });
+});

--- a/libs/ui/theme/src/theme.service.ts
+++ b/libs/ui/theme/src/theme.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, signal, inject } from '@angular/core';
+import type { M3ThemeConfig, M3Contrast, M3ResolvedRoles } from './types';
+import { generateScheme, type GeneratedScheme } from './engine';
+import { buildCss } from './css-builder';
+import { M3StyleApplier } from './style-applier';
+import { validateConfig } from './validate';
+
+/**
+ * Owns the active M3 dynamic-color scheme: validates a config, generates the
+ * scheme, serializes it to CSS, and applies it via {@link M3StyleApplier}. The
+ * same instance is reused at bootstrap (`init`) and at runtime (`setTheme`).
+ */
+@Injectable({ providedIn: 'root' })
+export class M3ThemeService {
+  private readonly applier = inject(M3StyleApplier);
+  private readonly _config = signal<M3ThemeConfig | null>(null);
+  private _scheme: GeneratedScheme | null = null;
+
+  /** Current config (read-only signal). */
+  readonly config = this._config.asReadonly();
+
+  /**
+   * Validate, generate, and apply a config (Req 6, 7.3). Fail-fast on invalid
+   * input (Req 9) — nothing is applied if validation throws.
+   */
+  setTheme(config: M3ThemeConfig): void {
+    validateConfig(config);
+    const scheme = generateScheme(config);
+    this._scheme = scheme;
+    this._config.set(config);
+    this.applier.apply(buildCss(scheme, config.mode ?? 'auto'));
+  }
+
+  /** Called by the bootstrap initializer with the provided config (Req 7.2). */
+  init(config: M3ThemeConfig): void {
+    this.setTheme(config);
+  }
+
+  /**
+   * Read computed values without needing them applied (Req 8). Returns a flat
+   * role→hex map for a specific mode + contrast (defaults: `light`, the active
+   * config's contrast). The values equal what the applied token contract
+   * resolves to for that mode/contrast (Req 8.3).
+   */
+  resolve(opts?: { mode?: 'light' | 'dark'; contrast?: M3Contrast }): M3ResolvedRoles {
+    const config = this._config();
+    if (!this._scheme || !config) {
+      throw new Error('M3 dynamic color: resolve() called before a theme was applied');
+    }
+    const contrast = opts?.contrast ?? config.contrast ?? 'standard';
+    const mode = opts?.mode ?? 'light';
+    const scope = this._scheme[contrast];
+
+    const roles: M3ResolvedRoles = {};
+    for (const [token, pair] of Object.entries(scope)) {
+      roles[token] = pair[mode];
+    }
+    return roles;
+  }
+}

--- a/libs/ui/theme/src/types.ts
+++ b/libs/ui/theme/src/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Public types for @ngguide/ui/theme (M3 dynamic color).
+ *
+ * These describe the configuration accepted by `provideM3Theme` /
+ * `M3ThemeService.setTheme` and the shapes returned by the read API. They carry
+ * no behaviour — generation lives in `engine.ts`.
+ */
+
+/** M3 scheme variants (map 1:1 to MCU's `Variant` enum). */
+export type M3SchemeVariant =
+  | 'monochrome'
+  | 'neutral'
+  | 'tonal-spot'
+  | 'vibrant'
+  | 'expressive'
+  | 'fidelity'
+  | 'content'
+  | 'rainbow'
+  | 'fruit-salad';
+
+/** M3 contrast levels (map to MCU `contrastLevel` 0 / 0.5 / 1). */
+export type M3Contrast = 'standard' | 'medium' | 'high';
+
+/** Active-mode policy. `'auto'` follows the OS via `color-scheme` + `light-dark()`. */
+export type M3Mode = 'light' | 'dark' | 'auto';
+
+/** A named brand color folded into the scheme as its own role set. */
+export interface M3CustomColor {
+  /** Identifier used to build role names: `--md-sys-color-<name>`, `-on-<name>`, … */
+  name: string;
+  /** Source hex for this color. */
+  value: string;
+  /** Blend the hue toward the source color (M3 harmonize). Default: `true`. */
+  harmonize?: boolean;
+}
+
+/** Configuration accepted by `provideM3Theme` and `M3ThemeService.setTheme`. */
+export interface M3ThemeConfig {
+  /** Source/seed hex color. Required. */
+  sourceColor: string;
+  /** Default: `'tonal-spot'`. */
+  variant?: M3SchemeVariant;
+  /** Default: `'standard'`. */
+  contrast?: M3Contrast;
+  /** Default: `'auto'`. */
+  mode?: M3Mode;
+  /** Optional extended colors. */
+  customColors?: M3CustomColor[];
+}
+
+/** The four roles of one color family, as hex. */
+export interface M3ColorGroup {
+  color: string;
+  onColor: string;
+  colorContainer: string;
+  onColorContainer: string;
+}
+
+/**
+ * Flat role→hex map for one `(mode, contrast)`, including custom roles.
+ * Returned by `M3ThemeService.resolve()`. Keys are role names WITHOUT the
+ * `--md-sys-color-` prefix (e.g. `'primary'`, `'on-primary'`).
+ */
+export type M3ResolvedRoles = Record<string, string>;

--- a/libs/ui/theme/src/validate.spec.ts
+++ b/libs/ui/theme/src/validate.spec.ts
@@ -1,0 +1,52 @@
+import { parseHex, validateConfig } from './validate';
+
+describe('parseHex', () => {
+  it('normalizes shorthand and casing to the same ARGB', () => {
+    expect(parseHex('#ABC', 'x')).toBe(parseHex('#aabbcc', 'x'));
+  });
+
+  it('drops alpha from #RRGGBBAA', () => {
+    expect(parseHex('#6750A4FF', 'x')).toBe(parseHex('#6750A4', 'x'));
+  });
+
+  it("throws naming the label for unparseable input (Req 9)", () => {
+    expect(() => parseHex('nope', 'sourceColor')).toThrow(/invalid sourceColor 'nope'/);
+  });
+});
+
+describe('validateConfig', () => {
+  it('accepts a valid config (incl. shorthand) without throwing', () => {
+    expect(() => validateConfig({ sourceColor: '#6750A4' })).not.toThrow();
+    expect(() => validateConfig({ sourceColor: '#abc' })).not.toThrow();
+  });
+
+  it('throws naming the offending sourceColor (Req 9.1)', () => {
+    expect(() => validateConfig({ sourceColor: '#zzz' })).toThrow(/sourceColor/);
+  });
+
+  it('throws naming the offending custom color (Req 9.2)', () => {
+    expect(() =>
+      validateConfig({
+        sourceColor: '#6750A4',
+        customColors: [{ name: 'brand', value: 'nope' }],
+      }),
+    ).toThrow(/brand/);
+  });
+
+  it('rejects a custom name whose derived role collides with a core role (Req 5.5)', () => {
+    expect(() =>
+      validateConfig({
+        sourceColor: '#6750A4',
+        customColors: [{ name: 'primary', value: '#00FF00' }],
+      }),
+    ).toThrow(/collides/);
+
+    // 'surface' would derive 'on-surface', which is a core role.
+    expect(() =>
+      validateConfig({
+        sourceColor: '#6750A4',
+        customColors: [{ name: 'surface', value: '#00FF00' }],
+      }),
+    ).toThrow(/collides/);
+  });
+});

--- a/libs/ui/theme/src/validate.ts
+++ b/libs/ui/theme/src/validate.ts
@@ -1,0 +1,89 @@
+/**
+ * Fail-fast validation for M3 dynamic-color config (Req 9). No silent
+ * fallbacks: an unparseable color or a colliding custom name throws a
+ * descriptive error naming the offender.
+ */
+import { argbFromHex } from '@material/material-color-utilities';
+import type { M3ThemeConfig } from './types';
+import { coreRoles } from './engine';
+
+const HEX3 = /^#?([0-9a-fA-F]{3})$/;
+const HEX6 = /^#?([0-9a-fA-F]{6})$/;
+const HEX8 = /^#?([0-9a-fA-F]{8})$/;
+
+/**
+ * Parse a hex color to ARGB. Accepts `#RGB`, `#RRGGBB`, and `#RRGGBBAA`
+ * (alpha dropped); the leading `#` is optional and casing is ignored. Throws a
+ * descriptive `Error` (using `label`) for anything else — never a fallback.
+ */
+export function parseHex(input: string, label: string): number {
+  const fail = (): never => {
+    throw new Error(`M3 dynamic color: invalid ${label} '${input}'`);
+  };
+
+  if (typeof input !== 'string') {
+    fail();
+  }
+  const value = input.trim();
+
+  let rrggbb: string | null = null;
+  let m: RegExpMatchArray | null;
+  if ((m = value.match(HEX6))) {
+    rrggbb = m[1];
+  } else if ((m = value.match(HEX3))) {
+    const [r, g, b] = m[1].split('');
+    rrggbb = `${r}${r}${g}${g}${b}${b}`;
+  } else if ((m = value.match(HEX8))) {
+    // #RRGGBBAA — keep RGB, drop alpha (scheme generation is alpha-agnostic).
+    rrggbb = m[1].slice(0, 6);
+  } else {
+    fail();
+  }
+
+  return argbFromHex(`#${rrggbb}`);
+}
+
+/**
+ * Validate `sourceColor` and every `customColors[].value`, and reject custom
+ * names whose derived roles collide with a core `--md-sys-color-` role
+ * (protects Req 5.5). Throws on the first problem, naming it.
+ */
+export function validateConfig(config: M3ThemeConfig): void {
+  if (config == null || typeof config.sourceColor !== 'string') {
+    throw new Error("M3 dynamic color: config.sourceColor is required");
+  }
+
+  parseHex(config.sourceColor, 'sourceColor');
+
+  const customColors = config.customColors ?? [];
+  if (customColors.length === 0) {
+    return;
+  }
+
+  const coreTokens = new Set(coreRoles().map((role) => role.token));
+
+  for (const custom of customColors) {
+    if (!custom.name || typeof custom.name !== 'string') {
+      throw new Error('M3 dynamic color: every custom color must have a non-empty name');
+    }
+
+    parseHex(custom.value, `custom color "${custom.name}" value`);
+
+    // Each custom color contributes four derived role names; none may overwrite
+    // a core contract role (e.g. a custom named "surface" → "on-surface").
+    const derived = [
+      custom.name,
+      `on-${custom.name}`,
+      `${custom.name}-container`,
+      `on-${custom.name}-container`,
+    ];
+    for (const token of derived) {
+      if (coreTokens.has(token)) {
+        throw new Error(
+          `M3 dynamic color: custom color "${custom.name}" produces role ` +
+            `"--md-sys-color-${token}" that collides with a core role`,
+        );
+      }
+    }
+  }
+}

--- a/libs/ui/vitest.config.ts
+++ b/libs/ui/vitest.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Advanced Vitest config for the `ui` library's `@nx/angular:unit-test` target
+ * (wired via `runnerConfig` in project.json). The Angular Vitest builder still
+ * auto-initializes TestBed, `globals`, jsdom, and zoneless support on top of
+ * this — these options only ADD to that.
+ *
+ * `@material/material-color-utilities` is ESM-only and ships extensionless
+ * relative imports (e.g. `./dynamic_color`). The test build externalizes
+ * packages, so without this the runner would import MCU through raw Node ESM
+ * and fail to resolve those paths. Inlining it routes MCU through Vite's
+ * esbuild pipeline (which resolves extensionless imports) so the theme specs
+ * can import the real algorithm.
+ */
+export default defineConfig({
+  optimizeDeps: {
+    include: ['@material/material-color-utilities'],
+  },
+  ssr: {
+    noExternal: ['@material/material-color-utilities'],
+  },
+  test: {
+    server: {
+      deps: {
+        inline: [/@material\/material-color-utilities/],
+      },
+    },
+    deps: {
+      optimizer: {
+        ssr: {
+          enabled: true,
+          include: ['@material/material-color-utilities'],
+        },
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "@angular/core": "21.2.9",
     "@angular/forms": "21.2.9",
     "@angular/platform-browser": "21.2.9",
+    "@angular/platform-server": "21.2.9",
     "@angular/router": "21.2.9",
+    "@angular/ssr": "21.2.9",
     "rxjs": "~7.8.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,16 +23,22 @@ importers:
       '@angular/platform-browser':
         specifier: 21.2.9
         version: 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-server':
+        specifier: 21.2.9
+        version: 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@angular/router':
         specifier: 21.2.9
         version: 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/ssr':
+        specifier: 21.2.9
+        version: 21.2.9(0a13670e9e7769d115823586aa4749b4)
       rxjs:
         specifier: ~7.8.0
         version: 7.8.2
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 21.2.9
-        version: 21.2.9(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@18.16.9)(chokidar@5.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3))(sass-embedded@1.89.2)(tailwindcss@4.1.7)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
+        version: 21.2.9(2cc1e57e1dac389b76db1a846f30fb4b)
       '@angular-devkit/core':
         specifier: 21.2.9
         version: 21.2.9(chokidar@5.0.0)
@@ -56,7 +62,7 @@ importers:
         version: 0.4.0
       '@nx/angular':
         specifier: 22.7.5
-        version: 22.7.5(a0047917aab132449fcd24fc51f4aee7)
+        version: 22.7.5(5ce39ed97286748ae28c47639a6a478d)
       '@nx/eslint':
         specifier: 22.7.5
         version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
@@ -470,6 +476,16 @@ packages:
       '@angular/animations':
         optional: true
 
+  '@angular/platform-server@21.2.9':
+    resolution: {integrity: sha512-sVkx1762qO+XDE+JFnMZU/m95W2v+Qg5Kh1IIQ9wG9krjV2Tl6ufnGYdxKf4EKnPj7oOQdhKq4cb8VhOokESBw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@angular/common': 21.2.9
+      '@angular/compiler': 21.2.9
+      '@angular/core': 21.2.9
+      '@angular/platform-browser': 21.2.9
+      rxjs: ^6.5.3 || ^7.4.0
+
   '@angular/router@21.2.9':
     resolution: {integrity: sha512-ExqOEO6IUuNaI75ZcjAbOuzJKpvVze6hRdETyVf7Sny07+XSKv9t8DK9tBHmR7+67wz+zPIUgCXxsQXi8jJu0w==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -478,6 +494,17 @@ packages:
       '@angular/core': 21.2.9
       '@angular/platform-browser': 21.2.9
       rxjs: ^6.5.3 || ^7.4.0
+
+  '@angular/ssr@21.2.9':
+    resolution: {integrity: sha512-kNOCyk3l3fxC1x6KoIRpeVke4HHlnSjaPdK5b0DA2YBgVT02Kz+Bzn818b/a1HCCMFfPBUh3xb623mC5LSyvlw==}
+    peerDependencies:
+      '@angular/common': ^21.0.0
+      '@angular/core': ^21.0.0
+      '@angular/platform-server': ^21.0.0
+      '@angular/router': ^21.0.0
+    peerDependenciesMeta:
+      '@angular/platform-server':
+        optional: true
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -8615,6 +8642,10 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xhr2@0.2.1:
+    resolution: {integrity: sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==}
+    engines: {node: '>= 6'}
+
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
@@ -8802,13 +8833,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.2.9(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@18.16.9)(chokidar@5.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3))(sass-embedded@1.89.2)(tailwindcss@4.1.7)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)':
+  '@angular-devkit/build-angular@21.2.9(2cc1e57e1dac389b76db1a846f30fb4b)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.9(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.30.1)(postcss@8.5.12)))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.30.1)(postcss@8.5.12))
       '@angular-devkit/core': 21.2.9(chokidar@5.0.0)
-      '@angular/build': 21.2.9(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@18.16.9)(chokidar@5.0.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.12)(sass-embedded@1.89.2)(tailwindcss@4.1.7)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
+      '@angular/build': 21.2.9(2dc217e3b5e8f214e2c020698489037b)
       '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3)
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -8863,6 +8894,8 @@ snapshots:
     optionalDependencies:
       '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
       '@angular/platform-browser': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/ssr': 21.2.9(0a13670e9e7769d115823586aa4749b4)
       esbuild: 0.27.3
       ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3)
       tailwindcss: 4.1.7
@@ -9014,7 +9047,7 @@ snapshots:
       eslint: 9.30.1(jiti@2.4.2)
       typescript: 5.9.3
 
-  '@angular/build@21.2.9(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@18.16.9)(chokidar@5.0.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.12)(sass-embedded@1.89.2)(tailwindcss@4.1.7)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)':
+  '@angular/build@21.2.9(29a00afc02471cbc8a03eb038e8e0b51)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
@@ -9050,63 +9083,8 @@ snapshots:
     optionalDependencies:
       '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
       '@angular/platform-browser': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
-      less: 4.4.2
-      lmdb: 3.5.1
-      ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3)
-      postcss: 8.5.12
-      tailwindcss: 4.1.7
-      vitest: 4.1.7(@types/node@18.16.9)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@22.1.0)(vite@7.3.3(@types/node@18.16.9)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.46.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@21.2.9(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@18.16.9)(chokidar@5.0.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.6)(sass-embedded@1.89.2)(tailwindcss@4.1.7)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
-      '@angular/compiler': 21.2.9
-      '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3)
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21(@types/node@18.16.9)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@18.16.9)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0))
-      beasties: 0.4.1
-      browserslist: 4.28.2
-      esbuild: 0.27.3
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.4
-      piscina: 5.1.4
-      rolldown: 1.0.0-rc.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      sass: 1.97.3
-      semver: 7.7.4
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.15
-      tslib: 2.8.1
-      typescript: 5.9.3
-      undici: 7.24.4
-      vite: 7.3.2(@types/node@18.16.9)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0)
-      watchpack: 2.5.1
-    optionalDependencies:
-      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/ssr': 21.2.9(0a13670e9e7769d115823586aa4749b4)
       less: 4.4.2
       lmdb: 3.5.1
       ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3)
@@ -9128,6 +9106,65 @@ snapshots:
       - tsx
       - yaml
     optional: true
+
+  '@angular/build@21.2.9(2dc217e3b5e8f214e2c020698489037b)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
+      '@angular/compiler': 21.2.9
+      '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3)
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@inquirer/confirm': 5.1.21(@types/node@18.16.9)
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@18.16.9)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0))
+      beasties: 0.4.1
+      browserslist: 4.28.2
+      esbuild: 0.27.3
+      https-proxy-agent: 7.0.6
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      listr2: 9.0.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      parse5-html-rewriting-stream: 8.0.0
+      picomatch: 4.0.4
+      piscina: 5.1.4
+      rolldown: 1.0.0-rc.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      sass: 1.97.3
+      semver: 7.7.4
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.15
+      tslib: 2.8.1
+      typescript: 5.9.3
+      undici: 7.24.4
+      vite: 7.3.2(@types/node@18.16.9)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0)
+      watchpack: 2.5.1
+    optionalDependencies:
+      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
+      '@angular/platform-browser': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/ssr': 21.2.9(0a13670e9e7769d115823586aa4749b4)
+      less: 4.4.2
+      lmdb: 3.5.1
+      ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3)
+      postcss: 8.5.12
+      tailwindcss: 4.1.7
+      vitest: 4.1.7(@types/node@18.16.9)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@22.1.0)(vite@7.3.3(@types/node@18.16.9)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.46.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@types/node'
+      - chokidar
+      - jiti
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   '@angular/cli@21.2.13(@types/node@18.16.9)(chokidar@5.0.0)':
     dependencies:
@@ -9206,6 +9243,16 @@ snapshots:
       '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
       tslib: 2.8.1
 
+  '@angular/platform-server@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
+    dependencies:
+      '@angular/common': 21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
+      '@angular/compiler': 21.2.9
+      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
+      '@angular/platform-browser': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      xhr2: 0.2.1
+
   '@angular/router@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
     dependencies:
       '@angular/common': 21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
@@ -9213,6 +9260,15 @@ snapshots:
       '@angular/platform-browser': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
       rxjs: 7.8.2
       tslib: 2.8.1
+
+  '@angular/ssr@21.2.9(0a13670e9e7769d115823586aa4749b4)':
+    dependencies:
+      '@angular/common': 21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
+      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
+      '@angular/router': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -11648,7 +11704,7 @@ snapshots:
       node-gyp: 12.3.0
       proc-log: 6.1.0
 
-  '@nx/angular@22.7.5(a0047917aab132449fcd24fc51f4aee7)':
+  '@nx/angular@22.7.5(5ce39ed97286748ae28c47639a6a478d)':
     dependencies:
       '@angular-devkit/core': 21.2.9(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.9(chokidar@5.0.0)
@@ -11672,8 +11728,8 @@ snapshots:
       tslib: 2.8.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular-devkit/build-angular': 21.2.9(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@18.16.9)(chokidar@5.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3))(sass-embedded@1.89.2)(tailwindcss@4.1.7)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
-      '@angular/build': 21.2.9(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@18.16.9)(chokidar@5.0.0)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.6)(sass-embedded@1.89.2)(tailwindcss@4.1.7)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
+      '@angular-devkit/build-angular': 21.2.9(2cc1e57e1dac389b76db1a846f30fb4b)
+      '@angular/build': 21.2.9(29a00afc02471cbc8a03eb038e8e0b51)
       ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.1.7)(tslib@2.8.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -18783,6 +18839,8 @@ snapshots:
     dependencies:
       is-wsl: 3.1.0
       powershell-utils: 0.1.0
+
+  xhr2@0.2.1: {}
 
   xml-name-validator@4.0.0: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,7 +18,8 @@
       "@ngguide/ui": ["libs/ui/src/index.ts"],
       "@ngguide/ui/button": ["libs/ui/button/src/index.ts"],
       "@ngguide/ui/fab": ["libs/ui/fab/src/index.ts"],
-      "@ngguide/ui/icon": ["libs/ui/icon/src/index.ts"]
+      "@ngguide/ui/icon": ["libs/ui/icon/src/index.ts"],
+      "@ngguide/ui/theme": ["libs/ui/theme/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary

Adds runtime **M3 dynamic color** as a new secondary entry point **`@ngguide/ui/theme`**. Generates a full M3 scheme from a seed color (HCT/tonal-palette via `@material/material-color-utilities`) and applies it as the existing `--md-sys-color-*` token contract. Purely additive — the static `m3-tokens` baseline is untouched until a consumer opts in with `provideM3Theme`.

Implements spec `.specs/m3-dynamic-color` (requirements → research → design → tasks → implement → test-plan → test).

## What's included

- **Scheme engine** (DOM-free, contract-faithful): all 9 M3 variants, 3 contrast levels, light+dark. Role enumeration matches the build-time generator, so output equals the committed `_color.generated.css` by construction.
- **Contrast-aware custom colors** with optional `Blend.harmonize` (per-color toggle); 4 roles each, collision-guarded.
- **Runtime application** via an SSR-safe injected `<style>` (`RendererFactory2` + `DOCUMENT`), mirroring the static CSS shape so `light-dark()` + `[data-contrast]` + OS switching keep working.
- **Angular integration**: `provideM3Theme(config)` (bootstrap, server + client), `M3ThemeService` (`setTheme`, `resolve`), fail-fast hex/config validation.
- **SSR host** added to `apps/web` (demo only) + dogfood wiring with a runtime re-theme control.

## Groups (independently mergeable, in dependency order)

- **A** — theme entry point + DOM-free core (types, engine, custom colors, validation, CSS builder, unit tests)
- **B** — Angular integration (style applier, service, provider, TestBed tests, barrel + README)
- **C** — SSR host in `apps/web` + dogfood + SSR verification

## Verification

- `ui`: lint clean, **27 unit/TestBed tests** pass (value parity vs M3 reference, variants, contrast, WCAG AA, validation, applier/service/provider, SSR-style adoption).
- `web`: lint clean, 2 tests, SSR build succeeds; server-rendered HTML carries the dynamic tokens.
- **Manual test plan: 30/30 pass.** One defect found during testing (duplicate `<style>` after SSR hydration) was fixed — the applier now adopts the server-serialized element — and re-tested.
- Root `@ngguide/ui` entry pulls **0** MCU references; only the `theme` entry does.

## Notes

- Two minor, documented deviations (in `design.md`): Vitest `runnerConfig` to inline MCU's ESM-only package for tests, and ng-packagr `allowedNonPeerDependencies` to ship MCU via `dependencies` (Decision 2A).
- Pre-existing warnings left out of scope: unused `IconComponent` import, button/fab CSS budgets.
- Release / verdaccio / Nx release config untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)