### PR TITLE
feat: M3 communication components (badge, progress, loading, snackbar, tooltips)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f00e4c07-4c1b-4887-94ed-01ee3659ae9e","pid":85274,"procStart":"Fri May 29 12:29:50 2026","acquiredAt":1780487630654}

--- a/.specs/communication/design.md
+++ b/.specs/communication/design.md
@@ -1,0 +1,494 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Design Document: Communication Components
+
+## Overview
+
+This design implements the M3 **communication** family for `@ngguide/ui` as new secondary entry
+points, built on the kit's existing CDK-overlay service, M3 token system, and interaction foundation.
+All anatomy/measurements/color-roles come from the verified values read live from m3.material.io
+(see `research.md` → "Verified M3 Measurements"). Nothing here is improvised.
+
+New entry points:
+- `@ngguide/ui/badge` — `[guiBadge]` host directive (dot + numeric, "max+" cap).
+- `@ngguide/ui/progress` — `gui-linear-progress` (CSS) and `gui-circular-progress` (SVG).
+- `@ngguide/ui/loading-indicator` — `gui-loading-indicator` (SVG morphing shapes).
+- `@ngguide/ui/snackbar` — `GuiSnackbar` service (queue + timer + announce) + `gui-snackbar` surface.
+- `@ngguide/ui/tooltip` — `[guiTooltip]` plain directive + `gui-rich-tooltip` panel + trigger directive.
+
+Plus a small additive extension to `@ngguide/ui/overlay` (`GuiPickerOverlay`): a bottom-anchored,
+no-focus-trap global opener for the snackbar, and a connected opener (no focus capture/restore) for
+tooltips.
+
+### Key Changes
+
+1. **Two new floating openers on `GuiPickerOverlay`** — `openGlobalBottom()` (snackbar) and
+   `openConnected()` (tooltips). Neither captures/restores focus (unlike `openModal`/`openDocked`),
+   because snackbars and tooltips must not steal focus.
+2. **Five new presentational/feedback entry points** following kit conventions (standalone, OnPush,
+   signal inputs, attribute selectors, host-driven theming, zoneless-safe). None use `GuiFormControl`.
+3. **Shared a11y via first-party primitives** — CDK `LiveAnnouncer` for the snackbar, `GuiReducedMotion`
+   (from `@ngguide/ui/interaction`) + `@media (prefers-reduced-motion)` for motion, native
+   `role="progressbar"`/`role="tooltip"`/`role="status"` semantics.
+
+### Decisions
+
+| Problem Area | Chosen Variant | Why chosen | Reference |
+|-------------|----------------|------------|-----------|
+| 1. Badge anchoring | A — `[guiBadge]` host directive | Low effort/risk, strong fit with the kit's attribute-selector convention; no wrapper DOM around the host | research.md §1 |
+| 2. Progress/loading rendering | C — hybrid (CSS linear + SVG circular/loading) | each visual uses its best-fit technique; faithful rounded caps/gap on circular; loading shape-morph needs SVG regardless | research.md §2 |
+| 3. Snackbar service/overlay/queue | A — extend `GuiPickerOverlay` + `GuiSnackbar` queue service | literal "reuse CDK overlay" constraint; keeps one overlay service for the kit | research.md §3 |
+| 4. Tooltip structure | B — split plain directive + rich component | plain (non-interactive, `aria-describedby`) and rich (interactive, persistent) have materially different a11y lifecycles; mirrors M3's own split | research.md §4 |
+| 5. Shared a11y | A — CDK `LiveAnnouncer` + `GuiReducedMotion` | reuses first-party + existing foundation; no reinvented a11y primitives | research.md §5 |
+| Sub: progress visual | Classic (flat) now | flat determinate+indeterminate per M3 baseline; wavy/expressive deferred to a later iteration | research.md §2 note |
+| Sub: snackbar role | `role="status"` / polite + timer-pause | reconciles M3 auto-dismiss with APG alert guidance (no focus theft, adequate time via pause-on-hover/focus + reachable action) | research.md APG |
+
+## Architecture
+
+### Component Diagram
+
+```mermaid
+graph TB
+    subgraph deps["Existing infrastructure"]
+        overlay["@ngguide/ui/overlay<br/>GuiPickerOverlay (CDK Overlay)"]
+        tokens["M3 tokens (CSS custom props)"]
+        interaction["@ngguide/ui/interaction<br/>GuiReducedMotion, state-layer/ripple/focus-ring"]
+        button["@ngguide/ui/button<br/>gui-button / gui-icon-button"]
+        icon["@ngguide/ui/icon"]
+        cdkA11y["@angular/cdk/a11y<br/>LiveAnnouncer"]
+    end
+
+    subgraph comm["@ngguide/ui — communication entry points"]
+        badge["badge<br/>[guiBadge] directive"]
+        progress["progress<br/>gui-linear-progress (CSS)<br/>gui-circular-progress (SVG)"]
+        loading["loading-indicator<br/>gui-loading-indicator (SVG)"]
+        snackbar["snackbar<br/>GuiSnackbar service + gui-snackbar"]
+        tooltip["tooltip<br/>[guiTooltip] + gui-rich-tooltip"]
+    end
+
+    tokens --> badge & progress & loading & snackbar & tooltip
+    interaction --> progress & loading & snackbar
+    overlay --> snackbar & tooltip
+    cdkA11y --> snackbar
+    button --> snackbar & tooltip
+    icon --> snackbar & tooltip
+```
+
+### Data Flow — Snackbar (queue + announce + dismiss)
+
+```mermaid
+sequenceDiagram
+    participant App as App code
+    participant Svc as GuiSnackbar (service)
+    participant Q as Queue (signal FIFO)
+    participant Ovl as GuiPickerOverlay.openGlobalBottom
+    participant Sur as gui-snackbar surface
+    participant LA as LiveAnnouncer (polite)
+
+    App->>Svc: open({message, action, duration})
+    Svc->>Q: enqueue(config) → return GuiSnackbarRef
+    alt nothing showing
+        Svc->>Ovl: attach surface portal (bottom, no trap, no backdrop)
+        Ovl-->>Sur: render
+        Svc->>LA: announce(message, 'polite')
+        Svc->>Svc: start auto-dismiss timer (if duration != null)
+    end
+    Note over Sur,Svc: pointerenter/focusin → pause timer; leave/blur → resume (req 9.7)
+    App->>Sur: click action / close / swipe / timeout
+    Sur->>Svc: dismiss(reason)
+    Svc->>Ovl: detach + dispose
+    Svc-->>App: ref.afterDismissed.next(reason)
+    Svc->>Q: dequeue; if next → show next
+```
+
+## Components and Interfaces
+
+### Overlay extension — `@ngguide/ui/overlay`
+
+```typescript
+// Path: libs/ui/overlay/src/picker-overlay.ts  (additive — existing methods unchanged)
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { Portal } from '@angular/cdk/portal';
+
+export interface GuiGlobalBottomConfig {
+  /** Horizontal alignment of the bottom-anchored surface. Caller drives via breakpoint. */
+  alignment?: 'center' | 'leading';   // M3: centered on compact, leading on wide
+  /** Distance from the bottom edge, e.g. '16px' or an above-FAB offset. */
+  bottomOffset?: string;
+  /** Max inline width (M3 snackbar max width). */
+  maxWidth?: string;
+  panelClass?: string | string[];
+}
+
+export interface GuiConnectedConfig {
+  origin: HTMLElement;
+  /** Preferred connected positions (e.g. above-then-below for tooltips). */
+  positions?: ConnectedPosition[];
+  panelClass?: string | string[];
+}
+
+export interface GuiPickerOverlay {
+  // existing:
+  openDocked(portal: Portal<unknown>, cfg: GuiDockedConfig): GuiOverlayHandle;
+  openModal(portal: Portal<unknown>, cfg: GuiModalConfig): GuiOverlayHandle;
+
+  // NEW — bottom-anchored, GlobalPositionStrategy, NO backdrop, NO focus trap, NO focus restore.
+  // Scroll strategy: reposition. Used by the snackbar.
+  openGlobalBottom(portal: Portal<unknown>, cfg?: GuiGlobalBottomConfig): GuiOverlayHandle;
+
+  // NEW — connected to an origin, FlexibleConnectedPositionStrategy, NO backdrop,
+  // NO focus capture/restore (tooltips must not move focus). Scroll: reposition.
+  openConnected(portal: Portal<unknown>, cfg: GuiConnectedConfig): GuiOverlayHandle;
+}
+// GuiOverlayHandle { ref: OverlayRef; closed: Observable<void>; close(): void } — unchanged.
+```
+
+### Badge — `@ngguide/ui/badge`
+
+```typescript
+// Path: libs/ui/badge/src/badge.ts
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: '[guiBadge]',
+  host: {
+    'class': 'gui-badge-host',
+    '[style.position]': '"relative"',          // anchor for the absolutely-positioned badge
+    '[attr.data-gui-badge-variant]': 'variant()',
+    '[attr.data-gui-badge-hidden]': 'isHidden()',
+  },
+})
+export class GuiBadge {
+  /** Numeric/string value. Empty/absent ⇒ small dot; present ⇒ large numeric badge. */
+  readonly value = input<number | string | null>(null, { alias: 'guiBadge' });
+  /** Max before "max+" cap. M3 does not publish the number; default 999. */
+  readonly max = input(999, { alias: 'guiBadgeMax', transform: numberAttribute });
+  /** Force-hide without removing the directive. */
+  readonly hidden = input(false, { alias: 'guiBadgeHidden', transform: booleanAttribute });
+
+  protected readonly variant = computed<'small' | 'large'>(() =>
+    this.value() === null || this.value() === '' ? 'small' : 'large');
+  protected readonly isHidden = computed(() => this.hidden());
+  /** Capped display text for the large badge (e.g. "999+"). */
+  protected readonly display = computed(() => {
+    const v = this.value();
+    if (typeof v === 'number' && v > this.max()) return `${this.max()}+`;
+    return v == null ? '' : String(v);
+  });
+  // On init, the directive creates a child <span class="gui-badge" aria-hidden="true"> via Renderer2,
+  // positioned in the host's top-trailing corner. The dot/label is aria-hidden; meaning is conveyed
+  // through the host's own accessible name (consumer sets aria-label, e.g. "Notifications, 3 unread").
+}
+```
+
+Measurements (from verified M3): small dot **6dp** / 3dp corner; large **16dp** min, **8dp** corner;
+max-count container **16×34dp**, 4dp internal padding; offsets small **6×6dp**, large **14×12dp**.
+Color: container `--md-sys-color-error`, label `--md-sys-color-on-error`. Label typography:
+`--md-sys-typescale-label-small`.
+
+### Progress — `@ngguide/ui/progress`
+
+```typescript
+// Path: libs/ui/progress/src/linear-progress.ts   (CSS rendering)
+@Component({
+  selector: 'gui-linear-progress',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    'class': 'gui-linear-progress',
+    'role': 'progressbar',
+    '[attr.data-mode]': 'mode()',
+    '[attr.aria-label]': 'label() || null',
+    '[attr.aria-valuemin]': 'mode() === "determinate" ? 0 : null',
+    '[attr.aria-valuemax]': 'mode() === "determinate" ? 100 : null',
+    '[attr.aria-valuenow]': 'mode() === "determinate" ? percent() : null',
+  },
+  template: `
+    <div class="gui-linear-track"></div>
+    <div class="gui-linear-active" [style.transform]="activeTransform()"></div>
+    <div class="gui-linear-stop"></div>`,
+})
+export class GuiLinearProgress {
+  /** 0..1. null ⇒ indeterminate. */
+  readonly value = input<number | null>(null);
+  readonly label = input<string>();
+  protected readonly mode = computed(() => this.value() == null ? 'indeterminate' : 'determinate');
+  protected readonly clamped = computed(() => Math.min(1, Math.max(0, this.value() ?? 0)));
+  protected readonly percent = computed(() => Math.round(this.clamped() * 100));
+  protected readonly activeTransform = computed(() => `scaleX(${this.clamped()})`);
+  // Track thickness 4dp; rounded ends; 4dp gap to stop indicator; inset 4dp applied by consumer/layout.
+  // Colors: active --md-sys-color-primary; track --md-sys-color-secondary-container;
+  //         stop indicator --md-sys-color-primary. Indeterminate animation via @keyframes,
+  //         disabled under prefers-reduced-motion (CSS @media), replaced by a low-key pulse.
+}
+```
+
+```typescript
+// Path: libs/ui/progress/src/circular-progress.ts   (SVG rendering)
+@Component({
+  selector: 'gui-circular-progress',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    'class': 'gui-circular-progress',
+    'role': 'progressbar',
+    '[attr.data-mode]': 'mode()',
+    '[attr.aria-label]': 'label() || null',
+    '[attr.aria-valuemin]': 'mode() === "determinate" ? 0 : null',
+    '[attr.aria-valuemax]': 'mode() === "determinate" ? 100 : null',
+    '[attr.aria-valuenow]': 'mode() === "determinate" ? percent() : null',
+  },
+  // SVG <circle> track + active arc using stroke-dasharray/offset, stroke-linecap="round".
+})
+export class GuiCircularProgress {
+  readonly value = input<number | null>(null);   // 0..1, null ⇒ indeterminate
+  readonly label = input<string>();
+  protected readonly mode = computed(() => this.value() == null ? 'indeterminate' : 'determinate');
+  protected readonly clamped = computed(() => Math.min(1, Math.max(0, this.value() ?? 0)));
+  protected readonly percent = computed(() => Math.round(this.clamped() * 100));
+  protected readonly dashOffset = computed(() => this.CIRCUMFERENCE * (1 - this.clamped()));
+  // Diameter/stroke: M3 default (~48dp/4dp) — confirm against the token browser at build (figure-only).
+  // Color: --md-sys-color-primary (active) over --md-sys-color-secondary-container (track).
+}
+```
+
+### Loading indicator — `@ngguide/ui/loading-indicator`
+
+```typescript
+// Path: libs/ui/loading-indicator/src/loading-indicator.ts   (SVG morphing shapes)
+@Component({
+  selector: 'gui-loading-indicator',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    'class': 'gui-loading-indicator',
+    'role': 'progressbar',                 // busy/indeterminate — no aria-valuenow
+    '[attr.data-variant]': 'variant()',
+    '[attr.aria-label]': 'label() || "Loading"',
+  },
+  // SVG <path> whose `d` is driven by a deterministic shape-tween between the M3 shapes.
+})
+export class GuiLoadingIndicator {
+  readonly variant = input<'default' | 'contained'>('default');
+  readonly label = input<string>();
+  // Size 48dp overall, 38dp shape container. Color: default --md-sys-color-primary;
+  // contained: active --md-sys-color-on-primary-container over --md-sys-color-primary-container.
+  // Morph animation deterministic (no Math.random/Date.now). Under prefers-reduced-motion the
+  // morph stops at a resting shape (GuiReducedMotion / @media), surface stays visible & busy.
+}
+```
+
+### Snackbar — `@ngguide/ui/snackbar`
+
+```typescript
+// Path: libs/ui/snackbar/src/snackbar-config.ts
+export type GuiSnackbarCloseReason = 'action' | 'dismiss' | 'timeout' | 'swipe' | 'programmatic';
+
+export interface GuiSnackbarConfig {
+  message: string;
+  /** Optional single action affordance. */
+  action?: string;
+  /** Show a trailing close (dismiss) icon. */
+  showClose?: boolean;
+  /** Auto-dismiss after ms. null disables auto-dismiss (for action-required snackbars). Default M3-aligned (~4–10s). */
+  duration?: number | null;
+  /** Force two-line layout; otherwise inferred from content length. */
+  twoLine?: boolean;
+  /** Lift above a bottom-anchored FAB. true ⇒ default offset, string ⇒ explicit offset. */
+  aboveFab?: boolean | string;
+  /** Live-region politeness. Default 'polite'. */
+  politeness?: 'polite' | 'assertive';
+}
+
+export interface GuiSnackbarRef {
+  /** Emits once with the reason when the snackbar closes. */
+  readonly afterDismissed: Observable<GuiSnackbarCloseReason>;
+  /** Emits when the action is activated. */
+  readonly onAction: Observable<void>;
+  dismiss(reason?: GuiSnackbarCloseReason): void;
+}
+```
+
+```typescript
+// Path: libs/ui/snackbar/src/snackbar.service.ts
+@Injectable({ providedIn: 'root' })
+export class GuiSnackbar {
+  private readonly overlay = inject(GuiPickerOverlay);
+  private readonly announcer = inject(LiveAnnouncer);     // @angular/cdk/a11y
+  private readonly queue = signal<QueueItem[]>([]);        // FIFO; show one at a time
+
+  /** Enqueue a snackbar; returns a ref. Shows immediately if nothing is open. */
+  open(config: GuiSnackbarConfig | string): GuiSnackbarRef { /* ... */ }
+
+  /** Dismiss the current and clear the queue. */
+  dismissAll(): void { /* ... */ }
+  // Internals: timer (setTimeout) paused on pointerenter/focusin, resumed on leave/blur (req 9.7);
+  //  LiveAnnouncer.announce(message, politeness); on close → afterDismissed(reason), then show next.
+  //  Swipe: pointer drag past threshold → dismiss('swipe'). All timing in the service (side-effectful,
+  //  outside the no-Date.now pure-logic rule); pure helpers (queue ops, two-line inference) stay deterministic.
+}
+```
+
+```typescript
+// Path: libs/ui/snackbar/src/snackbar.ts   (surface component, rendered into the overlay)
+@Component({
+  selector: 'gui-snackbar',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { 'class': 'gui-snackbar', 'role': 'status', '[attr.data-two-line]': 'twoLine()' },
+  // container --md-sys-color-inverse-surface; text + close --md-sys-color-inverse-on-surface;
+  // action (gui-button text) --md-sys-color-inverse-primary; corner-extra-small (4dp); elevation level 3.
+})
+export class GuiSnackbarSurface { /* message, action label, showClose, twoLine inputs + outputs */ }
+```
+
+### Tooltip — `@ngguide/ui/tooltip`
+
+```typescript
+// Path: libs/ui/tooltip/src/tooltip.ts   (PLAIN — directive on the trigger)
+export type GuiTooltipPosition = 'above' | 'below' | 'before' | 'after';
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: '[guiTooltip]',
+  host: { '[attr.aria-describedby]': 'visible() ? tooltipId : null' },
+})
+export class GuiTooltip {
+  readonly message = input<string>('', { alias: 'guiTooltip' });
+  readonly position = input<GuiTooltipPosition>('above');
+  readonly showDelay = input(500);       // M3 doesn't publish; accessible default
+  readonly hideDelay = input(0);
+  readonly disabled = input(false, { transform: booleanAttribute });
+  protected readonly visible = signal(false);
+  protected readonly tooltipId = `gui-tooltip-${nextId++}`;
+  // pointerenter/focus/long-press → after showDelay, openConnected() a TemplatePortal carrying a
+  //   <div role="tooltip" id="tooltipId"> with --md-sys-color-inverse-surface bg / inverse-on-surface text,
+  //   24dp height, 8dp padding, corner-extra-small.
+  // pointerleave/blur/Escape → hide. Escape keeps focus on the trigger (APG).
+}
+```
+
+```typescript
+// Path: libs/ui/tooltip/src/rich-tooltip.ts   (RICH — panel component + trigger directive)
+@Component({
+  selector: 'gui-rich-tooltip',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  // Projects: [guiRichTooltipSubhead], default body, [guiRichTooltipActions] (up to two gui-buttons).
+  // Surface: --md-sys-color-surface-container; subhead/body --md-sys-color-on-surface-variant;
+  //   padding 12/8/16dp; corner-medium (12dp); elevation level 2. role="tooltip".
+  template: `<ng-template>...</ng-template>`,
+})
+export class GuiRichTooltip { /* exposes the TemplatePortal + open/close API */ }
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: '[guiRichTooltipTrigger]',
+})
+export class GuiRichTooltipTrigger {
+  /** The panel this trigger controls. */
+  readonly panel = input.required<GuiRichTooltip>({ alias: 'guiRichTooltipTrigger' });
+  // hover/focus opens openConnected(); PERSISTENT: stays open while pointer is over trigger OR panel
+  //   (track both; close only when pointer is over neither, after a small grace delay).
+  // Escape or action activation → close. Actions inside the panel are gui-buttons → already focusable.
+  // Sets aria-describedby on the trigger to the panel id while open.
+}
+```
+
+## Data Models
+
+```typescript
+// Snackbar queue item (internal)
+interface QueueItem {
+  config: Required<Pick<GuiSnackbarConfig, 'message'>> & GuiSnackbarConfig;
+  ref: GuiSnackbarRef;
+  // resolved at show time: handle: GuiOverlayHandle, timer state
+}
+```
+
+No persisted data models / DTOs — every component in this category is presentational/feedback. No
+schema, migration, query, or API layers are involved.
+
+## Data Flow Completeness
+
+These components introduce no cross-stack data fields (no DB/API). The "layers" that matter here are
+the component surface area: public input/output, host a11y attributes, rendered DOM, token-driven
+styling, and the spec registration. Traced per entry point:
+
+| Surface | Public API | Host a11y attrs | Rendered DOM | Token styling | Path alias | Spec in project.json |
+|--------|-----------|-----------------|--------------|---------------|-----------|----------------------|
+| badge | `guiBadge`/`Max`/`Hidden` | host name (consumer), badge `aria-hidden` | injected `<span>` corner | error/on-error, label-small | `@ngguide/ui/badge` | `../badge/src/badge.spec.ts` |
+| linear-progress | `value`,`label` | role=progressbar, valuenow/min/max | track/active/stop divs | primary/secondary-container | `@ngguide/ui/progress` | `../progress/src/linear-progress.spec.ts` |
+| circular-progress | `value`,`label` | role=progressbar, valuenow/min/max | SVG circle+arc | primary/secondary-container | `@ngguide/ui/progress` | `../progress/src/circular-progress.spec.ts` |
+| loading-indicator | `variant`,`label` | role=progressbar (busy), aria-label | SVG morph path | primary / on-primary-container | `@ngguide/ui/loading-indicator` | `../loading-indicator/src/loading-indicator.spec.ts` |
+| snackbar | `GuiSnackbar.open()`, `Ref` | role=status, LiveAnnouncer | overlay surface | inverse-surface trio | `@ngguide/ui/snackbar` | `../snackbar/src/snackbar.service.spec.ts`, `../snackbar/src/snackbar.spec.ts` |
+| tooltip (plain) | `guiTooltip`,`position`,delays | aria-describedby, role=tooltip | overlay text panel | inverse-surface/on-surface | `@ngguide/ui/tooltip` | `../tooltip/src/tooltip.spec.ts` |
+| rich tooltip | panel + trigger directive | aria-describedby, role=tooltip | overlay rich panel | surface-container/on-surface-variant | `@ngguide/ui/tooltip` | `../tooltip/src/rich-tooltip.spec.ts` |
+| overlay ext | `openGlobalBottom`,`openConnected` | — | CDK overlay pane | — (structural CSS exists) | `@ngguide/ui/overlay` | `../overlay/src/picker-overlay.spec.ts` (extend) |
+
+Each new entry point also needs: `ng-package.json`, `src/index.ts` barrel, a `tsconfig.base.json`
+`paths` entry, and the demo wiring in `apps/web` (not published).
+
+## Error Handling
+
+| Situation | Handling |
+|-----------|----------|
+| Badge value `> max` | Render `"{max}+"` (e.g. "999+"). |
+| Badge value `null`/empty | Render small dot (no label). `hidden` ⇒ render nothing. |
+| Progress `value` out of [0,1] | Clamp to [0,1]; `aria-valuenow` stays within min/max. |
+| Progress `value` null | Indeterminate mode; omit `aria-valuenow` (APG). |
+| Snackbar requested while one is showing | Queue it (FIFO); show after current dismisses. |
+| Snackbar `duration: null` | No auto-dismiss; stays until action/close/swipe (e.g. action-required). |
+| Pointer/focus on snackbar during auto-dismiss | Pause timer; resume on leave/blur (req 9.7). |
+| Tooltip trigger disabled | Do not open. |
+| Escape while tooltip open | Hide; keep focus on trigger (APG). |
+| `prefers-reduced-motion` | Indeterminate progress / loading morph / snackbar enter-exit reduced or stopped; surfaces remain visible; determinate values still update. |
+
+## Testing Strategy
+
+### Approach
+
+Native Angular Vitest (`@nx/angular:unit-test`, zoneless, jsdom). Specs live in each entry point's
+`src/` and are registered in `libs/ui/project.json` `test.options.include`. jsdom can't measure
+layout or run real overlay positioning, so tests assert **state, ARIA, and DOM structure**, not pixel
+geometry; overlay positioning and motion are verified by browser dogfood.
+
+### Unit Tests (per entry point)
+
+```typescript
+describe('GuiBadge', () => {
+  it('renders a dot when no value', () => { /* variant === 'small', no label text */ });
+  it('caps numeric value at max with "+"', () => { /* value 1200, max 999 → "999+" */ });
+  it('hides when guiBadgeHidden', () => { /* data-gui-badge-hidden, no visible badge */ });
+  it('marks the badge graphic aria-hidden', () => { /* badge span aria-hidden="true" */ });
+});
+
+describe('GuiLinearProgress', () => {
+  it('is indeterminate with no value (no aria-valuenow)', () => { /* role=progressbar, valuenow null */ });
+  it('clamps and exposes aria-valuenow for determinate', () => { /* value 0.5 → 50, value 2 → 100 */ });
+});
+
+describe('GuiSnackbar (service)', () => {
+  it('shows one at a time and queues the rest (FIFO)', () => { /* open a,b,c → a shows; b,c queued */ });
+  it('reports the close reason', () => { /* dismiss('action') → afterDismissed emits 'action' */ });
+  it('announces via LiveAnnouncer politely', () => { /* spy announce(message,'polite') */ });
+  it('does not auto-dismiss when duration is null', () => { /* timer never fires */ });
+});
+
+describe('GuiTooltip (plain)', () => {
+  it('sets aria-describedby only while visible', () => {});
+  it('hides on Escape and keeps focus on trigger', () => {});
+});
+
+describe('GuiPickerOverlay (extension)', () => {
+  it('openGlobalBottom attaches without a focus trap or backdrop', () => {});
+  it('openConnected does not capture or restore focus', () => {});
+});
+```
+
+### Edge Cases
+
+1. **Badge** value exactly `max` → no "+"; `max+1` → "max+".
+2. **Progress** value `0` (determinate, valuenow=0) vs `null` (indeterminate, no valuenow) — must differ.
+3. **Snackbar** rapid `open()` burst → strict FIFO order; `dismissAll()` clears queue + closes current.
+4. **Snackbar** timer pause/resume across multiple hover cycles → still dismisses once after total duration.
+5. **Rich tooltip** pointer travels trigger → gap → panel → stays open (persistent), but closes when over neither.
+6. **Reduced motion** → indeterminate progress/loading present and `role`/busy intact with animation removed.
+7. **Tooltip** with empty `guiTooltip` string or `disabled` → never opens.

--- a/.specs/communication/requirements.md
+++ b/.specs/communication/requirements.md
@@ -1,0 +1,343 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Requirements Document
+
+## Introduction
+
+The **communication** category delivers the Material Design 3 (M3) feedback and communication
+components for `@ngguide/ui`, published as secondary entry points. These are the surfaces that tell
+the user *what is happening* or *what changed*: status badges, progress and loading indicators,
+transient action feedback (snackbar), and contextual help (tooltips).
+
+Every component's anatomy, variants, states, measurements, motion, and accessibility behavior must
+trace 1:1 to the published M3 guideline at [m3.material.io](https://m3.material.io/) and the relevant
+WAI-ARIA Authoring Practices (APG) pattern. Where M3 is ambiguous, the open question is documented in
+research rather than guessed.
+
+This category covers five component families:
+1. **Badge** — small (dot) and large (numeric) status markers anchored to a host.
+2. **Progress indicators** — linear and circular, each with determinate and indeterminate modes.
+3. **Loading indicator** — the M3 loading indicator (animated morphing shape), distinct from circular progress.
+4. **Snackbar** — transient, queued action feedback with optional action and dismissal.
+5. **Tooltips** — plain (text-only) and rich (header + body + optional actions).
+
+Dialogs are explicitly **out of scope** here — they belong to the `containment` category.
+
+## Glossary
+
+- **Badge**: A small marker overlaid on a host element (icon, icon button, avatar, navigation item)
+  indicating unread count or a state needing attention. M3 defines a *small* badge (a dot, no label)
+  and a *large* badge (a numeric label).
+- **Host element**: The element a badge or tooltip is attached to / anchored to.
+- **Linear progress indicator**: A horizontal track + active indicator showing progress along a line.
+- **Circular progress indicator**: A circular arc/ring showing progress around a circle.
+- **Determinate**: The indicator reflects a known completion value between 0 and 1 (0–100%).
+- **Indeterminate**: The indicator animates continuously without communicating a specific value
+  (the amount of work is unknown).
+- **Loading indicator**: The M3 component that displays an animated, morphing shape while content
+  loads; distinct from the circular progress indicator.
+- **Snackbar**: A brief message at the bottom of the screen providing lightweight feedback about an
+  operation, optionally with a single action and/or a close affordance. M3 shows one snackbar at a time.
+- **Snackbar queue**: The mechanism by which multiple requested snackbars are shown sequentially,
+  one at a time, in request order.
+- **Plain tooltip**: A short, non-interactive text label describing an element, shown on hover, focus,
+  or long-press.
+- **Rich tooltip**: A larger tooltip containing an optional subhead/title, body text, and optional
+  action buttons; it can persist while the pointer moves into it.
+- **Trigger**: The element whose interaction (hover/focus/long-press/click) causes a tooltip to appear.
+- **Reduced motion**: The user preference, exposed to the system, requesting minimized or eliminated
+  non-essential animation.
+- **APG**: WAI-ARIA Authoring Practices Guide.
+
+## Requirements
+
+### Requirement 1: Badge — anatomy and variants
+
+**User Story:** As an app developer, I want to attach an M3 badge to an icon, icon button, avatar, or
+navigation item, so that I can communicate counts or attention states without adding extra layout.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a badge that can be anchored to a host element so the badge overlays the
+   host's corner per M3 badge placement.
+2. THE system SHALL support a **small badge** variant that renders as a dot with no label.
+3. THE system SHALL support a **large badge** variant that renders a numeric label.
+4. WHEN the numeric value exceeds the configured maximum THEN the system SHALL display the maximum
+   followed by a plus sign (e.g. "999+"), where the maximum is configurable and defaults to the M3
+   value.
+5. WHEN the badge is configured as hidden or its value is zero/absent in dot-less numeric mode THEN
+   the system SHALL not render a visible badge.
+6. THE system SHALL apply M3 badge measurements (small dot size, large badge height, horizontal
+   padding, label typography, corner radius) exactly as published.
+7. THE system SHALL color the badge using M3 color roles (error container / on-error per the M3 badge
+   spec) so it adapts to light and dark schemes.
+
+### Requirement 2: Badge — accessibility
+
+**User Story:** As an assistive-technology user, I want a badge's meaning conveyed to me, so that I
+know there is unread or attention-needing content.
+
+#### Acceptance Criteria
+
+1. THE system SHALL allow the host's accessible name to incorporate the badge's meaning (e.g. an
+   accessible label such as "Notifications, 3 unread") so the count is announced.
+2. THE system SHALL NOT expose the badge as a separate interactive or focusable element.
+3. WHEN the badge is purely decorative (small dot with externally described meaning) THEN the system
+   SHALL hide the badge graphic from the accessibility tree to avoid redundant announcements.
+
+### Requirement 3: Linear progress indicator
+
+**User Story:** As an app developer, I want a linear progress indicator, so that I can show the
+progress of an operation along a horizontal track.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a linear progress indicator with **determinate** and **indeterminate** modes.
+2. WHEN in determinate mode THEN the system SHALL render the active indicator proportional to a value
+   between 0 and 1 (clamped to that range).
+3. WHEN in indeterminate mode THEN the system SHALL animate continuously without representing a
+   specific value.
+4. THE system SHALL render the M3 linear anatomy — active indicator, track, the gap between active
+   indicator and track, the stop indicator, and rounded ends — with M3 thickness and measurements as
+   published.
+5. THE system SHALL color the active indicator, track, and stop indicator using M3 color roles
+   (primary / secondary-container per the M3 progress spec).
+6. WHEN the value changes in determinate mode THEN the system SHALL animate the active indicator to
+   the new value per M3 motion.
+
+### Requirement 4: Circular progress indicator
+
+**User Story:** As an app developer, I want a circular progress indicator, so that I can show progress
+in a compact circular form.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a circular progress indicator with **determinate** and **indeterminate** modes.
+2. WHEN in determinate mode THEN the system SHALL render an arc proportional to a value between 0 and 1.
+3. WHEN in indeterminate mode THEN the system SHALL animate continuously (rotation/arc sweep) without
+   representing a specific value.
+4. THE system SHALL render the M3 circular anatomy — active indicator arc, track, gap, and rounded
+   ends — with M3 size and stroke thickness as published.
+5. THE system SHALL color the indicator using the M3 color roles defined for circular progress.
+
+### Requirement 5: Loading indicator
+
+**User Story:** As an app developer, I want the M3 loading indicator, so that I can show an
+expressive, animated loading state distinct from a progress ring.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a loading indicator that renders the M3 animated morphing-shape loading
+   visual.
+2. THE system SHALL animate the loading indicator continuously while active, per M3 motion.
+3. THE system SHALL render the loading indicator at the M3-published size(s) and color it with the
+   M3 color roles for the loading indicator.
+4. THE system SHALL keep the loading indicator distinct from the circular progress indicator (it is
+   not a determinate ring and exposes no progress value).
+
+### Requirement 6: Progress and loading — accessibility
+
+**User Story:** As an assistive-technology user, I want progress and loading states announced, so I
+understand that the system is busy and how far along it is.
+
+#### Acceptance Criteria
+
+1. THE system SHALL expose each progress indicator with the progressbar accessibility role.
+2. WHEN a progress indicator is determinate THEN the system SHALL expose the current value, minimum,
+   and maximum to assistive technology.
+3. WHEN a progress indicator is indeterminate THEN the system SHALL expose it as a busy/indeterminate
+   progressbar without a current value.
+4. THE system SHALL allow an accessible label to be associated with each progress/loading indicator
+   so its purpose is announced.
+5. THE system SHALL communicate the loading indicator's busy state to assistive technology.
+
+### Requirement 7: Snackbar — content and variants
+
+**User Story:** As an app developer, I want to show a snackbar with a message and an optional action,
+so that I can give brief, non-blocking feedback about an operation.
+
+#### Acceptance Criteria
+
+1. THE system SHALL display a snackbar containing a text message.
+2. THE system SHALL support a **single-line** layout and a **two-line** layout for longer messages,
+   per M3.
+3. THE system SHALL support an optional single **action** affordance with a caller-provided label.
+4. WHEN the user activates the action THEN the system SHALL notify the caller and dismiss the snackbar.
+5. THE system SHALL support an optional **close** affordance that dismisses the snackbar when activated.
+6. THE system SHALL render the M3 snackbar anatomy (container, supporting text, action, optional close
+   icon), measurements, shape, and elevation as published.
+7. THE system SHALL color the snackbar using the M3 color roles for snackbar (inverse-surface /
+   inverse-on-surface / inverse-primary for the action) so it adapts to light and dark schemes.
+
+### Requirement 8: Snackbar — positioning
+
+**User Story:** As an app developer, I want snackbars positioned per M3, so that they don't obscure
+key UI and follow platform conventions.
+
+#### Acceptance Criteria
+
+1. THE system SHALL position the snackbar at the bottom of the screen by default, following M3
+   placement (centered on compact widths, leading-aligned on wider widths) as published.
+2. WHEN a floating action button or comparable bottom-anchored element is present and declared THEN
+   the system SHALL offset the snackbar so it appears above that element rather than overlapping it.
+3. THE system SHALL constrain the snackbar to the M3 maximum width on wide viewports.
+
+### Requirement 9: Snackbar — dismissal and queue
+
+**User Story:** As an app developer, I want snackbars shown one at a time with automatic dismissal,
+so that rapid feedback events don't stack or overwhelm the user.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a programmatic way to request a snackbar (open with message, optional
+   action, and options) and to dismiss it.
+2. THE system SHALL display at most one snackbar at a time.
+3. WHEN a snackbar is requested while another is showing THEN the system SHALL queue the new request
+   and show it after the current snackbar is dismissed, preserving request order.
+4. THE system SHALL automatically dismiss a snackbar after a timeout, with a configurable duration and
+   the ability to disable auto-dismiss for snackbars requiring user action.
+5. WHEN the user performs a dismissal gesture (swipe) on the snackbar THEN the system SHALL dismiss it.
+6. THE system SHALL report why a snackbar closed (action, dismiss affordance, timeout, or gesture) to
+   the caller.
+7. WHEN auto-dismiss is active and the user's pointer/focus is on the snackbar or its action THEN the
+   system SHALL pause the auto-dismiss timer until interaction ends, per M3/accessibility guidance.
+
+### Requirement 10: Snackbar — accessibility
+
+**User Story:** As an assistive-technology user, I want snackbar messages announced without stealing
+focus, so I'm informed but not interrupted.
+
+#### Acceptance Criteria
+
+1. WHEN a snackbar appears THEN the system SHALL announce its message to assistive technology via a
+   live region without moving focus to the snackbar.
+2. THE system SHALL make the action and close affordances keyboard-focusable and operable when present.
+3. THE system SHALL allow the user to reach the snackbar's action via the keyboard before it
+   auto-dismisses (consistent with Requirement 9.7).
+
+### Requirement 11: Plain tooltip
+
+**User Story:** As an app developer, I want a plain tooltip on an element, so that I can show a short
+descriptive label on hover, focus, or long-press.
+
+#### Acceptance Criteria
+
+1. THE system SHALL display a plain tooltip containing short text anchored to its trigger element.
+2. WHEN the pointer hovers the trigger THEN the system SHALL show the tooltip after the M3 show delay.
+3. WHEN the trigger receives keyboard focus THEN the system SHALL show the tooltip.
+4. WHEN the user long-presses the trigger on a touch device THEN the system SHALL show the tooltip.
+5. WHEN the pointer leaves the trigger, the trigger loses focus, or the user presses Escape THEN the
+   system SHALL hide the tooltip.
+6. THE system SHALL render the M3 plain-tooltip anatomy (container, supporting text), measurements,
+   shape, and color roles as published.
+7. THE system SHALL position the tooltip adjacent to the trigger and keep it within the viewport.
+
+### Requirement 12: Rich tooltip
+
+**User Story:** As an app developer, I want a rich tooltip with a title, body, and optional actions,
+so that I can provide more detailed, optionally interactive contextual help.
+
+#### Acceptance Criteria
+
+1. THE system SHALL display a rich tooltip that may contain an optional subhead/title, body text, and
+   optional action buttons.
+2. WHEN the rich tooltip contains actions THEN the system SHALL keep the tooltip visible while the
+   user moves the pointer from the trigger into the tooltip, so the actions can be used (persistent
+   behavior per M3).
+3. WHEN the user activates a rich-tooltip action, presses Escape, or moves focus/pointer away without
+   entering the tooltip THEN the system SHALL hide the tooltip.
+4. THE system SHALL render the M3 rich-tooltip anatomy (container, subhead, supporting text, action
+   row), measurements, shape, elevation, and color roles as published.
+5. THE system SHALL position the rich tooltip adjacent to the trigger and keep it within the viewport.
+
+### Requirement 13: Tooltip — accessibility
+
+**User Story:** As an assistive-technology user, I want tooltips associated with their triggers, so
+that the descriptive content is announced.
+
+#### Acceptance Criteria
+
+1. THE system SHALL associate a plain tooltip with its trigger so the tooltip text contributes to the
+   trigger's accessible description.
+2. THE system SHALL expose the tooltip surface with the tooltip accessibility role where appropriate.
+3. WHEN the user presses Escape while a tooltip is visible THEN the system SHALL hide it without
+   moving focus away from the trigger.
+4. WHEN a rich tooltip contains interactive actions THEN the system SHALL make those actions
+   keyboard-focusable and operable.
+
+### Requirement 14: Reduced motion
+
+**User Story:** As a motion-sensitive user, I want animations minimized when I've asked the system to
+reduce motion, so that the UI doesn't trigger discomfort.
+
+#### Acceptance Criteria
+
+1. WHEN the user has expressed a reduced-motion preference THEN the system SHALL reduce or remove
+   non-essential animation in indeterminate progress indicators, the loading indicator, and snackbar
+   enter/exit, without losing the conveyed meaning (busy/visible states remain perceivable).
+2. THE system SHALL still communicate determinate progress value changes when reduced motion is active
+   (the value updates remain correct even if transition animation is removed).
+
+### Requirement 15: Theming, sizing, and tokens
+
+**User Story:** As a design-system owner, I want these components driven by M3 tokens, so that they
+stay in sync with the theme and dynamic color.
+
+#### Acceptance Criteria
+
+1. THE system SHALL derive all colors, shapes, elevations, and motion of these components from the M3
+   token system (sys color roles, shape, elevation, state, motion) rather than hard-coded values.
+2. WHEN the active theme or color scheme changes (including dynamic color) THEN the system SHALL
+   reflect the change without code changes by consuming the token custom properties.
+3. THE system SHALL meet WCAG 2.1 AA contrast for text/iconography against their containers in both
+   light and dark schemes for every component in this category.
+
+### Requirement 16: Packaging and conventions
+
+**User Story:** As a consumer of `@ngguide/ui`, I want each communication component as a tree-shakable
+entry point following the kit's conventions, so that imports stay granular and consistent.
+
+#### Acceptance Criteria
+
+1. THE system SHALL publish the communication components as secondary entry points under
+   `@ngguide/ui/*`, each independently importable.
+2. THE system SHALL follow the established kit conventions: standalone, OnPush, signal-based inputs/
+   outputs, zoneless-safe, host-driven theming attributes.
+3. THE system SHALL provide at least one passing spec per published entry point on the native Angular
+   Vitest runner.
+4. THE system SHALL keep `lint`, `test`, and `build` green for `ui` and `web`.
+
+## Constraints
+
+- **Strict M3 fidelity** — every anatomy, measurement, state, motion value, and color role must trace
+  to the published M3 guideline; no improvised styling or behavior (project vision: "no invented
+  behavior").
+- **Built from scratch** — not a wrapper around Angular Material or MDC; M3 styling is implemented
+  on Angular 21 primitives.
+- **Reuse the existing CDK overlay infrastructure** — floating components (tooltip, snackbar) are to be
+  built on the `@angular/cdk/overlay` infrastructure already adopted by the `text-inputs` pickers
+  (the `GuiPickerOverlay` service / overlay container CSS), rather than introducing a new positioning
+  stack. *(Stated preference for research/design to honor or push back on.)*
+- **Depends on** the M3 token system (`m3-tokens`) and the interaction foundation
+  (`m3-interaction-foundation`) being available.
+- **Release/verdaccio and Nx release configuration are not changed** as part of this feature.
+
+## Non-functional Requirements
+
+- **Accessibility**: Meets WCAG 2.1 AA color contrast for M3 color roles in both light and dark
+  schemes; all interactive affordances (snackbar action/close, rich-tooltip actions) fully
+  keyboard-operable; progress/loading expose correct progressbar semantics; snackbar announced via a
+  live region without focus theft; behavior consistent with the relevant WAI-ARIA APG patterns
+  (tooltip, alert/status, progressbar).
+- **Determinism / SSR-safety**: Component logic must be zoneless-safe and free of nondeterministic
+  time sources in pure/reusable logic (no `Date.now()`, `Math.random()`, or argless `new Date()` in
+  pure functions), consistent with the kit's conventions.
+- **Motion**: Honors the user's reduced-motion preference for non-essential animation (Requirement 14).
+
+## Out of Scope
+
+- **Dialogs** — covered by the `containment` category.
+- **Menus** — the menu control lives in `selection`.

--- a/.specs/communication/research.md
+++ b/.specs/communication/research.md
@@ -1,0 +1,550 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Research: Communication Components
+
+## Problem Statement
+
+We need to implement the Material Design 3 (M3) **communication** components — badge, progress
+indicators (linear/circular), loading indicator, snackbar, and tooltips (plain/rich) — as
+secondary entry points of `@ngguide/ui`, strictly per [m3.material.io](https://m3.material.io/) and
+the relevant WAI-ARIA APG patterns. The kit already ships a CDK-overlay infrastructure, an M3 token
+system, and an interaction foundation; the research question is *how each component family should be
+structured on top of that existing infrastructure*, surfacing meaningfully distinct approaches with
+honest tradeoffs.
+
+This catalogue presents options only — decisions happen in `spec:design`.
+
+## Problem Areas
+
+### 1. Badge — anchoring and rendering
+
+_Related requirements: 1.1–1.7, 2.1–2.3_
+
+The badge must overlay a host element's corner (icon, icon button, avatar, nav item), render as a
+dot (small) or numeric label (large), cap at "999+", and contribute its meaning to the host's
+accessible name without becoming a separate focusable node.
+
+#### Variant A: Attribute directive on the host (`[guiBadge]`)
+
+**How it works:** A directive applied directly to the host element. It creates and positions a child
+badge element (absolutely positioned in the host's corner), reads inputs (`guiBadge` value,
+`guiBadgeMax`, `guiBadgeHidden`, dot vs numeric), and toggles `aria-hidden` on the badge graphic
+while leaving the host to own the accessible name. The host needs `position: relative` (the directive
+can set it).
+
+**Pros:**
+- Zero extra wrapper DOM around the host; cleanest markup (`<button gui-icon-button guiBadge="3">`).
+- Matches the kit's attribute-selector convention (button/fab/icon, `guiTextFieldInput`).
+- Easy to apply to existing components without changing their template.
+
+**Cons:**
+- Directive imperatively injects/positions a DOM node (renderer work), slightly more complex than a
+  template.
+- Requires care so the injected node doesn't disrupt host flex/grid layout.
+
+**Effort:** Low–Medium | **Risk:** Low
+**Codebase fit:** Strong — mirrors the attribute-directive style of `guiTextFieldInput`/`gui-button`
+host directives. Inline-SVG/`gui-icon` not needed (badge is text/dot).
+**Evidence:** Attribute-directive + host-binding convention confirmed in `libs/ui/button/src/button.ts`
+and `libs/ui/text-field/src/text-field-input.ts` [codebase].
+
+#### Variant B: Wrapper component with content projection (`<gui-badge>`)
+
+**How it works:** A component that wraps the host: `<gui-badge value="3"><gui-icon>…</gui-icon></gui-badge>`.
+The badge surface is rendered by the component template; the host is `<ng-content>`. The component owns
+`position: relative` and corner placement.
+
+**Pros:**
+- Fully declarative template; positioning lives in component CSS, no imperative DOM injection.
+- Self-contained styling and a11y wiring.
+
+**Cons:**
+- Adds a wrapper element around every badged host, which can interfere with parent layout (e.g. a nav
+  item expecting the icon as a direct child).
+- Less ergonomic for badging an existing button than a single attribute.
+
+**Effort:** Low | **Risk:** Low–Medium
+**Codebase fit:** Moderate — projection components exist (`gui-text-field`), but the kit leans toward
+attribute selectors for "decorate an existing element" cases.
+**Evidence:** Content-projection component pattern in `libs/ui/text-field/src/text-field.ts` [codebase].
+
+#### Variant C: Standalone badge, consumer-positioned
+
+**How it works:** A presentational `<gui-badge>` that only renders the dot/label; the consumer is
+responsible for anchoring it (their own `position: relative` container + placing the badge).
+
+**Pros:**
+- Maximum flexibility; the component has no opinions about the host.
+
+**Cons:**
+- Pushes M3 placement rules onto every consumer → high risk of inconsistent, non-spec placement.
+- Contradicts the "spec-literal placement" requirement (1.1).
+
+**Effort:** Low | **Risk:** Medium (placement drift)
+**Codebase fit:** Weak — offloads M3 anatomy to consumers, against the project vision.
+**Evidence:** —
+
+---
+
+### 2. Progress and loading — rendering and animation
+
+_Related requirements: 3.1–3.6, 4.1–4.5, 5.1–5.4, 6.1–6.5, 14.1–14.2_
+
+Three visuals: linear progress (track + active indicator + gap + stop indicator, rounded ends),
+circular progress (arc + track + gap), and the loading indicator (M3's animated morphing 7-shape
+sequence). Each progress type has determinate (value 0–1) and indeterminate modes; all must honor
+reduced motion and expose progressbar semantics.
+
+#### Variant A: Pure CSS
+
+**How it works:** Linear via nested `<div>`s with `transform: scaleX()` for the active indicator and
+CSS `@keyframes` for indeterminate; circular via `conic-gradient` (determinate) and CSS rotation
+(indeterminate). Reduced motion via `@media (prefers-reduced-motion)`.
+
+**Pros:**
+- No SVG; smallest determinate-linear implementation; GPU-friendly transforms.
+- Reduced-motion handled entirely in CSS media query.
+
+**Cons:**
+- M3 circular *gap* + *rounded arc ends* are hard to render faithfully with `conic-gradient`
+  (rounded caps and the track/indicator gap need extra masking).
+- The loading indicator's shape-morph cannot be done in pure CSS faithfully (it is a path morph).
+- Stop indicator + gap on linear need careful pseudo-element work.
+
+**Effort:** Medium | **Risk:** Medium (circular fidelity)
+**Codebase fit:** Neutral — CSS-token-driven styling is the kit norm.
+**Evidence:** Motion/shape tokens exist (`_motion.css`, `_shape.css`); reduced-motion utility
+`GuiReducedMotion` in `@ngguide/ui/interaction` [codebase].
+
+#### Variant B: SVG-based for all three
+
+**How it works:** Circular via `<svg><circle>` with `stroke-dasharray`/`stroke-dashoffset` +
+`stroke-linecap="round"` for rounded ends and a second circle for the track (gap via dash offset);
+linear via SVG rects (or CSS — see Variant C); loading indicator via an `<svg><path>` morph between
+the M3 shapes (animated `d` interpolation or a small shape-tween engine, deterministic/no RNG).
+
+**Pros:**
+- Faithful M3 circular anatomy: rounded arc ends, precise gap, exact stroke width.
+- SVG path morph is the natural fit for the loading indicator's shape sequence.
+- Reuses the inline-SVG convention already in the kit (`viewBox`, `fill/stroke=currentColor`).
+
+**Cons:**
+- More markup/geometry math than CSS for the simple linear case.
+- Path-morph engine for the loading indicator is the most involved piece (must be deterministic and
+  SSR-safe — no `Math.random()`/`Date.now()`).
+
+**Effort:** Medium–High | **Risk:** Medium
+**Codebase fit:** Strong for SVG (inline-SVG convention in `libs/ui/chip`, `date-picker`,
+`time-picker`); the clock-dial in `time-picker` already does trig-driven SVG geometry [codebase].
+**Evidence:** Inline-SVG geometry precedent in `libs/ui/time-picker/src/clock-dial.ts` and
+`libs/ui/chip/src/chip.ts` [codebase].
+
+#### Variant C: Hybrid — CSS linear, SVG circular + loading
+
+**How it works:** Linear progress as pure CSS (transforms + keyframes, easiest and faithful); circular
+progress and loading indicator as SVG (rounded caps, gap, path morph).
+
+**Pros:**
+- Each visual uses the technique it's best suited to; faithful across all three.
+- Avoids `conic-gradient` rounded-cap/gap pain while keeping linear minimal.
+
+**Cons:**
+- Two rendering techniques in one entry-point family (minor cohesion cost).
+
+**Effort:** Medium | **Risk:** Low–Medium
+**Codebase fit:** Strong — combines the two precedents already in the kit.
+**Evidence:** As Variant A + B above [codebase].
+
+> Note: M3's August-2024 "expressive" update adds wavy/variable-height progress tracks. Whether to
+> implement classic, expressive, or both is an **open question** (see Open Questions) — it affects
+> effort here but not the choice of rendering technique.
+
+---
+
+### 3. Snackbar — service, overlay, queue, and positioning
+
+_Related requirements: 7.1–7.7, 8.1–8.3, 9.1–9.7, 10.1–10.3, 14.1_
+
+Snackbar is invoked programmatically, shows one at a time with a FIFO queue, auto-dismisses
+(pausable), supports swipe-dismiss, an optional action and close, reports a close reason, positions
+at the bottom (M3 placement, above a declared FAB), and announces via a live region without stealing
+focus. The constraint from requirements is to reuse `@angular/cdk/overlay` (as the pickers do).
+
+#### Variant A: Extend the existing `GuiPickerOverlay` service with a global-bottom opener
+
+**How it works:** Add an `openGlobal()` (or `openBottom()`) method to `GuiPickerOverlay` that uses a
+CDK `GlobalPositionStrategy` anchored bottom (centered/leading per breakpoint) with a `noop`/
+`reposition` scroll strategy and **no backdrop, no focus trap** (snackbar must not steal focus). A
+separate `GuiSnackbar` service owns the queue (a signal-backed FIFO), auto-dismiss timer (pausable on
+hover/focus per 9.7), `LiveAnnouncer` call, and close-reason plumbing. The snackbar surface is a
+component rendered via `TemplatePortal`/`ComponentPortal`.
+
+**Pros:**
+- Honors the "reuse CDK overlay infra" constraint literally; one overlay service for the kit.
+- Queue/timer/announce logic stays in a focused snackbar service.
+
+**Cons:**
+- `GuiPickerOverlay` currently centers (`openModal`) or docks (`openDocked`); adding a third,
+  no-focus-trap, bottom-anchored mode widens its responsibility.
+- Must ensure the new mode never captures focus (the existing methods do focus management).
+
+**Effort:** Medium | **Risk:** Low–Medium
+**Codebase fit:** Strong — extends the exact service the constraint points at.
+**Evidence:** `GuiPickerOverlay` uses `Overlay`, `GlobalPositionStrategy`, `ScrollStrategyOptions`,
+focus capture/trap in `libs/ui/overlay/src/picker-overlay.ts` [codebase]; `LiveAnnouncer` ships in
+`@angular/cdk/a11y` (same package already used for `ConfigurableFocusTrapFactory`) [needs version
+confirmation via context7].
+
+#### Variant B: Dedicated `GuiSnackbar` service using CDK overlay directly
+
+**How it works:** A new service constructs its own `OverlayRef` via `Overlay.create()` with a
+`GlobalPositionStrategy().bottom().centerHorizontally()` (breakpoint-aware), bypassing
+`GuiPickerOverlay` entirely. Queue, timer, announce, swipe, and FAB-offset live here.
+
+**Pros:**
+- Snackbar's overlay config (no backdrop, no trap, bottom anchor, FAB offset, max-width) is
+  self-contained and not constrained by the picker service's shape.
+- Clear separation: pickers vs transient feedback.
+
+**Cons:**
+- Two places that call `Overlay.create()` directly (some duplication of overlay boilerplate).
+- Slightly looser reading of the "reuse the picker overlay service" constraint (still reuses the CDK
+  overlay *package*, just not the wrapper service).
+
+**Effort:** Medium | **Risk:** Low
+**Codebase fit:** Strong for CDK usage; moderate against the literal "reuse `GuiPickerOverlay`" wording.
+**Evidence:** CDK overlay primitives confirmed available and used [codebase, picker-overlay.ts].
+
+#### Variant C: Fixed-position container component, no overlay
+
+**How it works:** A host-rendered `<gui-snackbar-container>` placed once near the app root, with
+`position: fixed; bottom`. The service pushes snackbars into the container's signal queue; no CDK
+overlay.
+
+**Pros:**
+- No overlay layering concerns; trivially simple positioning.
+
+**Cons:**
+- Requires the consumer to place the container in their app shell (extra setup, easy to forget).
+- Reimplements stacking/z-index/viewport concerns the overlay already solves; ignores the reuse
+  constraint.
+- FAB-offset and breakpoint placement become bespoke.
+
+**Effort:** Medium | **Risk:** Medium
+**Codebase fit:** Weak — diverges from the established overlay approach and the stated constraint.
+**Evidence:** —
+
+> A11y note (applies to all variants): WAI-ARIA APG's *alert* pattern cautions against auto-dismiss
+> (WCAG 2.2.3) and uses `role="alert"` (assertive). M3 snackbars *do* auto-dismiss. The reconciling
+> approach is `role="status"`/`aria-live="polite"` (or `LiveAnnouncer` polite) **plus** the
+> requirement-9.7 timer-pause-on-hover/focus and a reachable action, so the user gets adequate time.
+> This is a documented tradeoff, not a variant choice.
+
+---
+
+### 4. Tooltip — overlay positioning and trigger handling (plain + rich)
+
+_Related requirements: 11.1–11.7, 12.1–12.5, 13.1–13.4, 14.1_
+
+Plain tooltip = non-interactive text, shown on hover/focus/long-press, `aria-describedby` on the
+trigger, Escape to dismiss. Rich tooltip = subhead + body + optional **interactive** actions,
+persistent (stays open when the pointer moves into it), focusable actions. Both anchor to the trigger
+and stay in the viewport. Constraint: reuse CDK overlay.
+
+#### Variant A: One directive `[guiTooltip]` for both, via `GuiPickerOverlay.openDocked`
+
+**How it works:** A single directive on the trigger. `guiTooltip="text"` → plain; a
+`guiTooltip`-with-template/`[guiRichTooltip]` input → rich. It opens a connected overlay using the
+existing docked opener (flexible connected position, preferred above/below), wires hover/focus/
+long-press listeners and Escape, and sets `aria-describedby`.
+
+**Pros:**
+- Reuses the picker overlay service; single import for consumers.
+- Directive-on-trigger matches the kit convention.
+
+**Cons:**
+- `openDocked` defaults to *below* dropdown positions; tooltips prefer above-then-below with small
+  offsets — needs a tooltip-specific position set (extend the service or pass positions in).
+- Plain (non-interactive, `aria-describedby`, no focus) and rich (interactive, focus into actions,
+  persistent) have materially different a11y/lifecycles; cramming both into one directive risks a
+  muddy API.
+
+**Effort:** Medium | **Risk:** Medium
+**Codebase fit:** Strong (directive + overlay reuse).
+**Evidence:** `openDocked` uses `flexibleConnectedTo` + `STANDARD_DROPDOWN_BELOW_POSITIONS` in
+`picker-overlay.ts` [codebase].
+
+#### Variant B: Split — `[guiTooltip]` directive (plain) + `<gui-rich-tooltip>` component (rich)
+
+**How it works:** Plain tooltip is a lightweight directive (hover/focus/long-press, `aria-describedby`,
+a small connected overlay or even a CSS-only fallback for the simplest case). Rich tooltip is a
+component/directive pair driving a connected overlay that contains projected interactive content,
+manages "keep open while pointer enters tooltip", and focus handling for actions.
+
+**Pros:**
+- Each tooltip type gets the API and a11y lifecycle it actually needs; plain stays tiny, rich owns
+  interactivity.
+- Mirrors how M3 itself documents plain vs rich as distinct patterns.
+
+**Cons:**
+- Two public surfaces instead of one.
+- Some shared positioning/trigger logic to factor out (a small internal helper).
+
+**Effort:** Medium–High | **Risk:** Low–Medium
+**Codebase fit:** Strong — the kit already splits presentational vs interactive concerns (e.g.
+text-field directives vs component).
+**Evidence:** Split-surface precedent in `libs/ui/text-field` (input directive + field component)
+[codebase].
+
+#### Variant C: CDK `CdkOverlay`/`cdkConnectedOverlay` template approach
+
+**How it works:** Use the CDK `cdkConnectedOverlay` *directive* in templates (not the `GuiPickerOverlay`
+service) with explicit `connectedPosition` arrays, wiring triggers in the host component.
+
+**Pros:**
+- Maximum positioning control declaratively in templates.
+
+**Cons:**
+- Bypasses the `GuiPickerOverlay` service the kit standardized on (looser fit with the reuse
+  constraint).
+- Pushes overlay wiring into each consumer template rather than encapsulating it in a directive.
+
+**Effort:** Medium | **Risk:** Medium
+**Codebase fit:** Moderate — uses CDK but not the kit's overlay service wrapper.
+**Evidence:** —
+
+---
+
+### 5. Shared accessibility — live region and reduced motion
+
+_Related requirements: 6.1–6.5, 10.1–10.3, 13.1–13.4, 14.1–14.2_
+
+Cross-cutting a11y concerns: announcing snackbars to AT without focus theft, progressbar semantics,
+tooltip association/Escape, and honoring reduced motion across indeterminate animations.
+
+#### Variant A: Reuse CDK `@angular/cdk/a11y` + interaction foundation utilities
+
+**How it works:** Snackbar announcements via CDK `LiveAnnouncer` (polite). Reduced motion via the
+existing `GuiReducedMotion` utility from `@ngguide/ui/interaction` for any JS-driven motion, plus
+`@media (prefers-reduced-motion)` in CSS for declarative animations. Progressbar via native
+`role="progressbar"` + `aria-valuenow/min/max/valuetext`. Tooltip via `aria-describedby` + Escape
+handler.
+
+**Pros:**
+- Reuses first-party CDK + the kit's own foundation; no reinvented a11y primitives.
+- `LiveAnnouncer` handles the polite live-region element lifecycle for us.
+
+**Cons:**
+- Depends on `LiveAnnouncer` behavior (single shared live region) — fine for one-at-a-time snackbars.
+
+**Effort:** Low | **Risk:** Low
+**Codebase fit:** Strong — `@angular/cdk/a11y` already a dependency; `GuiReducedMotion` exists.
+**Evidence:** `GuiReducedMotion` exported from `@ngguide/ui/interaction`; CDK a11y used in
+`picker-overlay.ts` [codebase].
+
+#### Variant B: Custom aria-live region element per surface
+
+**How it works:** Each component manages its own `aria-live` region in its template rather than using
+`LiveAnnouncer`; reduced motion handled purely in CSS.
+
+**Pros:**
+- No dependency on `LiveAnnouncer`'s shared-region semantics; explicit per-component control.
+
+**Cons:**
+- Reimplements what `LiveAnnouncer` already provides; more code, easy to get wrong (timing,
+  clearing, atomic).
+- Multiple live regions can produce duplicate/disordered announcements.
+
+**Effort:** Medium | **Risk:** Medium
+**Codebase fit:** Neutral.
+**Evidence:** —
+
+---
+
+## Verified M3 Measurements (read from live m3.material.io, 2026-06-03)
+
+The exact M3 anatomy below was read directly from the live spec pages via agent-browser (the
+measurement/color tables that WebFetch could not extract). Values shown as figures-only on the page
+(rather than text/token rows) are flagged `[figure — M3 standard token]` and use the documented M3
+component token.
+
+### Badge — `m3.material.io/components/badges/specs`
+- **Small badge** (dot): size **6dp** (H×W), corner radius **3dp**.
+- **Large badge** (one digit): **16dp** (H×W), corner radius **8dp**.
+- **Large badge, max character count**: **16×34dp** (H×W).
+- **Large badge padding** between badge and text container: **4dp**.
+- **Placement offset** (top-trailing icon corner → bottom-leading badge corner): small badge
+  **6×6dp**, large badge **14×12dp**.
+- **Color roles**: small badge = **Error**; large badge container = **Error**, label = **On error**;
+  max-character-count container = **Error**, label = **On error**.
+- **Max-count value**: the spec defines a "maximum character count" container/label but does not state
+  the numeric cap as text — "999+" is the conventional default; expose it configurable. _(value still
+  open — not given numerically on the page)_
+
+### Progress indicators — `m3.material.io/components/progress-indicators/specs`
+- **Linear track thickness**: **4dp** (default); thickness is "Default (4dp) and variable".
+- **Linear inset** from the screen edge: **4dp**.
+- **Shape**: **flat and wavy** (wavy = M3 Expressive; wavy uses *amplitude* = center-of-rest →
+  center-of-peak, and *wavelength* = distance between adjacent peaks).
+- **Behavior**: determinate (default) + indeterminate, for both linear and circular.
+- **Color roles** (shared): active indicator = **Primary**, track = **Secondary container**, stop
+  indicator = **Primary**.
+- **Availability**: linear and circular both available in **M3** and **M3 Expressive**. The old
+  separate circular/linear token sets are deprecated ("no longer recommended").
+- **Circular diameter / stroke / gap**: shown only in the interactive token browser (not
+  text-extractable). `[figure]` — use the M3 circular token defaults during implementation (commonly
+  **48dp** container, **4dp** active stroke); confirm against the token browser when building.
+
+### Loading indicator — `m3.material.io/components/loading-indicator/specs`
+- **Size**: **48dp** overall, with the **shape container 38dp** ("the size is 48dp while the shape
+  container is 38dp" — the 48dp gives margins around the 38dp morphing shape).
+- **Variants**: default and **Contained**.
+- **Color roles**: default = **Primary** (active indicator); **Contained** = active indicator
+  **On primary container**, container **Primary container**.
+- **Behavior**: "show the progress for a short wait time"; active indicator morphs through the M3
+  shape sequence; **single token set**.
+
+### Snackbar — `m3.material.io/components/snackbar/specs`
+- **Color roles**: container = **Inverse surface**, supporting text + close icon = **Inverse on
+  surface**, action = **Inverse primary**.
+- **Variants**: single line, single line with action, two lines, two lines with action, two lines
+  with longer action. Optional close icon, optional action.
+- **Container shape / elevation / min-max width / padding**: shown as figures, not token rows.
+  `[figure — M3 standard token]` — container shape = **corner-extra-small (4dp)**, elevation =
+  **level 3**; confirm exact width/padding against the figures during build.
+
+### Tooltips — `m3.material.io/components/tooltips/specs`
+- **Plain tooltip**: container = **Inverse surface**, supporting text = **Inverse on surface**;
+  **container height 24dp**, **padding 8dp**. Corner `[figure]` = **corner-extra-small (4dp)**.
+- **Rich tooltip**: container = **Surface container**, subhead + supporting text = **On surface
+  variant**; padding **top 12dp / bottom 8dp / left+right 16dp**. Corner `[figure]` =
+  **corner-medium (12dp)**. Configurations: subhead + supporting text + **up to two buttons** (the
+  headline and number of buttons are configurable).
+
+### Accessibility (APG, fetched 2026-06-03)
+- **Tooltip**: `role="tooltip"`, associate via `aria-describedby` on the trigger, **Escape** dismisses
+  while focus stays on the trigger; hover tooltip stays open while pointer is over trigger or tooltip.
+- **Snackbar / alert**: `role="alert"` is assertive and APG cautions against auto-dismiss (WCAG
+  2.2.3). Reconcile M3's auto-dismiss with `role="status"` / polite **plus** timer-pause-on-hover/focus
+  and a reachable action (requirement 9.7).
+- **Progressbar**: `role="progressbar"`; `aria-valuenow` **required for determinate**, **omit for
+  indeterminate**; `aria-valuemin`/`max` default 0/100; `aria-valuetext` optional.
+
+## Variant Catalogue at a glance
+
+| Problem Area | Variant | Effort | Risk | Codebase fit |
+|-------------|---------|--------|------|--------------|
+| 1. Badge | A: `[guiBadge]` directive on host | Low–Med | Low | Strong (attr-selector convention) |
+| 1. Badge | B: `<gui-badge>` wrapper + projection | Low | Low–Med | Moderate |
+| 1. Badge | C: Standalone, consumer-positioned | Low | Med | Weak (placement drift) |
+| 2. Progress/loading | A: Pure CSS | Med | Med | Neutral |
+| 2. Progress/loading | B: SVG for all three | Med–High | Med | Strong (SVG precedent) |
+| 2. Progress/loading | C: Hybrid CSS-linear + SVG-circular/loading | Med | Low–Med | Strong |
+| 3. Snackbar | A: Extend `GuiPickerOverlay` + queue service | Med | Low–Med | Strong (literal reuse) |
+| 3. Snackbar | B: Dedicated service on CDK overlay directly | Med | Low | Strong CDK / moderate vs wording |
+| 3. Snackbar | C: Fixed container, no overlay | Med | Med | Weak |
+| 4. Tooltip | A: One `[guiTooltip]` via openDocked | Med | Med | Strong |
+| 4. Tooltip | B: Split plain directive + rich component | Med–High | Low–Med | Strong |
+| 4. Tooltip | C: `cdkConnectedOverlay` templates | Med | Med | Moderate |
+| 5. A11y | A: Reuse CDK a11y + GuiReducedMotion | Low | Low | Strong |
+| 5. A11y | B: Custom per-surface live regions | Med | Med | Neutral |
+
+## Cross-area dependencies
+
+- **Area 3 (Snackbar) ↔ Area 5 (A11y):** Snackbar's announcement approach (LiveAnnouncer polite +
+  timer-pause) depends on picking Area-5 Variant A. Picking Area-5 Variant B would push live-region
+  management into the snackbar service itself.
+- **Area 3 & 4 ↔ overlay service shape:** Snackbar Variant A and Tooltip Variant A both *extend*
+  `GuiPickerOverlay` (new bottom-global opener; tooltip-specific connected positions). If the user
+  prefers not to widen that service, Snackbar Variant B / Tooltip Variant C keep it untouched at the
+  cost of some duplication. These choices should be made together for overlay consistency.
+- **Area 2 (loading indicator):** Whichever rendering variant is chosen, the loading indicator's
+  shape-morph effectively requires SVG (Variant B or C), so a pure-CSS Area-2 choice (Variant A)
+  still needs an SVG escape hatch for the loading indicator specifically.
+
+## Codebase Insights
+
+- **Overlay service** `GuiPickerOverlay` (`libs/ui/overlay/src/picker-overlay.ts`) wraps CDK
+  `Overlay` with `openDocked` (flexible connected, `STANDARD_DROPDOWN_BELOW_POSITIONS`, reposition
+  scroll) and `openModal` (global center, block scroll, focus trap + focus restore). It returns
+  `GuiOverlayHandle { ref, closed, close() }`. No bottom-anchored, no-focus-trap mode exists yet —
+  the snackbar needs one.
+- **Overlay CSS** ships manually in `libs/ui/src/styles/overlay.css` (CDK container/backdrop/pane +
+  `.gui-overlay-scrim` using `--md-sys-color-scrim`), imported by `theme.css`. New floating surfaces
+  inherit this container styling.
+- **Tokens** present and sufficient: error/on-error/error-container (badge), primary +
+  secondary-container (progress), inverse-surface/inverse-on-surface/inverse-primary (snackbar),
+  surface-container roles (tooltip), full motion/shape/elevation/state token sets
+  (`libs/ui/src/styles/tokens/_*.css`).
+- **Interaction foundation** (`@ngguide/ui/interaction`) exposes `GuiStateLayerDirective`,
+  `GuiRippleDirective`, `GuiFocusRingDirective`, `GuiReducedMotion`, and roving-focus helpers.
+  `gui-button` already composes the first three — snackbar action and rich-tooltip action buttons can
+  just use `gui-button`/`gui-icon-button`.
+- **SVG geometry precedent**: `libs/ui/time-picker/src/clock-dial.ts` (trig-driven SVG) and
+  `libs/ui/chip/src/chip.ts` (inline Material-Symbols SVG, `viewBox="0 -960 960 960"`,
+  `fill="currentColor"`) — directly reusable for progress/loading and snackbar/tooltip icons.
+- **Entry-point wiring**: each component is `libs/ui/<name>/{ng-package.json, src/index.ts}`, a
+  `tsconfig.base.json` `paths` entry `@ngguide/ui/<name>`, and spec files appended to
+  `libs/ui/project.json` `test.options.include`.
+- **No CVA**: `GuiFormControl` is irrelevant here — every communication component is presentational/
+  feedback, none tracks form input.
+
+## Sources
+
+_M3 component specification pages do not yield their anatomy/measurement tables to WebFetch (JS-driven
+token browser + figures). The measurements in the "Verified M3 Measurements" section above were read
+directly from the live pages via **agent-browser** on 2026-06-03 (same approach used for text-inputs).
+Values shown only as figures are flagged `[figure]` and use the documented M3 standard token._
+
+- [m3-badge] https://m3.material.io/components/badges/specs — read via agent-browser 2026-06-03 (sizes, corners, offsets, error roles)
+- [m3-progress] https://m3.material.io/components/progress-indicators/specs — read via agent-browser 2026-06-03 (4dp track, 4dp inset, primary/secondary-container roles, flat+wavy)
+- [m3-loading] https://m3.material.io/components/loading-indicator/specs — read via agent-browser 2026-06-03 (48dp/38dp, primary / contained roles)
+- [m3-snackbar] https://m3.material.io/components/snackbar/specs — read via agent-browser 2026-06-03 (inverse-surface/on-surface/primary roles, single/two-line variants)
+- [m3-tooltips] https://m3.material.io/components/tooltips/specs — read via agent-browser 2026-06-03 (plain 24dp/8dp inverse roles; rich 12/8/16dp surface-container/on-surface-variant, up to two buttons)
+- [apg-tooltip] https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/ — fetched 2026-06-03 (role=tooltip, aria-describedby, Escape, focus stays on trigger)
+- [apg-alert] https://www.w3.org/WAI/ARIA/apg/patterns/alert/ — fetched 2026-06-03 (role=alert assertive, no focus theft, auto-dismiss caution per WCAG 2.2.3)
+- [apg-range] https://www.w3.org/WAI/ARIA/apg/practices/range-related-properties/ — fetched 2026-06-03 (progressbar: aria-valuenow required for determinate, omit for indeterminate; valuemin/max default 0/100; valuetext optional)
+- [codebase] `libs/ui/overlay/src/picker-overlay.ts`, `libs/ui/src/styles/overlay.css`, `libs/ui/src/styles/tokens/_*.css`, `libs/ui/interaction/src/index.ts`, `libs/ui/button/src/button.ts`, `libs/ui/chip/src/chip.ts`, `libs/ui/time-picker/src/clock-dial.ts`, `libs/ui/text-field/src/*`, `libs/ui/project.json`, `tsconfig.base.json` — read 2026-06-03
+
+## Open Questions
+
+_Most measurement questions were closed by reading the live M3 pages (see "Verified M3 Measurements").
+The following remain — they are either figure-only values to confirm at build time or genuine
+decisions for `spec:design`._
+
+- [x] Badge measurements / color roles — **closed**: 6dp dot (3dp corner), 16dp large (8dp corner),
+  16×34dp max-count, 4–6–14×12dp offsets/padding, Error / On error roles.
+- [ ] **Badge max-count value**: the numeric cap is not stated as text on the page; default to "999+"
+  and expose configurable. _(value not published; decision)_
+- [x] Linear progress — **closed**: 4dp track, 4dp inset, Primary / Secondary container / Primary roles,
+  flat + wavy.
+- [ ] **Circular progress diameter/stroke/gap**: figure-only on the page; use M3 circular token
+  defaults (≈48dp/4dp) and confirm against the token browser at build time. _(figure — confirm)_
+- [ ] **Expressive vs classic progress**: implement classic only, expressive (wavy/variable thickness)
+  only, or both? Spec lists both as available. _(decision for design)_
+- [x] Loading indicator — **closed**: 48dp size / 38dp shape container, default Primary + Contained
+  (on-primary-container / primary-container), morphing shapes, single token set.
+- [x] Snackbar color roles + variants — **closed**: inverse-surface / inverse-on-surface /
+  inverse-primary; single + two-line, optional action + close.
+- [ ] **Snackbar dimensions/elevation + timing**: container width/padding/elevation are figure-only
+  (use corner-extra-small 4dp + elevation level 3); auto-dismiss duration and FAB-offset are not
+  published as text — choose sensible M3-aligned defaults (e.g. ~4–10s, configurable). _(figure + decision)_
+- [x] Tooltip measurements/roles — **closed**: plain 24dp height / 8dp padding (inverse-surface /
+  inverse-on-surface); rich 12/8/16dp padding (surface-container / on-surface-variant), up to two
+  buttons.
+- [ ] **Tooltip timing**: M3 hover show/hide delays and long-press threshold are not published as text;
+  choose accessible defaults (e.g. ~500ms show) configurable. _(value not published; decision)_
+- [ ] **Snackbar role**: confirm `role="status"`/polite (with timer-pause) as the reconciliation of
+  M3 auto-dismiss vs APG alert guidance, vs `role="alert"`. _(decision for design, informed by [apg-alert])_
+
+## Next Steps
+
+`spec:design communication` will pick one variant per problem area and produce the technical design.
+
+Several measurements are open questions blocked on reading the live M3 pages in a browser
+(agent-browser), as was done for text-inputs. Recommended: close those open questions before/early in
+design so the anatomy is spec-literal. Re-run `spec:research communication` (extension mode) if new
+directions surface.

--- a/.specs/communication/tasks.md
+++ b/.specs/communication/tasks.md
@@ -180,11 +180,11 @@ Group A** (uses `openGlobalBottom`); otherwise additive/**safe**.
 `[guiTooltip]` plain directive + `gui-rich-tooltip` panel + trigger directive. Blast radius: **coupled
 to Group A** (uses `openConnected`); otherwise additive/**safe**.
 
-- [ ] 22. Scaffold the `tooltip` entry point
+- [x] 22. Scaffold the `tooltip` entry point
   - Create `libs/ui/tooltip/{ng-package.json, src/index.ts}`; add path alias; register plain + rich specs.
   - _Requirements: 16.1, 16.2_
 
-- [ ] 23. Implement the plain tooltip directive
+- [x] 23. Implement the plain tooltip directive
   - `libs/ui/tooltip/src/tooltip.ts` + css per design: `guiTooltip` message, `position`, `showDelay`
     (default 500), `hideDelay`, `disabled`; hover/focus/long-press → after delay `openConnected` a
     `role="tooltip"` panel; set `aria-describedby` on the trigger while visible; pointerleave/blur/
@@ -192,7 +192,7 @@ to Group A** (uses `openConnected`); otherwise additive/**safe**.
     `--md-sys-color-inverse-on-surface`, height 24dp, padding 8dp, corner-extra-small.
   - _Requirements: 11.1–11.7, 13.1–13.3, 14.1_
 
-- [ ] 24. Implement the rich tooltip (panel + trigger)
+- [x] 24. Implement the rich tooltip (panel + trigger)
   - `libs/ui/tooltip/src/rich-tooltip.ts` + css per design: `gui-rich-tooltip` panel projecting
     subhead/body/actions (up to two `gui-button`s), `role="tooltip"`, surface
     `--md-sys-color-surface-container`, subhead/body `--md-sys-color-on-surface-variant`, padding
@@ -201,17 +201,17 @@ to Group A** (uses `openConnected`); otherwise additive/**safe**.
     when over neither after a grace delay); Escape / action activation closes; `aria-describedby` while open.
   - _Requirements: 12.1–12.5, 13.2, 13.4, 14.1_
 
-- [ ] 25. Tooltip specs + demo
+- [x] 25. Tooltip specs + demo
   - `tooltip.spec.ts`: `aria-describedby` only while visible; Escape hides + focus stays on trigger;
     disabled/empty never opens.
   - `rich-tooltip.spec.ts`: panel renders subhead/body/actions; persistent open/close logic; actions focusable.
   - Demo sections in `apps/web` (plain on icon buttons; rich with actions).
   - _Requirements: 11.5, 12.2, 13.1, 13.3, 16.3_
 
-- [ ] 26. Checkpoint — Group F verification
+- [x] 26. Checkpoint — Group F verification
   - Run tooltip specs + Group A overlay spec + `lint build -p ui`. Confirm independently mergeable on top of A.
 
-- [ ] 27. Final checkpoint — everything green
+- [x] 27. Final checkpoint — everything green
   - `pnpm exec nx run-many -t lint test build -p ui web` — all green for both projects.
   - Confirm every new entry point builds via ng-packagr (`nx build ui` produces all new entries).
   - All 16 requirements traceable to a shipped task; new specs registered in `project.json`.

--- a/.specs/communication/tasks.md
+++ b/.specs/communication/tasks.md
@@ -115,11 +115,11 @@ New `gui-linear-progress` (CSS) + `gui-circular-progress` (SVG). Blast radius: *
 
 New `gui-loading-indicator` (SVG morph). Blast radius: **safe** — independent.
 
-- [ ] 13. Scaffold the `loading-indicator` entry point
+- [x] 13. Scaffold the `loading-indicator` entry point
   - Create `libs/ui/loading-indicator/{ng-package.json, src/index.ts}`; add path alias; register spec.
   - _Requirements: 16.1, 16.2_
 
-- [ ] 14. Implement `GuiLoadingIndicator` (SVG morphing shapes)
+- [x] 14. Implement `GuiLoadingIndicator` (SVG morphing shapes)
   - `libs/ui/loading-indicator/src/loading-indicator.ts` + css per design: `variant`
     ('default'|'contained'), `label`; SVG `<path>` driven by a **deterministic** shape-tween (no
     `Math.random`/`Date.now`); 48dp overall / 38dp shape container; `role="progressbar"` busy +
@@ -127,13 +127,13 @@ New `gui-loading-indicator` (SVG morph). Blast radius: **safe** — independent.
     morph stops at a resting shape under `prefers-reduced-motion` (use `GuiReducedMotion`).
   - _Requirements: 5.1–5.4, 6.5, 14.1, 15.1_
 
-- [ ] 15. Loading-indicator spec + demo
+- [x] 15. Loading-indicator spec + demo
   - `loading-indicator.spec.ts`: renders SVG path; `role="progressbar"` + accessible label; default vs
     contained variant attr; deterministic output (no nondeterministic source).
   - Demo section in `apps/web`.
   - _Requirements: 5.4, 6.5, 16.3_
 
-- [ ] 16. Checkpoint — Group D verification
+- [x] 16. Checkpoint — Group D verification
   - Run loading-indicator spec + `lint build -p ui`. Confirm independently mergeable.
 
 ### Group E — Snackbar (`@ngguide/ui/snackbar`)

--- a/.specs/communication/tasks.md
+++ b/.specs/communication/tasks.md
@@ -83,12 +83,12 @@ on A. Independent.
 
 New `gui-linear-progress` (CSS) + `gui-circular-progress` (SVG). Blast radius: **safe** — independent.
 
-- [ ] 8. Scaffold the `progress` entry point
+- [x] 8. Scaffold the `progress` entry point
   - Create `libs/ui/progress/{ng-package.json, src/index.ts}`; add path alias; register both spec
     paths in `project.json`.
   - _Requirements: 16.1, 16.2_
 
-- [ ] 9. Implement `GuiLinearProgress` (CSS)
+- [x] 9. Implement `GuiLinearProgress` (CSS)
   - `libs/ui/progress/src/linear-progress.ts` + css per design: `value` (0..1, null⇒indeterminate),
     `label`; `role="progressbar"`, `aria-valuenow/min/max` for determinate, omitted for indeterminate;
     track 4dp + rounded ends + 4dp gap + stop indicator; `--md-sys-color-primary` active /
@@ -96,19 +96,19 @@ New `gui-linear-progress` (CSS) + `gui-circular-progress` (SVG). Blast radius: *
     `@media (prefers-reduced-motion)`.
   - _Requirements: 3.1–3.6, 6.1–6.4, 14.1, 14.2, 15.1_
 
-- [ ] 10. Implement `GuiCircularProgress` (SVG)
+- [x] 10. Implement `GuiCircularProgress` (SVG)
   - `libs/ui/progress/src/circular-progress.ts` + css per design: SVG track + active arc via
     `stroke-dasharray`/`offset`, `stroke-linecap="round"`; same ARIA contract; M3 circular default
     size/stroke (confirm against token browser); same color roles.
   - _Requirements: 4.1–4.5, 6.1–6.4, 14.1, 15.1_
 
-- [ ] 11. Progress specs + demo
+- [x] 11. Progress specs + demo
   - `linear-progress.spec.ts` + `circular-progress.spec.ts`: indeterminate omits `aria-valuenow`;
     determinate clamps + exposes `aria-valuenow`; value 0 vs null differ.
   - Demo sections in `apps/web` (determinate slider-driven + indeterminate, both geometries).
   - _Requirements: 3.2, 4.2, 6.2, 6.3, 16.3_
 
-- [ ] 12. Checkpoint — Group C verification
+- [x] 12. Checkpoint — Group C verification
   - Run progress specs + `lint build -p ui`. Confirm independently mergeable.
 
 ### Group D — Loading indicator (`@ngguide/ui/loading-indicator`)

--- a/.specs/communication/tasks.md
+++ b/.specs/communication/tasks.md
@@ -55,12 +55,12 @@ Adds two additive openers to `GuiPickerOverlay`. Blast radius: **safe** — new 
 New `[guiBadge]` host directive. Blast radius: **safe** — standalone new entry point, no dependencies
 on A. Independent.
 
-- [ ] 4. Scaffold the `badge` entry point
+- [x] 4. Scaffold the `badge` entry point
   - Create `libs/ui/badge/{ng-package.json, src/index.ts}`; add `@ngguide/ui/badge` to
     `tsconfig.base.json` `paths`; register the spec path in `libs/ui/project.json` `test.options.include`.
   - _Requirements: 16.1, 16.2_
 
-- [ ] 5. Implement the `GuiBadge` directive
+- [x] 5. Implement the `GuiBadge` directive
   - `libs/ui/badge/src/badge.ts` per design: `value`/`max`/`hidden` signal inputs, `variant`/`display`
     computeds, "{max}+" cap, dot vs numeric; inject a corner `<span class="gui-badge" aria-hidden="true">`
     via `Renderer2`; host `position: relative` + `data-gui-badge-*` attrs.
@@ -70,13 +70,13 @@ on A. Independent.
   - Export from `src/index.ts`.
   - _Requirements: 1.1–1.7, 2.1–2.3, 15.1, 15.2_
 
-- [ ] 6. Badge spec + demo
+- [x] 6. Badge spec + demo
   - `libs/ui/badge/src/badge.spec.ts`: dot when no value; cap "999+"; hidden ⇒ no badge; badge graphic
     `aria-hidden`.
   - Add a demo section to `apps/web` (`app.component.{ts,html}`) badging an icon button.
   - _Requirements: 1.4, 1.5, 2.2, 2.3, 16.3_
 
-- [ ] 7. Checkpoint — Group B verification
+- [x] 7. Checkpoint — Group B verification
   - Run badge spec + `lint build -p ui`. Confirm independently mergeable; no other entry points touched.
 
 ### Group C — Progress (`@ngguide/ui/progress`)

--- a/.specs/communication/tasks.md
+++ b/.specs/communication/tasks.md
@@ -1,0 +1,239 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Implementation Plan: Communication Components
+
+## Overview
+
+Build the M3 communication family — badge, progress (linear/circular), loading indicator, snackbar,
+and tooltips (plain/rich) — as new `@ngguide/ui/*` secondary entry points, plus a small additive
+extension to the existing `GuiPickerOverlay` for bottom-anchored (snackbar) and connected (tooltip)
+floating surfaces.
+
+The plan is split into 6 groups in dependency order. Each group is independently mergeable — build,
+lint, and tests stay green with only that group (and earlier ones) applied. The work is **purely
+additive**: every group adds a new entry point or an additive method; nothing existing is removed or
+changed in a breaking way, so there are no cutovers.
+
+Group A (overlay extension) is the only shared prerequisite — Groups E (snackbar) and F (tooltip)
+depend on it. Groups B/C/D are independent and can land in any order after the repo is green.
+
+## Tasks
+
+### Group A — Overlay extension (foundation)
+
+Adds two additive openers to `GuiPickerOverlay`. Blast radius: **safe** — new methods only; existing
+`openDocked`/`openModal` untouched. Required by Groups E and F.
+
+- [x] 1. Add `openGlobalBottom` and `openConnected` to `GuiPickerOverlay`
+  - In `libs/ui/overlay/src/picker-overlay.ts`, add `GuiGlobalBottomConfig` + `GuiConnectedConfig`
+    interfaces and two methods (design.md → "Overlay extension"):
+    - `openGlobalBottom(portal, cfg?)` — `GlobalPositionStrategy` anchored bottom with
+      `alignment` ('center'|'leading'), `bottomOffset`, `maxWidth`; **no backdrop, no focus trap, no
+      focus capture/restore**; scroll strategy `reposition`.
+    - `openConnected(portal, cfg)` — `FlexibleConnectedPositionStrategy` to `cfg.origin` with optional
+      `cfg.positions`; **no backdrop, no focus capture/restore**; scroll `reposition`.
+  - Export the new interfaces from `libs/ui/overlay/src/index.ts`.
+  - _Requirements: 8.1, 8.2, 8.3, 9.1, 11.7, 12.5_
+
+- [x] 2. Unit tests for the overlay extension
+  - In `libs/ui/overlay/src/picker-overlay.spec.ts` (extend existing): assert `openGlobalBottom`
+    attaches a pane without a backdrop element and without creating a focus trap / moving focus;
+    assert `openConnected` attaches connected to an origin and does not capture/restore focus.
+  - Note jsdom limits (no real positioning) — assert overlay-ref state + that focus is unchanged.
+  - _Requirements: 8.1, 9.1, 11.7_
+
+- [x] 3. Checkpoint — Group A verification
+  - `pnpm exec nx test ui --include=libs/ui/overlay/src/picker-overlay.spec.ts` (or run `ui` test target).
+  - `pnpm exec nx run-many -t lint build -p ui` — confirm `ui` still builds with the additive API.
+  - Confirm `main` stays green with only Group A applied (existing picker tests unaffected).
+
+### Group B — Badge (`@ngguide/ui/badge`)
+
+New `[guiBadge]` host directive. Blast radius: **safe** — standalone new entry point, no dependencies
+on A. Independent.
+
+- [ ] 4. Scaffold the `badge` entry point
+  - Create `libs/ui/badge/{ng-package.json, src/index.ts}`; add `@ngguide/ui/badge` to
+    `tsconfig.base.json` `paths`; register the spec path in `libs/ui/project.json` `test.options.include`.
+  - _Requirements: 16.1, 16.2_
+
+- [ ] 5. Implement the `GuiBadge` directive
+  - `libs/ui/badge/src/badge.ts` per design: `value`/`max`/`hidden` signal inputs, `variant`/`display`
+    computeds, "{max}+" cap, dot vs numeric; inject a corner `<span class="gui-badge" aria-hidden="true">`
+    via `Renderer2`; host `position: relative` + `data-gui-badge-*` attrs.
+  - `libs/ui/badge/src/badge.css` (or inline styles): small dot **6dp**/3dp corner; large **16dp**/8dp
+    corner; max-count **16×34dp**, 4dp padding; offsets 6×6 / 14×12dp; `--md-sys-color-error` /
+    `--md-sys-color-on-error`; label `--md-sys-typescale-label-small`.
+  - Export from `src/index.ts`.
+  - _Requirements: 1.1–1.7, 2.1–2.3, 15.1, 15.2_
+
+- [ ] 6. Badge spec + demo
+  - `libs/ui/badge/src/badge.spec.ts`: dot when no value; cap "999+"; hidden ⇒ no badge; badge graphic
+    `aria-hidden`.
+  - Add a demo section to `apps/web` (`app.component.{ts,html}`) badging an icon button.
+  - _Requirements: 1.4, 1.5, 2.2, 2.3, 16.3_
+
+- [ ] 7. Checkpoint — Group B verification
+  - Run badge spec + `lint build -p ui`. Confirm independently mergeable; no other entry points touched.
+
+### Group C — Progress (`@ngguide/ui/progress`)
+
+New `gui-linear-progress` (CSS) + `gui-circular-progress` (SVG). Blast radius: **safe** — independent.
+
+- [ ] 8. Scaffold the `progress` entry point
+  - Create `libs/ui/progress/{ng-package.json, src/index.ts}`; add path alias; register both spec
+    paths in `project.json`.
+  - _Requirements: 16.1, 16.2_
+
+- [ ] 9. Implement `GuiLinearProgress` (CSS)
+  - `libs/ui/progress/src/linear-progress.ts` + css per design: `value` (0..1, null⇒indeterminate),
+    `label`; `role="progressbar"`, `aria-valuenow/min/max` for determinate, omitted for indeterminate;
+    track 4dp + rounded ends + 4dp gap + stop indicator; `--md-sys-color-primary` active /
+    `--md-sys-color-secondary-container` track; indeterminate `@keyframes`, reduced under
+    `@media (prefers-reduced-motion)`.
+  - _Requirements: 3.1–3.6, 6.1–6.4, 14.1, 14.2, 15.1_
+
+- [ ] 10. Implement `GuiCircularProgress` (SVG)
+  - `libs/ui/progress/src/circular-progress.ts` + css per design: SVG track + active arc via
+    `stroke-dasharray`/`offset`, `stroke-linecap="round"`; same ARIA contract; M3 circular default
+    size/stroke (confirm against token browser); same color roles.
+  - _Requirements: 4.1–4.5, 6.1–6.4, 14.1, 15.1_
+
+- [ ] 11. Progress specs + demo
+  - `linear-progress.spec.ts` + `circular-progress.spec.ts`: indeterminate omits `aria-valuenow`;
+    determinate clamps + exposes `aria-valuenow`; value 0 vs null differ.
+  - Demo sections in `apps/web` (determinate slider-driven + indeterminate, both geometries).
+  - _Requirements: 3.2, 4.2, 6.2, 6.3, 16.3_
+
+- [ ] 12. Checkpoint — Group C verification
+  - Run progress specs + `lint build -p ui`. Confirm independently mergeable.
+
+### Group D — Loading indicator (`@ngguide/ui/loading-indicator`)
+
+New `gui-loading-indicator` (SVG morph). Blast radius: **safe** — independent.
+
+- [ ] 13. Scaffold the `loading-indicator` entry point
+  - Create `libs/ui/loading-indicator/{ng-package.json, src/index.ts}`; add path alias; register spec.
+  - _Requirements: 16.1, 16.2_
+
+- [ ] 14. Implement `GuiLoadingIndicator` (SVG morphing shapes)
+  - `libs/ui/loading-indicator/src/loading-indicator.ts` + css per design: `variant`
+    ('default'|'contained'), `label`; SVG `<path>` driven by a **deterministic** shape-tween (no
+    `Math.random`/`Date.now`); 48dp overall / 38dp shape container; `role="progressbar"` busy +
+    `aria-label`; default `--md-sys-color-primary`, contained on-primary-container/primary-container;
+    morph stops at a resting shape under `prefers-reduced-motion` (use `GuiReducedMotion`).
+  - _Requirements: 5.1–5.4, 6.5, 14.1, 15.1_
+
+- [ ] 15. Loading-indicator spec + demo
+  - `loading-indicator.spec.ts`: renders SVG path; `role="progressbar"` + accessible label; default vs
+    contained variant attr; deterministic output (no nondeterministic source).
+  - Demo section in `apps/web`.
+  - _Requirements: 5.4, 6.5, 16.3_
+
+- [ ] 16. Checkpoint — Group D verification
+  - Run loading-indicator spec + `lint build -p ui`. Confirm independently mergeable.
+
+### Group E — Snackbar (`@ngguide/ui/snackbar`)
+
+`GuiSnackbar` service (queue + timer + announce) + `gui-snackbar` surface. Blast radius: **coupled to
+Group A** (uses `openGlobalBottom`); otherwise additive/**safe**.
+
+- [ ] 17. Scaffold the `snackbar` entry point
+  - Create `libs/ui/snackbar/{ng-package.json, src/index.ts}`; add path alias; register service + surface specs.
+  - _Requirements: 16.1, 16.2_
+
+- [ ] 18. Implement snackbar config + surface
+  - `libs/ui/snackbar/src/snackbar-config.ts`: `GuiSnackbarConfig`, `GuiSnackbarRef`,
+    `GuiSnackbarCloseReason`.
+  - `libs/ui/snackbar/src/snackbar.ts` surface component + css: `role="status"`; single/two-line;
+    optional action (`gui-button` text) + optional close (`gui-icon-button`); container
+    `--md-sys-color-inverse-surface`, text/close `--md-sys-color-inverse-on-surface`, action
+    `--md-sys-color-inverse-primary`; corner-extra-small (4dp); elevation level 3.
+  - _Requirements: 7.1–7.7, 10.2, 15.1_
+
+- [ ] 19. Implement `GuiSnackbar` service (queue, timer, announce, dismissal)
+  - `libs/ui/snackbar/src/snackbar.service.ts` per design: signal FIFO queue showing one at a time;
+    `open(config|string)` → `GuiSnackbarRef`; `dismissAll()`; attach surface via
+    `GuiPickerOverlay.openGlobalBottom` (alignment by breakpoint, `aboveFab` offset, max-width);
+    `LiveAnnouncer.announce(message, politeness 'polite')`; auto-dismiss timer with configurable
+    `duration` (null disables); pause on `pointerenter`/`focusin`, resume on leave/blur; swipe-dismiss;
+    `afterDismissed(reason)` + `onAction`. Keep pure helpers (queue ops, two-line inference)
+    deterministic; timer side-effects live in the service.
+  - _Requirements: 8.1–8.3, 9.1–9.7, 10.1, 10.3, 14.1_
+
+- [ ] 20. Snackbar specs + demo
+  - `snackbar.service.spec.ts`: FIFO one-at-a-time; queues while showing; reports close reason;
+    `LiveAnnouncer` called politely; `duration: null` never auto-dismisses; `dismissAll()` clears.
+  - `snackbar.spec.ts`: surface renders message/action/close; `role="status"`.
+  - Demo buttons in `apps/web` (simple, with-action, action-required, above-FAB).
+  - _Requirements: 9.2, 9.3, 9.4, 9.6, 10.1, 16.3_
+
+- [ ] 21. Checkpoint — Group E verification
+  - Run snackbar specs + Group A overlay spec + `lint build -p ui`. Confirm Group A is present (coupled);
+    confirm independently mergeable on top of A.
+
+### Group F — Tooltips (`@ngguide/ui/tooltip`)
+
+`[guiTooltip]` plain directive + `gui-rich-tooltip` panel + trigger directive. Blast radius: **coupled
+to Group A** (uses `openConnected`); otherwise additive/**safe**.
+
+- [ ] 22. Scaffold the `tooltip` entry point
+  - Create `libs/ui/tooltip/{ng-package.json, src/index.ts}`; add path alias; register plain + rich specs.
+  - _Requirements: 16.1, 16.2_
+
+- [ ] 23. Implement the plain tooltip directive
+  - `libs/ui/tooltip/src/tooltip.ts` + css per design: `guiTooltip` message, `position`, `showDelay`
+    (default 500), `hideDelay`, `disabled`; hover/focus/long-press → after delay `openConnected` a
+    `role="tooltip"` panel; set `aria-describedby` on the trigger while visible; pointerleave/blur/
+    Escape hide (Escape keeps focus on trigger); container `--md-sys-color-inverse-surface` /
+    `--md-sys-color-inverse-on-surface`, height 24dp, padding 8dp, corner-extra-small.
+  - _Requirements: 11.1–11.7, 13.1–13.3, 14.1_
+
+- [ ] 24. Implement the rich tooltip (panel + trigger)
+  - `libs/ui/tooltip/src/rich-tooltip.ts` + css per design: `gui-rich-tooltip` panel projecting
+    subhead/body/actions (up to two `gui-button`s), `role="tooltip"`, surface
+    `--md-sys-color-surface-container`, subhead/body `--md-sys-color-on-surface-variant`, padding
+    12/8/16dp, corner-medium (12dp), elevation level 2; `[guiRichTooltipTrigger]` opens via
+    `openConnected` and is **persistent** (stays open while pointer is over trigger OR panel, closes
+    when over neither after a grace delay); Escape / action activation closes; `aria-describedby` while open.
+  - _Requirements: 12.1–12.5, 13.2, 13.4, 14.1_
+
+- [ ] 25. Tooltip specs + demo
+  - `tooltip.spec.ts`: `aria-describedby` only while visible; Escape hides + focus stays on trigger;
+    disabled/empty never opens.
+  - `rich-tooltip.spec.ts`: panel renders subhead/body/actions; persistent open/close logic; actions focusable.
+  - Demo sections in `apps/web` (plain on icon buttons; rich with actions).
+  - _Requirements: 11.5, 12.2, 13.1, 13.3, 16.3_
+
+- [ ] 26. Checkpoint — Group F verification
+  - Run tooltip specs + Group A overlay spec + `lint build -p ui`. Confirm independently mergeable on top of A.
+
+- [ ] 27. Final checkpoint — everything green
+  - `pnpm exec nx run-many -t lint test build -p ui web` — all green for both projects.
+  - Confirm every new entry point builds via ng-packagr (`nx build ui` produces all new entries).
+  - All 16 requirements traceable to a shipped task; new specs registered in `project.json`.
+  - Dogfood in browser (`nx serve web`) recommended before release — overlay positioning, motion, and
+    geometry are not covered by jsdom specs.
+
+## Notes
+
+### Scope boundaries
+
+- **Dialogs** are out of scope (containment category).
+- **Wavy/expressive progress** is deferred — Group C implements classic flat only (design decision).
+- **Pixel geometry & overlay positioning** are verified by browser dogfood, not jsdom specs (jsdom
+  can't measure layout). Specs assert state/ARIA/DOM structure only.
+
+### Codebase verification findings
+
+- `libs/ui/project.json` `test.options.include` lists each spec path explicitly (relative `../<name>/src/*.spec.ts`)
+  and now also carries `runnerConfig: libs/ui/vitest.config.ts` — append new spec paths there.
+- `tsconfig.base.json` `paths` map confirmed — add one entry per new entry point.
+- `GuiPickerOverlay` (`libs/ui/overlay/src/picker-overlay.ts`) currently exposes only
+  `openDocked`/`openModal`, both of which manage focus — the new snackbar/tooltip openers must NOT, so
+  they are new methods rather than option flags on the existing ones.
+- `@angular/cdk/a11y` is already a dependency (focus-trap usage in picker-overlay) — `LiveAnnouncer`
+  comes from the same package, no new dependency.

--- a/.specs/communication/tasks.md
+++ b/.specs/communication/tasks.md
@@ -141,11 +141,11 @@ New `gui-loading-indicator` (SVG morph). Blast radius: **safe** — independent.
 `GuiSnackbar` service (queue + timer + announce) + `gui-snackbar` surface. Blast radius: **coupled to
 Group A** (uses `openGlobalBottom`); otherwise additive/**safe**.
 
-- [ ] 17. Scaffold the `snackbar` entry point
+- [x] 17. Scaffold the `snackbar` entry point
   - Create `libs/ui/snackbar/{ng-package.json, src/index.ts}`; add path alias; register service + surface specs.
   - _Requirements: 16.1, 16.2_
 
-- [ ] 18. Implement snackbar config + surface
+- [x] 18. Implement snackbar config + surface
   - `libs/ui/snackbar/src/snackbar-config.ts`: `GuiSnackbarConfig`, `GuiSnackbarRef`,
     `GuiSnackbarCloseReason`.
   - `libs/ui/snackbar/src/snackbar.ts` surface component + css: `role="status"`; single/two-line;
@@ -154,7 +154,7 @@ Group A** (uses `openGlobalBottom`); otherwise additive/**safe**.
     `--md-sys-color-inverse-primary`; corner-extra-small (4dp); elevation level 3.
   - _Requirements: 7.1–7.7, 10.2, 15.1_
 
-- [ ] 19. Implement `GuiSnackbar` service (queue, timer, announce, dismissal)
+- [x] 19. Implement `GuiSnackbar` service (queue, timer, announce, dismissal)
   - `libs/ui/snackbar/src/snackbar.service.ts` per design: signal FIFO queue showing one at a time;
     `open(config|string)` → `GuiSnackbarRef`; `dismissAll()`; attach surface via
     `GuiPickerOverlay.openGlobalBottom` (alignment by breakpoint, `aboveFab` offset, max-width);
@@ -164,14 +164,14 @@ Group A** (uses `openGlobalBottom`); otherwise additive/**safe**.
     deterministic; timer side-effects live in the service.
   - _Requirements: 8.1–8.3, 9.1–9.7, 10.1, 10.3, 14.1_
 
-- [ ] 20. Snackbar specs + demo
+- [x] 20. Snackbar specs + demo
   - `snackbar.service.spec.ts`: FIFO one-at-a-time; queues while showing; reports close reason;
     `LiveAnnouncer` called politely; `duration: null` never auto-dismisses; `dismissAll()` clears.
   - `snackbar.spec.ts`: surface renders message/action/close; `role="status"`.
   - Demo buttons in `apps/web` (simple, with-action, action-required, above-FAB).
   - _Requirements: 9.2, 9.3, 9.4, 9.6, 10.1, 16.3_
 
-- [ ] 21. Checkpoint — Group E verification
+- [x] 21. Checkpoint — Group E verification
   - Run snackbar specs + Group A overlay spec + `lint build -p ui`. Confirm Group A is present (coupled);
     confirm independently mergeable on top of A.
 

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -818,6 +818,40 @@
       <div class="ml-4 text-sm text-gray-600">Dot, numeric, capped "999+"</div>
     </div>
 
+    <!-- Progress -->
+    <h2 class="text-xl font-semibold mt-8">Progress</h2>
+    <div class="flex flex-col gap-4 max-w-md">
+      <label class="text-sm text-gray-600">
+        Determinate value: {{ (progressValue() * 100).toFixed(0) }}%
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          [value]="progressValue()"
+          (input)="progressValue.set(+$any($event.target).value)"
+          class="w-full"
+        />
+      </label>
+
+      <div class="flex flex-row gap-6 items-center">
+        <gui-linear-progress
+          [value]="progressValue()"
+          label="Determinate linear"
+          class="flex-1"
+        />
+        <gui-circular-progress
+          [value]="progressValue()"
+          label="Determinate circular"
+        />
+      </div>
+
+      <div class="flex flex-row gap-6 items-center">
+        <gui-linear-progress label="Indeterminate linear" class="flex-1" />
+        <gui-circular-progress label="Indeterminate circular" />
+      </div>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -860,6 +860,30 @@
       <div class="ml-4 text-sm text-gray-600">Default, contained</div>
     </div>
 
+    <!-- Snackbar -->
+    <h2 class="text-xl font-semibold mt-8">Snackbar</h2>
+    <div class="flex flex-row flex-wrap gap-3 items-center">
+      <button gui-button variant="filled" type="button" (click)="showSnackbar()">
+        Simple
+      </button>
+      <button
+        gui-button
+        variant="filled"
+        type="button"
+        (click)="showSnackbarWithAction()"
+      >
+        With action
+      </button>
+      <button
+        gui-button
+        variant="filled"
+        type="button"
+        (click)="showSnackbarRequired()"
+      >
+        Action required (two-line)
+      </button>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -884,6 +884,46 @@
       </button>
     </div>
 
+    <!-- Tooltips -->
+    <h2 class="text-xl font-semibold mt-8">Tooltips</h2>
+    <div class="flex flex-row gap-6 items-center">
+      <button
+        gui-icon-button
+        variant="standard"
+        aria-label="Settings"
+        guiTooltip="Settings"
+      >
+        <gui-icon>★</gui-icon>
+      </button>
+      <button
+        gui-icon-button
+        variant="standard"
+        aria-label="Search"
+        guiTooltip="Search the catalog"
+        position="below"
+      >
+        <gui-icon>☆</gui-icon>
+      </button>
+
+      <gui-rich-tooltip #rt>
+        <span guiRichTooltipSubhead>Encrypted storage</span>
+        Your files are encrypted at rest and in transit.
+        <div guiRichTooltipActions>
+          <button gui-button variant="text" type="button">Learn more</button>
+          <button gui-button variant="text" type="button">Dismiss</button>
+        </div>
+      </gui-rich-tooltip>
+      <button
+        gui-button
+        variant="outlined"
+        type="button"
+        [guiRichTooltipTrigger]="rt"
+      >
+        Rich tooltip
+      </button>
+      <div class="ml-4 text-sm text-gray-600">Plain (hover/focus), rich</div>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -795,26 +795,29 @@
 
     <!-- Badge -->
     <h2 class="text-xl font-semibold mt-8">Badge</h2>
+    <!-- [guiBadge] anchors to its host's top-trailing corner and overflows it,
+         so it must sit on a non-clipping element. Icon buttons clip overflow for
+         their state layer, so wrap them in an inline-flex badge host. -->
     <div class="flex flex-row gap-6 items-center">
-      <button gui-icon-button variant="standard" aria-label="Notifications" guiBadge>
-        <gui-icon>★</gui-icon>
-      </button>
-      <button
-        gui-icon-button
-        variant="standard"
-        aria-label="Messages, 3 unread"
-        [guiBadge]="3"
-      >
-        <gui-icon>✉</gui-icon>
-      </button>
-      <button
-        gui-icon-button
-        variant="standard"
-        aria-label="Alerts, 999+ unread"
-        [guiBadge]="1500"
-      >
-        <gui-icon>☆</gui-icon>
-      </button>
+      <span guiBadge class="inline-flex">
+        <button gui-icon-button variant="standard" aria-label="Notifications">
+          <gui-icon>★</gui-icon>
+        </button>
+      </span>
+      <span [guiBadge]="3" class="inline-flex">
+        <button gui-icon-button variant="standard" aria-label="Messages, 3 unread">
+          <gui-icon>✉</gui-icon>
+        </button>
+      </span>
+      <span [guiBadge]="1500" class="inline-flex">
+        <button
+          gui-icon-button
+          variant="standard"
+          aria-label="Alerts, 999+ unread"
+        >
+          <gui-icon>☆</gui-icon>
+        </button>
+      </span>
       <div class="ml-4 text-sm text-gray-600">Dot, numeric, capped "999+"</div>
     </div>
 

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -793,6 +793,31 @@
       />
     </div>
 
+    <!-- Badge -->
+    <h2 class="text-xl font-semibold mt-8">Badge</h2>
+    <div class="flex flex-row gap-6 items-center">
+      <button gui-icon-button variant="standard" aria-label="Notifications" guiBadge>
+        <gui-icon>★</gui-icon>
+      </button>
+      <button
+        gui-icon-button
+        variant="standard"
+        aria-label="Messages, 3 unread"
+        [guiBadge]="3"
+      >
+        <gui-icon>✉</gui-icon>
+      </button>
+      <button
+        gui-icon-button
+        variant="standard"
+        aria-label="Alerts, 999+ unread"
+        [guiBadge]="1500"
+      >
+        <gui-icon>☆</gui-icon>
+      </button>
+      <div class="ml-4 text-sm text-gray-600">Dot, numeric, capped "999+"</div>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -852,6 +852,14 @@
       </div>
     </div>
 
+    <!-- Loading indicator -->
+    <h2 class="text-xl font-semibold mt-8">Loading indicator</h2>
+    <div class="flex flex-row gap-8 items-center">
+      <gui-loading-indicator label="Loading" />
+      <gui-loading-indicator variant="contained" label="Loading" />
+      <div class="ml-4 text-sm text-gray-600">Default, contained</div>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -46,6 +46,7 @@ import {
 } from '@ngguide/ui/date-picker';
 import { GuiDateRange, GuiTime } from '@ngguide/ui/datetime';
 import { TimePickerComponent } from '@ngguide/ui/time-picker';
+import { GuiBadge } from '@ngguide/ui/badge';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -81,6 +82,7 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     DatePickerComponent,
     DateRangePickerComponent,
     TimePickerComponent,
+    GuiBadge,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -53,6 +53,11 @@ import {
 } from '@ngguide/ui/progress';
 import { GuiLoadingIndicator } from '@ngguide/ui/loading-indicator';
 import { GuiSnackbar } from '@ngguide/ui/snackbar';
+import {
+  GuiRichTooltip,
+  GuiRichTooltipTrigger,
+  GuiTooltip,
+} from '@ngguide/ui/tooltip';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -92,6 +97,9 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiLinearProgress,
     GuiCircularProgress,
     GuiLoadingIndicator,
+    GuiTooltip,
+    GuiRichTooltip,
+    GuiRichTooltipTrigger,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -52,6 +52,7 @@ import {
   GuiLinearProgress,
 } from '@ngguide/ui/progress';
 import { GuiLoadingIndicator } from '@ngguide/ui/loading-indicator';
+import { GuiSnackbar } from '@ngguide/ui/snackbar';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -118,6 +119,29 @@ export class AppComponent {
 
   /** Determinate progress demo value (0..1). */
   readonly progressValue = signal(0.4);
+
+  private readonly snackbar = inject(GuiSnackbar);
+
+  /** Demo: a simple auto-dismissing snackbar. */
+  showSnackbar(): void {
+    this.snackbar.open('Profile saved');
+  }
+
+  /** Demo: a snackbar with an action. */
+  showSnackbarWithAction(): void {
+    const ref = this.snackbar.open({ message: 'Message deleted', action: 'Undo' });
+    ref.onAction.subscribe(() => this.snackbar.open('Restore complete'));
+  }
+
+  /** Demo: an action-required snackbar (no auto-dismiss) with a close button. */
+  showSnackbarRequired(): void {
+    this.snackbar.open({
+      message: 'Connection lost — changes are saved locally and will sync',
+      action: 'Retry',
+      showClose: true,
+      duration: null,
+    });
+  }
 
   sizes: GuiSize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
   variants: GuiButtonVariant[] = [

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -47,6 +47,10 @@ import {
 import { GuiDateRange, GuiTime } from '@ngguide/ui/datetime';
 import { TimePickerComponent } from '@ngguide/ui/time-picker';
 import { GuiBadge } from '@ngguide/ui/badge';
+import {
+  GuiCircularProgress,
+  GuiLinearProgress,
+} from '@ngguide/ui/progress';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -83,6 +87,8 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     DateRangePickerComponent,
     TimePickerComponent,
     GuiBadge,
+    GuiLinearProgress,
+    GuiCircularProgress,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,
@@ -107,6 +113,9 @@ export class AppComponent {
       customColors: [{ name: 'brand-success', value: '#2e7d32' }],
     });
   }
+
+  /** Determinate progress demo value (0..1). */
+  readonly progressValue = signal(0.4);
 
   sizes: GuiSize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
   variants: GuiButtonVariant[] = [

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -51,6 +51,7 @@ import {
   GuiCircularProgress,
   GuiLinearProgress,
 } from '@ngguide/ui/progress';
+import { GuiLoadingIndicator } from '@ngguide/ui/loading-indicator';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -89,6 +90,7 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiBadge,
     GuiLinearProgress,
     GuiCircularProgress,
+    GuiLoadingIndicator,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,

--- a/libs/ui/badge/ng-package.json
+++ b/libs/ui/badge/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/badge/src/badge.spec.ts
+++ b/libs/ui/badge/src/badge.spec.ts
@@ -1,0 +1,80 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiBadge } from './badge';
+
+@Component({
+  imports: [GuiBadge],
+  template: `<button
+    [guiBadge]="value"
+    [guiBadgeMax]="max"
+    [guiBadgeHidden]="hidden"
+  >
+    host
+  </button>`,
+})
+class HostComponent {
+  value: number | string | null = null;
+  max = 999;
+  hidden = false;
+}
+
+describe('GuiBadge', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<HostComponent>>;
+  let host: HostComponent;
+
+  function hostEl(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+  }
+  function badgeEl(): HTMLSpanElement | null {
+    return fixture.nativeElement.querySelector('.gui-badge');
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('renders a small dot with no text when there is no value', () => {
+    fixture.detectChanges();
+
+    expect(hostEl().getAttribute('data-gui-badge-variant')).toBe('small');
+    expect(badgeEl()).not.toBeNull();
+    expect(badgeEl()?.textContent?.trim()).toBe('');
+  });
+
+  it('renders a large numeric badge when a value is present', () => {
+    host.value = 3;
+    fixture.detectChanges();
+
+    expect(hostEl().getAttribute('data-gui-badge-variant')).toBe('large');
+    expect(badgeEl()?.textContent?.trim()).toBe('3');
+  });
+
+  it('caps the value as "{max}+" when it exceeds max', () => {
+    host.value = 1500;
+    fixture.detectChanges();
+
+    expect(badgeEl()?.textContent?.trim()).toBe('999+');
+  });
+
+  it('marks the badge graphic aria-hidden', () => {
+    fixture.detectChanges();
+
+    expect(badgeEl()?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('sets data-gui-badge-hidden on the host when hidden', () => {
+    host.value = 5;
+    host.hidden = true;
+    fixture.detectChanges();
+
+    expect(hostEl().getAttribute('data-gui-badge-hidden')).toBe('true');
+  });
+
+  it('treats an empty string value as a dot', () => {
+    host.value = '';
+    fixture.detectChanges();
+
+    expect(hostEl().getAttribute('data-gui-badge-variant')).toBe('small');
+  });
+});

--- a/libs/ui/badge/src/badge.ts
+++ b/libs/ui/badge/src/badge.ts
@@ -20,6 +20,10 @@ import {
  * The injected badge graphic is `aria-hidden`; the meaning must be conveyed by
  * the host's own accessible name (e.g. `aria-label="Notifications, 3 unread"`).
  *
+ * The badge overflows the host's bounds, so the host must not clip overflow.
+ * Elements that clip for a state layer (e.g. icon buttons) should be wrapped in
+ * a non-clipping badge host such as `<span guiBadge><button …>…</button></span>`.
+ *
  * Requires the kit theme stylesheet (`@ngguide/ui/styles/theme.css`), which
  * carries the `.gui-badge` styling.
  */

--- a/libs/ui/badge/src/badge.ts
+++ b/libs/ui/badge/src/badge.ts
@@ -1,0 +1,82 @@
+import {
+  Directive,
+  ElementRef,
+  Renderer2,
+  booleanAttribute,
+  computed,
+  effect,
+  inject,
+  input,
+  numberAttribute,
+} from '@angular/core';
+
+/**
+ * M3 badge — a small status overlay anchored to the top-trailing corner of its
+ * host element (typically an icon button or avatar).
+ *
+ * - No `guiBadge` value (or empty string) ⇒ a 6dp **dot** (small variant).
+ * - A value present ⇒ a **numeric** badge (large variant), capped as `"{max}+"`.
+ *
+ * The injected badge graphic is `aria-hidden`; the meaning must be conveyed by
+ * the host's own accessible name (e.g. `aria-label="Notifications, 3 unread"`).
+ *
+ * Requires the kit theme stylesheet (`@ngguide/ui/styles/theme.css`), which
+ * carries the `.gui-badge` styling.
+ */
+@Directive({
+  selector: '[guiBadge]',
+  host: {
+    class: 'gui-badge-host',
+    '[style.position]': '"relative"',
+    '[attr.data-gui-badge-variant]': 'variant()',
+    '[attr.data-gui-badge-hidden]': 'isHidden() ? "true" : null',
+  },
+})
+export class GuiBadge {
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private badgeEl: HTMLSpanElement | null = null;
+
+  /** Numeric/string value. Empty/absent ⇒ small dot; present ⇒ large numeric badge. */
+  readonly value = input<number | string | null>(null, { alias: 'guiBadge' });
+  /** Max before the `"{max}+"` cap. M3 does not publish the number; default 999. */
+  readonly max = input(999, { alias: 'guiBadgeMax', transform: numberAttribute });
+  /** Force-hide without removing the directive. */
+  readonly hidden = input(false, {
+    alias: 'guiBadgeHidden',
+    transform: booleanAttribute,
+  });
+
+  protected readonly variant = computed<'small' | 'large'>(() =>
+    this.value() === null || this.value() === '' ? 'small' : 'large',
+  );
+  protected readonly isHidden = computed(() => this.hidden());
+  /** Capped display text for the large badge (e.g. "999+"). */
+  protected readonly display = computed(() => {
+    const v = this.value();
+    if (typeof v === 'number' && v > this.max()) {
+      return `${this.max()}+`;
+    }
+    return v == null ? '' : String(v);
+  });
+
+  constructor() {
+    effect(() => {
+      const el = this.ensureBadge();
+      // Only the large (numeric) variant carries text; the small dot is empty.
+      const text = this.variant() === 'large' ? this.display() : '';
+      this.renderer.setProperty(el, 'textContent', text);
+    });
+  }
+
+  private ensureBadge(): HTMLSpanElement {
+    if (!this.badgeEl) {
+      const el = this.renderer.createElement('span') as HTMLSpanElement;
+      this.renderer.addClass(el, 'gui-badge');
+      this.renderer.setAttribute(el, 'aria-hidden', 'true');
+      this.renderer.appendChild(this.host.nativeElement, el);
+      this.badgeEl = el;
+    }
+    return this.badgeEl;
+  }
+}

--- a/libs/ui/badge/src/index.ts
+++ b/libs/ui/badge/src/index.ts
@@ -1,0 +1,1 @@
+export * from './badge';

--- a/libs/ui/loading-indicator/ng-package.json
+++ b/libs/ui/loading-indicator/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/loading-indicator/src/index.ts
+++ b/libs/ui/loading-indicator/src/index.ts
@@ -1,0 +1,1 @@
+export * from './loading-indicator';

--- a/libs/ui/loading-indicator/src/loading-indicator.css
+++ b/libs/ui/loading-indicator/src/loading-indicator.css
@@ -1,0 +1,45 @@
+/* M3 loading indicator — 48dp overall, ~38dp shape, spinning + morphing cookie. */
+:host {
+  display: inline-block;
+  inline-size: 48px;
+  block-size: 48px;
+  line-height: 0;
+}
+
+.gui-loading-svg {
+  inline-size: 100%;
+  block-size: 100%;
+  transform-origin: center;
+  animation: gui-loading-spin 2.5s linear infinite;
+}
+
+.gui-loading-shape {
+  fill: var(--md-sys-color-primary);
+}
+
+/* Contained — shape sits on a filled circular container. */
+:host([data-variant='contained']) {
+  background-color: var(--md-sys-color-primary-container);
+  border-radius: 50%;
+}
+
+:host([data-variant='contained']) .gui-loading-shape {
+  fill: var(--md-sys-color-on-primary-container);
+}
+
+@keyframes gui-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Reduced motion — rest at a static shape; surface stays visible and busy. */
+:host([data-reduced-motion='true']) .gui-loading-svg {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gui-loading-svg {
+    animation: none;
+  }
+}

--- a/libs/ui/loading-indicator/src/loading-indicator.spec.ts
+++ b/libs/ui/loading-indicator/src/loading-indicator.spec.ts
@@ -1,0 +1,80 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiLoadingIndicator } from './loading-indicator';
+
+@Component({
+  imports: [GuiLoadingIndicator],
+  template: `<gui-loading-indicator [variant]="variant" [label]="label" />`,
+})
+class HostComponent {
+  variant: 'default' | 'contained' = 'default';
+  label: string | undefined;
+}
+
+describe('GuiLoadingIndicator', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<HostComponent>>;
+  let host: HostComponent;
+
+  function el(): HTMLElement {
+    return fixture.nativeElement.querySelector('gui-loading-indicator');
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('renders an SVG path and is an indeterminate progressbar', () => {
+    fixture.detectChanges();
+
+    expect(el().getAttribute('role')).toBe('progressbar');
+    expect(el().getAttribute('aria-busy')).toBe('true');
+    expect(el().getAttribute('aria-valuenow')).toBeNull();
+    const path = el().querySelector('.gui-loading-shape');
+    expect(path).not.toBeNull();
+    expect(path?.getAttribute('d')).toMatch(/^M/);
+  });
+
+  it('defaults the accessible label to "Loading"', () => {
+    fixture.detectChanges();
+    expect(el().getAttribute('aria-label')).toBe('Loading');
+  });
+
+  it('uses a provided label', () => {
+    host.label = 'Fetching results';
+    fixture.detectChanges();
+    expect(el().getAttribute('aria-label')).toBe('Fetching results');
+  });
+
+  it('reflects the variant on the host', () => {
+    fixture.detectChanges();
+    expect(el().getAttribute('data-variant')).toBe('default');
+
+    const contained = TestBed.createComponent(HostComponent);
+    contained.componentInstance.variant = 'contained';
+    contained.detectChanges();
+    expect(
+      (
+        contained.nativeElement.querySelector(
+          'gui-loading-indicator',
+        ) as HTMLElement
+      ).getAttribute('data-variant'),
+    ).toBe('contained');
+  });
+
+  it('produces a deterministic shape path (stable across instances)', () => {
+    fixture.detectChanges();
+    const d1 = el()
+      .querySelector('.gui-loading-shape')
+      ?.getAttribute('d');
+
+    const other = TestBed.createComponent(HostComponent);
+    other.detectChanges();
+    const d2 = (
+      other.nativeElement.querySelector('.gui-loading-shape') as SVGPathElement
+    ).getAttribute('d');
+
+    expect(d1).toBe(d2);
+    expect(d1).toBeTruthy();
+  });
+});

--- a/libs/ui/loading-indicator/src/loading-indicator.ts
+++ b/libs/ui/loading-indicator/src/loading-indicator.ts
@@ -1,0 +1,91 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { GuiReducedMotion } from '@ngguide/ui/interaction';
+
+/**
+ * Builds a deterministic "cookie" (multi-lobed rounded) path on a 48×48 canvas.
+ * Pure trig — no `Math.random`/`Date.now`, so output is identical on every render
+ * (SSR-safe and stable for hydration).
+ */
+function cookiePath(baseR: number, amp: number, lobes: number): string {
+  const cx = 24;
+  const cy = 24;
+  const steps = 120;
+  let d = '';
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * Math.PI * 2;
+    const r = baseR + amp * Math.cos(lobes * t);
+    const x = (cx + r * Math.cos(t)).toFixed(2);
+    const y = (cy + r * Math.sin(t)).toFixed(2);
+    d += i === 0 ? `M${x} ${y}` : `L${x} ${y}`;
+  }
+  return `${d}Z`;
+}
+
+// Two M3-inspired shapes the indicator morphs between. Same segment count/type so
+// SMIL can interpolate `d` point-for-point.
+const SHAPE_A = cookiePath(14, 4, 7);
+const SHAPE_B = cookiePath(15, 3, 4);
+
+/**
+ * M3 loading indicator (SVG morphing shapes).
+ *
+ * An indeterminate, always-busy indicator: a single SVG `<path>` whose `d`
+ * morphs between two deterministic shapes (declarative SMIL) while the canvas
+ * spins (CSS). Under `prefers-reduced-motion` the morph and spin stop at a
+ * resting shape while the surface stays visible and `aria-busy`.
+ *
+ * `role="progressbar"` with no `aria-valuenow` (indeterminate).
+ */
+@Component({
+  selector: 'gui-loading-indicator',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'gui-loading-indicator',
+    role: 'progressbar',
+    'aria-busy': 'true',
+    '[attr.data-variant]': 'variant()',
+    '[attr.data-reduced-motion]': 'reduced() ? "true" : null',
+    '[attr.aria-label]': 'label() || "Loading"',
+  },
+  template: `
+    <svg
+      class="gui-loading-svg"
+      viewBox="0 0 48 48"
+      focusable="false"
+      aria-hidden="true"
+    >
+      <path class="gui-loading-shape" [attr.d]="shapeA">
+        @if (!reduced()) {
+          <animate
+            attributeName="d"
+            [attr.values]="morphValues"
+            dur="1.2s"
+            repeatCount="indefinite"
+            calcMode="spline"
+            keyTimes="0;0.5;1"
+            keySplines="0.4 0 0.2 1;0.4 0 0.2 1"
+          />
+        }
+      </path>
+    </svg>
+  `,
+  styleUrl: './loading-indicator.css',
+})
+export class GuiLoadingIndicator {
+  private readonly reducedMotion = inject(GuiReducedMotion);
+
+  readonly variant = input<'default' | 'contained'>('default');
+  readonly label = input<string>();
+
+  protected readonly shapeA = SHAPE_A;
+  protected readonly morphValues = `${SHAPE_A};${SHAPE_B};${SHAPE_A}`;
+  protected readonly reduced = computed(() =>
+    this.reducedMotion.prefersReducedMotion(),
+  );
+}

--- a/libs/ui/overlay/src/picker-overlay.spec.ts
+++ b/libs/ui/overlay/src/picker-overlay.spec.ts
@@ -88,4 +88,51 @@ describe('GuiPickerOverlay', () => {
     handle.close();
     expect(handle.ref.hasAttached()).toBe(false);
   });
+
+  it('openGlobalBottom attaches without a backdrop and does not move focus', () => {
+    const trigger = fixture.nativeElement.querySelector(
+      'button',
+    ) as HTMLButtonElement;
+    document.body.appendChild(fixture.nativeElement);
+    trigger.focus();
+    const focusedBefore = document.activeElement;
+
+    const portal = host.buildPortal();
+    const handle = service.openGlobalBottom(portal, { maxWidth: '672px' });
+
+    expect(handle.ref.hasAttached()).toBe(true);
+    // No backdrop element is created for the global-bottom surface.
+    expect(handle.ref.backdropElement).toBeFalsy();
+    // Focus is not stolen by the surface.
+    expect(document.activeElement).toBe(focusedBefore);
+
+    handle.close();
+    expect(handle.ref.hasAttached()).toBe(false);
+    // Closing does not restore/alter focus either (no focus management).
+    expect(document.activeElement).toBe(focusedBefore);
+
+    fixture.nativeElement.remove();
+  });
+
+  it('openConnected attaches connected to an origin without capturing focus', () => {
+    const origin = fixture.nativeElement.querySelector(
+      'button',
+    ) as HTMLButtonElement;
+    document.body.appendChild(fixture.nativeElement);
+    origin.focus();
+    const focusedBefore = document.activeElement;
+
+    const portal = host.buildPortal();
+    const handle = service.openConnected(portal, { origin });
+
+    expect(handle.ref.hasAttached()).toBe(true);
+    expect(handle.ref.backdropElement).toBeFalsy();
+    expect(document.activeElement).toBe(focusedBefore);
+
+    handle.close();
+    expect(handle.ref.hasAttached()).toBe(false);
+    expect(document.activeElement).toBe(focusedBefore);
+
+    fixture.nativeElement.remove();
+  });
 });

--- a/libs/ui/overlay/src/picker-overlay.ts
+++ b/libs/ui/overlay/src/picker-overlay.ts
@@ -1,10 +1,11 @@
 import { ConfigurableFocusTrapFactory, FocusTrap } from '@angular/cdk/a11y';
 import {
+  ConnectedPosition,
   Overlay,
   OverlayRef,
   STANDARD_DROPDOWN_BELOW_POSITIONS,
 } from '@angular/cdk/overlay';
-import { TemplatePortal } from '@angular/cdk/portal';
+import { Portal, TemplatePortal } from '@angular/cdk/portal';
 import { Injectable, inject } from '@angular/core';
 import { Observable, Subject, takeUntil } from 'rxjs';
 
@@ -15,6 +16,23 @@ export interface GuiDockedConfig {
 
 export interface GuiModalConfig {
   ariaLabel?: string;
+}
+
+export interface GuiGlobalBottomConfig {
+  /** Horizontal alignment of the bottom-anchored surface. Caller drives via breakpoint. */
+  alignment?: 'center' | 'leading';
+  /** Distance from the bottom edge, e.g. '16px' or an above-FAB offset. */
+  bottomOffset?: string;
+  /** Max inline width (M3 snackbar max width). */
+  maxWidth?: string;
+  panelClass?: string | string[];
+}
+
+export interface GuiConnectedConfig {
+  origin: HTMLElement;
+  /** Preferred connected positions (e.g. above-then-below for tooltips). */
+  positions?: ConnectedPosition[];
+  panelClass?: string | string[];
 }
 
 export interface GuiOverlayHandle {
@@ -107,6 +125,72 @@ export class GuiPickerOverlay {
           handle.close();
         }
       });
+
+    return handle;
+  }
+
+  /**
+   * Bottom-anchored floating surface (snackbar). GlobalPositionStrategy, NO backdrop,
+   * NO focus trap, NO focus capture/restore — snackbars must not steal focus.
+   * Scroll strategy: reposition.
+   */
+  openGlobalBottom(
+    portal: Portal<unknown>,
+    cfg: GuiGlobalBottomConfig = {},
+  ): GuiOverlayHandle {
+    const bottomOffset = cfg.bottomOffset ?? '16px';
+    const positionBuilder = this.overlay
+      .position()
+      .global()
+      .bottom(bottomOffset);
+
+    const positionStrategy =
+      cfg.alignment === 'leading'
+        ? positionBuilder.left('16px')
+        : positionBuilder.centerHorizontally();
+
+    const ref = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      hasBackdrop: false,
+      maxWidth: cfg.maxWidth,
+      panelClass: cfg.panelClass,
+    });
+
+    const closed$ = new Subject<void>();
+    const handle = this.makeHandle(ref, closed$, null, null);
+
+    ref.attach(portal);
+
+    return handle;
+  }
+
+  /**
+   * Connected floating surface anchored to an origin (tooltips).
+   * FlexibleConnectedPositionStrategy, NO backdrop, NO focus capture/restore —
+   * tooltips must not move focus. Scroll strategy: reposition.
+   */
+  openConnected(
+    portal: Portal<unknown>,
+    cfg: GuiConnectedConfig,
+  ): GuiOverlayHandle {
+    const positionStrategy = this.overlay
+      .position()
+      .flexibleConnectedTo(cfg.origin)
+      .withPositions(cfg.positions ?? STANDARD_DROPDOWN_BELOW_POSITIONS)
+      .withViewportMargin(8);
+
+    const ref = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      hasBackdrop: false,
+      panelClass: cfg.panelClass,
+    });
+
+    const closed$ = new Subject<void>();
+    const handle = this.makeHandle(ref, closed$, null, null);
+
+    ref.attach(portal);
 
     return handle;
   }

--- a/libs/ui/progress/ng-package.json
+++ b/libs/ui/progress/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/progress/src/circular-progress.css
+++ b/libs/ui/progress/src/circular-progress.css
@@ -1,0 +1,65 @@
+/* M3 circular progress — 48dp diameter, 4dp stroke, rounded active cap. */
+:host {
+  --_size: 48px;
+  --_stroke: 4px;
+
+  display: inline-block;
+  inline-size: var(--_size);
+  block-size: var(--_size);
+  line-height: 0;
+}
+
+.gui-circular-svg {
+  inline-size: 100%;
+  block-size: 100%;
+  /* Start the determinate arc at 12 o'clock. */
+  transform: rotate(-90deg);
+}
+
+.gui-circular-track {
+  stroke: var(--md-sys-color-secondary-container);
+  stroke-width: var(--_stroke);
+}
+
+.gui-circular-active {
+  stroke: var(--md-sys-color-primary);
+  stroke-width: var(--_stroke);
+  /* stroke-dasharray / stroke-dashoffset supplied inline (determinate). */
+  transition: stroke-dashoffset 0.2s var(--md-sys-motion-easing-standard, ease);
+}
+
+/* Indeterminate — rotate the whole SVG; the arc length is a fixed fraction. */
+:host([data-mode='indeterminate']) .gui-circular-svg {
+  animation: gui-circular-rotate 1.4s linear infinite;
+}
+
+:host([data-mode='indeterminate']) .gui-circular-active {
+  /* ~25% visible arc that the rotation sweeps around the track. */
+  stroke-dasharray: 34.56 103.67;
+  stroke-dashoffset: 0;
+  transition: none;
+}
+
+@keyframes gui-circular-rotate {
+  to {
+    transform: rotate(270deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :host([data-mode='indeterminate']) .gui-circular-svg {
+    animation: none;
+  }
+  :host([data-mode='indeterminate']) .gui-circular-active {
+    animation: gui-circular-pulse 1.5s ease-in-out infinite;
+  }
+  @keyframes gui-circular-pulse {
+    0%,
+    100% {
+      opacity: 0.4;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+}

--- a/libs/ui/progress/src/circular-progress.spec.ts
+++ b/libs/ui/progress/src/circular-progress.spec.ts
@@ -1,0 +1,73 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiCircularProgress } from './circular-progress';
+
+@Component({
+  imports: [GuiCircularProgress],
+  template: `<gui-circular-progress [value]="value" [label]="label" />`,
+})
+class HostComponent {
+  value: number | null = null;
+  label = 'Loading';
+}
+
+describe('GuiCircularProgress', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<HostComponent>>;
+  let host: HostComponent;
+
+  function el(): HTMLElement {
+    return fixture.nativeElement.querySelector('gui-circular-progress');
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('renders an SVG with a track and active arc', () => {
+    fixture.detectChanges();
+    expect(el().querySelector('svg')).not.toBeNull();
+    expect(el().querySelector('.gui-circular-track')).not.toBeNull();
+    expect(el().querySelector('.gui-circular-active')).not.toBeNull();
+  });
+
+  it('is indeterminate (no aria-valuenow) when value is null', () => {
+    host.value = null;
+    fixture.detectChanges();
+
+    expect(el().getAttribute('data-mode')).toBe('indeterminate');
+    expect(el().getAttribute('aria-valuenow')).toBeNull();
+  });
+
+  it('is determinate and exposes aria-valuenow when value is set', () => {
+    host.value = 0.75;
+    fixture.detectChanges();
+
+    expect(el().getAttribute('data-mode')).toBe('determinate');
+    expect(el().getAttribute('aria-valuenow')).toBe('75');
+  });
+
+  it('fully offsets the active arc at value 0 (no visible progress)', () => {
+    host.value = 0;
+    fixture.detectChanges();
+    const active = el().querySelector('.gui-circular-active') as SVGCircleElement;
+    const circumference = 2 * Math.PI * 22;
+    expect(Number(active.getAttribute('stroke-dashoffset'))).toBeCloseTo(
+      circumference,
+      3,
+    );
+  });
+
+  it('zeroes the active arc offset at value 1 (complete)', () => {
+    host.value = 1;
+    fixture.detectChanges();
+    const active = el().querySelector('.gui-circular-active') as SVGCircleElement;
+    expect(Number(active.getAttribute('stroke-dashoffset'))).toBeCloseTo(0, 3);
+  });
+
+  it('uses round stroke caps on the active arc', () => {
+    fixture.detectChanges();
+    const active = el().querySelector('.gui-circular-active') as SVGCircleElement;
+    expect(active.getAttribute('stroke-linecap')).toBe('round');
+  });
+});

--- a/libs/ui/progress/src/circular-progress.ts
+++ b/libs/ui/progress/src/circular-progress.ts
@@ -1,0 +1,77 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+
+const RADIUS = 22;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+/**
+ * M3 circular progress indicator (SVG rendering).
+ *
+ * - `value` in `0..1` ⇒ **determinate** arc (stroke-dasharray/offset, round caps).
+ * - `value` `null` ⇒ **indeterminate** (rotating arc, paused under `prefers-reduced-motion`).
+ *
+ * Same ARIA contract as the linear variant: `aria-valuenow` only when determinate.
+ */
+@Component({
+  selector: 'gui-circular-progress',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'gui-circular-progress',
+    role: 'progressbar',
+    '[attr.data-mode]': 'mode()',
+    '[attr.aria-label]': 'label() || null',
+    '[attr.aria-valuemin]': 'mode() === "determinate" ? 0 : null',
+    '[attr.aria-valuemax]': 'mode() === "determinate" ? 100 : null',
+    '[attr.aria-valuenow]': 'mode() === "determinate" ? percent() : null',
+  },
+  template: `
+    <svg
+      class="gui-circular-svg"
+      viewBox="0 0 48 48"
+      focusable="false"
+      aria-hidden="true"
+    >
+      <circle
+        class="gui-circular-track"
+        cx="24"
+        cy="24"
+        [attr.r]="radius"
+        fill="none"
+      />
+      <circle
+        class="gui-circular-active"
+        cx="24"
+        cy="24"
+        [attr.r]="radius"
+        fill="none"
+        stroke-linecap="round"
+        [attr.stroke-dasharray]="circumference"
+        [attr.stroke-dashoffset]="dashOffset()"
+      />
+    </svg>
+  `,
+  styleUrl: './circular-progress.css',
+})
+export class GuiCircularProgress {
+  /** 0..1. null ⇒ indeterminate. */
+  readonly value = input<number | null>(null);
+  readonly label = input<string>();
+
+  protected readonly radius = RADIUS;
+  protected readonly circumference = CIRCUMFERENCE;
+
+  protected readonly mode = computed(() =>
+    this.value() == null ? 'indeterminate' : 'determinate',
+  );
+  protected readonly clamped = computed(() =>
+    Math.min(1, Math.max(0, this.value() ?? 0)),
+  );
+  protected readonly percent = computed(() => Math.round(this.clamped() * 100));
+  protected readonly dashOffset = computed(
+    () => CIRCUMFERENCE * (1 - this.clamped()),
+  );
+}

--- a/libs/ui/progress/src/index.ts
+++ b/libs/ui/progress/src/index.ts
@@ -1,0 +1,2 @@
+export * from './linear-progress';
+export * from './circular-progress';

--- a/libs/ui/progress/src/linear-progress.css
+++ b/libs/ui/progress/src/linear-progress.css
@@ -1,0 +1,79 @@
+/* M3 linear progress — track 4dp, rounded ends, active bar + stop indicator. */
+:host {
+  --_track-height: 4px;
+  --_stop-size: 4px;
+
+  position: relative;
+  display: block;
+  width: 100%;
+  height: var(--_track-height);
+  overflow: hidden;
+}
+
+.gui-linear-track,
+.gui-linear-active {
+  position: absolute;
+  inset: 0;
+  height: var(--_track-height);
+  border-radius: calc(var(--_track-height) / 2);
+}
+
+.gui-linear-track {
+  background-color: var(--md-sys-color-secondary-container);
+}
+
+.gui-linear-active {
+  background-color: var(--md-sys-color-primary);
+  transform-origin: left center;
+  /* `transform: scaleX(value)` is supplied inline (determinate). */
+}
+
+/* Stop indicator — a 4dp dot pinned to the trailing edge of the track. */
+.gui-linear-stop {
+  position: absolute;
+  top: 50%;
+  inset-inline-end: 0;
+  width: var(--_stop-size);
+  height: var(--_stop-size);
+  border-radius: 50%;
+  background-color: var(--md-sys-color-primary);
+  transform: translateY(-50%);
+}
+
+/* Indeterminate — the inline scaleX is ignored; an animated band sweeps the track. */
+:host([data-mode='indeterminate']) .gui-linear-active {
+  transform-origin: left center;
+  animation: gui-linear-indeterminate 2s linear infinite;
+}
+
+:host([data-mode='indeterminate']) .gui-linear-stop {
+  display: none;
+}
+
+@keyframes gui-linear-indeterminate {
+  0% {
+    transform: translateX(-100%) scaleX(0.3);
+  }
+  50% {
+    transform: translateX(50%) scaleX(0.5);
+  }
+  100% {
+    transform: translateX(150%) scaleX(0.3);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :host([data-mode='indeterminate']) .gui-linear-active {
+    animation: gui-linear-pulse 1.5s ease-in-out infinite;
+    transform: scaleX(1);
+  }
+  @keyframes gui-linear-pulse {
+    0%,
+    100% {
+      opacity: 0.4;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+}

--- a/libs/ui/progress/src/linear-progress.spec.ts
+++ b/libs/ui/progress/src/linear-progress.spec.ts
@@ -1,0 +1,78 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiLinearProgress } from './linear-progress';
+
+@Component({
+  imports: [GuiLinearProgress],
+  template: `<gui-linear-progress [value]="value" [label]="label" />`,
+})
+class HostComponent {
+  value: number | null = null;
+  label = 'Loading';
+}
+
+describe('GuiLinearProgress', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<HostComponent>>;
+  let host: HostComponent;
+
+  function el(): HTMLElement {
+    return fixture.nativeElement.querySelector('gui-linear-progress');
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('exposes role="progressbar"', () => {
+    fixture.detectChanges();
+    expect(el().getAttribute('role')).toBe('progressbar');
+  });
+
+  it('is indeterminate (no aria-valuenow) when value is null', () => {
+    host.value = null;
+    fixture.detectChanges();
+
+    expect(el().getAttribute('data-mode')).toBe('indeterminate');
+    expect(el().getAttribute('aria-valuenow')).toBeNull();
+  });
+
+  it('is determinate and exposes aria-valuenow when value is set', () => {
+    host.value = 0.42;
+    fixture.detectChanges();
+
+    expect(el().getAttribute('data-mode')).toBe('determinate');
+    expect(el().getAttribute('aria-valuenow')).toBe('42');
+    expect(el().getAttribute('aria-valuemin')).toBe('0');
+    expect(el().getAttribute('aria-valuemax')).toBe('100');
+  });
+
+  it('clamps values outside 0..1', () => {
+    host.value = 1.5;
+    fixture.detectChanges();
+    expect(el().getAttribute('aria-valuenow')).toBe('100');
+
+    const fixture2 = TestBed.createComponent(HostComponent);
+    fixture2.componentInstance.value = -0.5;
+    fixture2.detectChanges();
+    expect(
+      (
+        fixture2.nativeElement.querySelector('gui-linear-progress') as HTMLElement
+      ).getAttribute('aria-valuenow'),
+    ).toBe('0');
+  });
+
+  it('distinguishes value 0 (determinate) from null (indeterminate)', () => {
+    host.value = 0;
+    fixture.detectChanges();
+    expect(el().getAttribute('data-mode')).toBe('determinate');
+    expect(el().getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  it('scales the active bar by the clamped value', () => {
+    host.value = 0.5;
+    fixture.detectChanges();
+    const active = el().querySelector('.gui-linear-active') as HTMLElement;
+    expect(active.style.transform).toBe('scaleX(0.5)');
+  });
+});

--- a/libs/ui/progress/src/linear-progress.ts
+++ b/libs/ui/progress/src/linear-progress.ts
@@ -1,0 +1,51 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+
+/**
+ * M3 linear progress indicator (CSS rendering).
+ *
+ * - `value` in `0..1` ⇒ **determinate** (track + scaling active bar + stop indicator).
+ * - `value` `null` ⇒ **indeterminate** (animated, paused under `prefers-reduced-motion`).
+ *
+ * Exposes `role="progressbar"` with `aria-valuemin/max/now` only when determinate;
+ * indeterminate omits `aria-valuenow` per ARIA APG.
+ */
+@Component({
+  selector: 'gui-linear-progress',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'gui-linear-progress',
+    role: 'progressbar',
+    '[attr.data-mode]': 'mode()',
+    '[attr.aria-label]': 'label() || null',
+    '[attr.aria-valuemin]': 'mode() === "determinate" ? 0 : null',
+    '[attr.aria-valuemax]': 'mode() === "determinate" ? 100 : null',
+    '[attr.aria-valuenow]': 'mode() === "determinate" ? percent() : null',
+  },
+  template: `
+    <div class="gui-linear-track"></div>
+    <div class="gui-linear-active" [style.transform]="activeTransform()"></div>
+    <div class="gui-linear-stop"></div>
+  `,
+  styleUrl: './linear-progress.css',
+})
+export class GuiLinearProgress {
+  /** 0..1. null ⇒ indeterminate. */
+  readonly value = input<number | null>(null);
+  readonly label = input<string>();
+
+  protected readonly mode = computed(() =>
+    this.value() == null ? 'indeterminate' : 'determinate',
+  );
+  protected readonly clamped = computed(() =>
+    Math.min(1, Math.max(0, this.value() ?? 0)),
+  );
+  protected readonly percent = computed(() => Math.round(this.clamped() * 100));
+  protected readonly activeTransform = computed(
+    () => `scaleX(${this.clamped()})`,
+  );
+}

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -40,6 +40,7 @@
         "tsConfig": "libs/ui/tsconfig.spec.json",
         "runnerConfig": "libs/ui/vitest.config.ts",
         "include": [
+          "../badge/src/badge.spec.ts",
           "../button/src/button.spec.ts",
           "../fab/src/fab.spec.ts",
           "../fab/src/extended-fab.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -78,6 +78,8 @@
           "../loading-indicator/src/loading-indicator.spec.ts",
           "../snackbar/src/snackbar.service.spec.ts",
           "../snackbar/src/snackbar.spec.ts",
+          "../tooltip/src/tooltip.spec.ts",
+          "../tooltip/src/rich-tooltip.spec.ts",
           "../date-picker/src/calendar.spec.ts",
           "../date-picker/src/date-picker.spec.ts",
           "../date-picker/src/date-range-picker.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -76,6 +76,8 @@
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",
+          "../snackbar/src/snackbar.service.spec.ts",
+          "../snackbar/src/snackbar.spec.ts",
           "../date-picker/src/calendar.spec.ts",
           "../date-picker/src/date-picker.spec.ts",
           "../date-picker/src/date-range-picker.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -75,6 +75,7 @@
           "../overlay/src/picker-overlay.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
+          "../loading-indicator/src/loading-indicator.spec.ts",
           "../date-picker/src/calendar.spec.ts",
           "../date-picker/src/date-picker.spec.ts",
           "../date-picker/src/date-range-picker.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -73,6 +73,8 @@
           "../datetime/src/intl.spec.ts",
           "../datetime/src/parse.spec.ts",
           "../overlay/src/picker-overlay.spec.ts",
+          "../progress/src/linear-progress.spec.ts",
+          "../progress/src/circular-progress.spec.ts",
           "../date-picker/src/calendar.spec.ts",
           "../date-picker/src/date-picker.spec.ts",
           "../date-picker/src/date-range-picker.spec.ts",

--- a/libs/ui/snackbar/ng-package.json
+++ b/libs/ui/snackbar/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/snackbar/src/index.ts
+++ b/libs/ui/snackbar/src/index.ts
@@ -1,0 +1,3 @@
+export * from './snackbar-config';
+export * from './snackbar';
+export * from './snackbar.service';

--- a/libs/ui/snackbar/src/snackbar-config.ts
+++ b/libs/ui/snackbar/src/snackbar-config.ts
@@ -1,0 +1,91 @@
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+
+export type GuiSnackbarCloseReason =
+  | 'action'
+  | 'dismiss'
+  | 'timeout'
+  | 'swipe'
+  | 'programmatic';
+
+export interface GuiSnackbarConfig {
+  message: string;
+  /** Optional single action affordance. */
+  action?: string;
+  /** Show a trailing close (dismiss) icon. */
+  showClose?: boolean;
+  /**
+   * Auto-dismiss after ms. `null` disables auto-dismiss (for action-required
+   * snackbars). Defaults to a M3-aligned duration.
+   */
+  duration?: number | null;
+  /** Force two-line layout; otherwise inferred from content length. */
+  twoLine?: boolean;
+  /** Lift above a bottom-anchored FAB. `true` ⇒ default offset, string ⇒ explicit offset. */
+  aboveFab?: boolean | string;
+  /** Live-region politeness. Default `'polite'`. */
+  politeness?: 'polite' | 'assertive';
+}
+
+export interface GuiSnackbarRef {
+  /** Emits once with the reason when the snackbar closes. */
+  readonly afterDismissed: Observable<GuiSnackbarCloseReason>;
+  /** Emits when the action is activated. */
+  readonly onAction: Observable<void>;
+  dismiss(reason?: GuiSnackbarCloseReason): void;
+}
+
+/** Default auto-dismiss duration (ms) when `duration` is omitted. M3-aligned. */
+export const GUI_SNACKBAR_DEFAULT_DURATION = 5000;
+
+/** Heuristic threshold (chars) above which a single-action snackbar wraps to two lines. */
+export const GUI_SNACKBAR_TWO_LINE_THRESHOLD = 50;
+
+/** Resolved, defaults-applied data handed to the surface component. */
+export interface GuiSnackbarData {
+  message: string;
+  action?: string;
+  showClose: boolean;
+  twoLine: boolean;
+}
+
+/** Surface → service callbacks (provided to the surface via DI). */
+export interface GuiSnackbarController {
+  activateAction(): void;
+  dismiss(reason?: GuiSnackbarCloseReason): void;
+}
+
+export const GUI_SNACKBAR_DATA = new InjectionToken<GuiSnackbarData>(
+  'GUI_SNACKBAR_DATA',
+);
+export const GUI_SNACKBAR_CONTROLLER =
+  new InjectionToken<GuiSnackbarController>('GUI_SNACKBAR_CONTROLLER');
+
+/**
+ * Normalize a `string | GuiSnackbarConfig` into resolved surface data. Pure and
+ * deterministic — no side effects, no `Date.now`/`Math.random`.
+ */
+export function normalizeSnackbarConfig(
+  config: GuiSnackbarConfig | string,
+): { config: GuiSnackbarConfig; data: GuiSnackbarData } {
+  const cfg: GuiSnackbarConfig =
+    typeof config === 'string' ? { message: config } : config;
+  const twoLine = inferTwoLine(cfg);
+  return {
+    config: cfg,
+    data: {
+      message: cfg.message,
+      action: cfg.action,
+      showClose: cfg.showClose ?? false,
+      twoLine,
+    },
+  };
+}
+
+/** Deterministic two-line inference: explicit `twoLine` wins, else length-based. */
+export function inferTwoLine(config: GuiSnackbarConfig): boolean {
+  if (config.twoLine !== undefined) {
+    return config.twoLine;
+  }
+  return config.message.length > GUI_SNACKBAR_TWO_LINE_THRESHOLD;
+}

--- a/libs/ui/snackbar/src/snackbar.css
+++ b/libs/ui/snackbar/src/snackbar.css
@@ -1,0 +1,48 @@
+/* M3 snackbar surface — inverse color roles, extra-small corner, elevation 3. */
+:host {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-sizing: border-box;
+  min-height: 48px;
+  min-width: 288px;
+  max-width: 100%;
+  padding: 4px 8px 4px 16px;
+  border-radius: var(--md-sys-shape-corner-extra-small, 4px);
+  background-color: var(--md-sys-color-inverse-surface);
+  color: var(--md-sys-color-inverse-on-surface);
+  box-shadow: var(--md-sys-elevation-level3);
+  font-family: var(--md-sys-typescale-body-medium-font);
+  font-weight: var(--md-sys-typescale-body-medium-weight);
+  font-size: var(--md-sys-typescale-body-medium-size);
+  line-height: var(--md-sys-typescale-body-medium-line-height);
+  letter-spacing: var(--md-sys-typescale-body-medium-tracking);
+}
+
+.gui-snackbar-label {
+  flex: 1 1 auto;
+  padding: 10px 0;
+}
+
+/* Two-line layout — taller surface, top-aligned controls. */
+:host([data-two-line='true']) {
+  align-items: flex-start;
+  min-height: 68px;
+}
+
+:host([data-two-line='true']) .gui-snackbar-action,
+:host([data-two-line='true']) .gui-snackbar-close {
+  margin-top: 4px;
+}
+
+/* The action button text uses the inverse-primary role. */
+.gui-snackbar-action {
+  flex: 0 0 auto;
+  --md-comp-button-text-label-color: var(--md-sys-color-inverse-primary);
+  color: var(--md-sys-color-inverse-primary);
+}
+
+.gui-snackbar-close {
+  flex: 0 0 auto;
+  color: var(--md-sys-color-inverse-on-surface);
+}

--- a/libs/ui/snackbar/src/snackbar.service.spec.ts
+++ b/libs/ui/snackbar/src/snackbar.service.spec.ts
@@ -1,0 +1,155 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { ApplicationRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  GuiSnackbarCloseReason,
+  inferTwoLine,
+  normalizeSnackbarConfig,
+} from './snackbar-config';
+import { GuiSnackbar } from './snackbar.service';
+
+describe('normalizeSnackbarConfig', () => {
+  it('wraps a string into a config and applies defaults', () => {
+    const { config, data } = normalizeSnackbarConfig('Saved');
+    expect(config.message).toBe('Saved');
+    expect(data.showClose).toBe(false);
+    expect(data.message).toBe('Saved');
+  });
+
+  it('infers two lines from message length, honoring an explicit flag', () => {
+    expect(inferTwoLine({ message: 'short' })).toBe(false);
+    expect(inferTwoLine({ message: 'x'.repeat(60) })).toBe(true);
+    expect(inferTwoLine({ message: 'x'.repeat(60), twoLine: false })).toBe(
+      false,
+    );
+  });
+});
+
+describe('GuiSnackbar', () => {
+  let service: GuiSnackbar;
+
+  function surfaces(): NodeListOf<Element> {
+    return document.querySelectorAll('gui-snackbar');
+  }
+  function flush(): void {
+    TestBed.inject(ApplicationRef).tick();
+  }
+
+  beforeEach(() => {
+    service = TestBed.inject(GuiSnackbar);
+  });
+
+  afterEach(() => {
+    service.dismissAll();
+  });
+
+  it('shows a single snackbar with the message', () => {
+    service.open('Saved');
+    flush();
+
+    expect(surfaces().length).toBe(1);
+    expect(
+      document.querySelector('.gui-snackbar-label')?.textContent?.trim(),
+    ).toBe('Saved');
+  });
+
+  it('announces the message politely', () => {
+    const announcer = TestBed.inject(LiveAnnouncer);
+    const spy = vi.spyOn(announcer, 'announce');
+
+    service.open('Profile updated');
+
+    expect(spy).toHaveBeenCalledWith('Profile updated', 'polite');
+  });
+
+  it('shows one at a time and reveals the next after dismissal (FIFO)', () => {
+    const first = service.open('First');
+    service.open('Second');
+    flush();
+
+    // Only one surface is shown while the first is active.
+    expect(surfaces().length).toBe(1);
+    expect(
+      document.querySelector('.gui-snackbar-label')?.textContent?.trim(),
+    ).toBe('First');
+
+    first.dismiss('programmatic');
+    flush();
+
+    expect(surfaces().length).toBe(1);
+    expect(
+      document.querySelector('.gui-snackbar-label')?.textContent?.trim(),
+    ).toBe('Second');
+  });
+
+  it('reports the close reason through afterDismissed', () => {
+    const ref = service.open('Saved');
+    let reason: GuiSnackbarCloseReason | undefined;
+    ref.afterDismissed.subscribe((r) => (reason = r));
+
+    ref.dismiss('programmatic');
+
+    expect(reason).toBe('programmatic');
+  });
+
+  it('emits onAction and dismisses with reason "action"', () => {
+    const ref = service.open({ message: 'Deleted', action: 'Undo' });
+    let actioned = false;
+    let reason: GuiSnackbarCloseReason | undefined;
+    ref.onAction.subscribe(() => (actioned = true));
+    ref.afterDismissed.subscribe((r) => (reason = r));
+
+    // Drive the action through the controller surface API.
+    (ref as unknown as { activateAction(): void }).activateAction();
+
+    expect(actioned).toBe(true);
+    expect(reason).toBe('action');
+  });
+
+  it('auto-dismisses after the default duration', () => {
+    vi.useFakeTimers();
+    try {
+      const ref = service.open({ message: 'Saved' });
+      let reason: GuiSnackbarCloseReason | undefined;
+      ref.afterDismissed.subscribe((r) => (reason = r));
+
+      vi.advanceTimersByTime(5000);
+
+      expect(reason).toBe('timeout');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('never auto-dismisses when duration is null', () => {
+    vi.useFakeTimers();
+    try {
+      const ref = service.open({ message: 'Action required', duration: null });
+      let dismissed = false;
+      ref.afterDismissed.subscribe(() => (dismissed = true));
+
+      vi.advanceTimersByTime(60000);
+
+      expect(dismissed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dismissAll clears the queue and closes the current', () => {
+    const first = service.open('First');
+    const second = service.open('Second');
+    let firstReason: GuiSnackbarCloseReason | undefined;
+    let secondReason: GuiSnackbarCloseReason | undefined;
+    first.afterDismissed.subscribe((r) => (firstReason = r));
+    second.afterDismissed.subscribe((r) => (secondReason = r));
+    flush();
+
+    service.dismissAll();
+    flush();
+
+    expect(firstReason).toBe('programmatic');
+    expect(secondReason).toBe('programmatic');
+    expect(surfaces().length).toBe(0);
+  });
+});

--- a/libs/ui/snackbar/src/snackbar.service.ts
+++ b/libs/ui/snackbar/src/snackbar.service.ts
@@ -1,0 +1,254 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { Injectable, Injector, inject, signal } from '@angular/core';
+import { GuiOverlayHandle, GuiPickerOverlay } from '@ngguide/ui/overlay';
+import { Observable, Subject } from 'rxjs';
+import {
+  GUI_SNACKBAR_CONTROLLER,
+  GUI_SNACKBAR_DATA,
+  GUI_SNACKBAR_DEFAULT_DURATION,
+  GuiSnackbarCloseReason,
+  GuiSnackbarConfig,
+  GuiSnackbarController,
+  GuiSnackbarData,
+  GuiSnackbarRef,
+  normalizeSnackbarConfig,
+} from './snackbar-config';
+import { GuiSnackbarSurface } from './snackbar';
+
+/** Pixels of horizontal drag past which a pointer gesture dismisses the snackbar. */
+const SWIPE_THRESHOLD = 80;
+/** Bottom offset (px) used when lifting above a default-size bottom FAB. */
+const ABOVE_FAB_OFFSET = '88px';
+/** Viewport width (px) at/above which the snackbar aligns leading instead of centered. */
+const LEADING_BREAKPOINT = 768;
+
+class SnackbarRefImpl implements GuiSnackbarRef, GuiSnackbarController {
+  private readonly afterDismissed$ = new Subject<GuiSnackbarCloseReason>();
+  private readonly onAction$ = new Subject<void>();
+  readonly afterDismissed: Observable<GuiSnackbarCloseReason> =
+    this.afterDismissed$.asObservable();
+  readonly onAction: Observable<void> = this.onAction$.asObservable();
+  private settled = false;
+
+  constructor(
+    private readonly requestDismiss: (reason: GuiSnackbarCloseReason) => void,
+  ) {}
+
+  activateAction(): void {
+    if (this.settled) {
+      return;
+    }
+    this.onAction$.next();
+    this.dismiss('action');
+  }
+
+  dismiss(reason: GuiSnackbarCloseReason = 'programmatic'): void {
+    if (this.settled) {
+      return;
+    }
+    this.requestDismiss(reason);
+  }
+
+  /** Called by the service once the overlay has been torn down. */
+  settle(reason: GuiSnackbarCloseReason): void {
+    if (this.settled) {
+      return;
+    }
+    this.settled = true;
+    this.afterDismissed$.next(reason);
+    this.afterDismissed$.complete();
+    this.onAction$.complete();
+  }
+}
+
+interface QueueEntry {
+  config: GuiSnackbarConfig;
+  data: GuiSnackbarData;
+  ref: SnackbarRefImpl;
+}
+
+interface ActiveSnackbar {
+  entry: QueueEntry;
+  handle: GuiOverlayHandle;
+  timerId: ReturnType<typeof setTimeout> | null;
+  cleanup: () => void;
+}
+
+/**
+ * M3 snackbar service. Shows one snackbar at a time (FIFO queue), anchored at the
+ * bottom via {@link GuiPickerOverlay.openGlobalBottom} (no backdrop, no focus
+ * theft). Announces politely through CDK `LiveAnnouncer`, auto-dismisses after a
+ * configurable duration, pauses the timer while hovered/focused, and supports
+ * swipe-to-dismiss.
+ */
+@Injectable({ providedIn: 'root' })
+export class GuiSnackbar {
+  private readonly overlay = inject(GuiPickerOverlay);
+  private readonly announcer = inject(LiveAnnouncer);
+  private readonly injector = inject(Injector);
+  private readonly queue = signal<QueueEntry[]>([]);
+  private active: ActiveSnackbar | null = null;
+
+  /** Enqueue a snackbar; shows immediately if nothing is open. Returns a ref. */
+  open(config: GuiSnackbarConfig | string): GuiSnackbarRef {
+    const { config: cfg, data } = normalizeSnackbarConfig(config);
+    const ref = new SnackbarRefImpl((reason) =>
+      this.handleDismiss(ref, reason),
+    );
+    const entry: QueueEntry = { config: cfg, data, ref };
+    this.queue.update((q) => [...q, entry]);
+    this.pump();
+    return ref;
+  }
+
+  /** Dismiss the current snackbar and clear everything still queued. */
+  dismissAll(): void {
+    const activeEntry = this.active?.entry;
+    const queued = this.queue().filter((e) => e !== activeEntry);
+    this.queue.set(activeEntry ? [activeEntry] : []);
+    for (const e of queued) {
+      e.ref.settle('programmatic');
+    }
+    this.active?.entry.ref.dismiss('programmatic');
+  }
+
+  private pump(): void {
+    if (this.active) {
+      return;
+    }
+    const next = this.queue()[0];
+    if (next) {
+      this.show(next);
+    }
+  }
+
+  private show(entry: QueueEntry): void {
+    const injector = Injector.create({
+      parent: this.injector,
+      providers: [
+        { provide: GUI_SNACKBAR_DATA, useValue: entry.data },
+        { provide: GUI_SNACKBAR_CONTROLLER, useValue: entry.ref },
+      ],
+    });
+    const portal = new ComponentPortal(GuiSnackbarSurface, null, injector);
+    const handle = this.overlay.openGlobalBottom(portal, {
+      alignment: this.resolveAlignment(),
+      bottomOffset: this.resolveBottomOffset(entry.config),
+      maxWidth: '672px',
+      panelClass: 'gui-snackbar-pane',
+    });
+
+    const active: ActiveSnackbar = {
+      entry,
+      handle,
+      timerId: null,
+      cleanup: () => undefined,
+    };
+    this.active = active;
+
+    this.announcer.announce(
+      entry.data.message,
+      entry.config.politeness ?? 'polite',
+    );
+
+    const duration =
+      entry.config.duration === undefined
+        ? GUI_SNACKBAR_DEFAULT_DURATION
+        : entry.config.duration;
+
+    const clearTimer = () => {
+      if (active.timerId != null) {
+        clearTimeout(active.timerId);
+        active.timerId = null;
+      }
+    };
+    // Restart-on-resume (rather than tracking elapsed time) keeps the timer logic
+    // free of Date.now and errs toward giving the user adequate time (req 9.7).
+    const startTimer = () => {
+      if (duration == null) {
+        return;
+      }
+      active.timerId = setTimeout(
+        () => entry.ref.dismiss('timeout'),
+        duration,
+      );
+    };
+    startTimer();
+
+    const overlayEl = handle.ref.overlayElement;
+    const onPause = () => clearTimer();
+    const onResume = () => {
+      clearTimer();
+      startTimer();
+    };
+    overlayEl.addEventListener('pointerenter', onPause);
+    overlayEl.addEventListener('focusin', onPause);
+    overlayEl.addEventListener('pointerleave', onResume);
+    overlayEl.addEventListener('focusout', onResume);
+
+    let dragStartX = 0;
+    let dragging = false;
+    const onDown = (e: PointerEvent) => {
+      dragging = true;
+      dragStartX = e.clientX;
+    };
+    const onUp = (e: PointerEvent) => {
+      if (dragging && Math.abs(e.clientX - dragStartX) > SWIPE_THRESHOLD) {
+        entry.ref.dismiss('swipe');
+      }
+      dragging = false;
+    };
+    overlayEl.addEventListener('pointerdown', onDown);
+    overlayEl.addEventListener('pointerup', onUp);
+
+    active.cleanup = () => {
+      clearTimer();
+      overlayEl.removeEventListener('pointerenter', onPause);
+      overlayEl.removeEventListener('focusin', onPause);
+      overlayEl.removeEventListener('pointerleave', onResume);
+      overlayEl.removeEventListener('focusout', onResume);
+      overlayEl.removeEventListener('pointerdown', onDown);
+      overlayEl.removeEventListener('pointerup', onUp);
+    };
+  }
+
+  private handleDismiss(
+    ref: SnackbarRefImpl,
+    reason: GuiSnackbarCloseReason,
+  ): void {
+    if (this.active && this.active.entry.ref === ref) {
+      const active = this.active;
+      active.cleanup();
+      active.handle.close();
+      this.active = null;
+      this.queue.update((q) => q.filter((e) => e !== active.entry));
+      ref.settle(reason);
+      this.pump();
+      return;
+    }
+    // Still queued (not yet shown): remove and settle without touching the overlay.
+    const entry = this.queue().find((e) => e.ref === ref);
+    if (entry) {
+      this.queue.update((q) => q.filter((e) => e !== entry));
+      ref.settle(reason);
+    }
+  }
+
+  private resolveAlignment(): 'center' | 'leading' {
+    if (typeof window !== 'undefined' && window.innerWidth >= LEADING_BREAKPOINT) {
+      return 'leading';
+    }
+    return 'center';
+  }
+
+  private resolveBottomOffset(config: GuiSnackbarConfig): string | undefined {
+    if (typeof config.aboveFab === 'string') {
+      return config.aboveFab;
+    }
+    if (config.aboveFab) {
+      return ABOVE_FAB_OFFSET;
+    }
+    return undefined;
+  }
+}

--- a/libs/ui/snackbar/src/snackbar.spec.ts
+++ b/libs/ui/snackbar/src/snackbar.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import { GuiSnackbarSurface } from './snackbar';
+import {
+  GUI_SNACKBAR_CONTROLLER,
+  GUI_SNACKBAR_DATA,
+  GuiSnackbarController,
+  GuiSnackbarData,
+} from './snackbar-config';
+
+function setup(
+  data: GuiSnackbarData,
+  controller: GuiSnackbarController,
+): ReturnType<typeof TestBed.createComponent<GuiSnackbarSurface>> {
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: GUI_SNACKBAR_DATA, useValue: data },
+      { provide: GUI_SNACKBAR_CONTROLLER, useValue: controller },
+    ],
+  });
+  const fixture = TestBed.createComponent(GuiSnackbarSurface);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('GuiSnackbarSurface', () => {
+  let controller: GuiSnackbarController;
+
+  beforeEach(() => {
+    controller = { activateAction: vi.fn(), dismiss: vi.fn() };
+  });
+
+  it('renders the message and exposes role="status"', () => {
+    const fixture = setup(
+      { message: 'Saved', showClose: false, twoLine: false },
+      controller,
+    );
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.getAttribute('role')).toBe('status');
+    expect(
+      host.querySelector('.gui-snackbar-label')?.textContent?.trim(),
+    ).toBe('Saved');
+  });
+
+  it('renders no action or close affordance by default', () => {
+    const fixture = setup(
+      { message: 'Saved', showClose: false, twoLine: false },
+      controller,
+    );
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.querySelector('.gui-snackbar-action')).toBeNull();
+    expect(host.querySelector('.gui-snackbar-close')).toBeNull();
+  });
+
+  it('renders an action button and reports activation', () => {
+    const fixture = setup(
+      { message: 'Deleted', action: 'Undo', showClose: false, twoLine: false },
+      controller,
+    );
+    const action = (fixture.nativeElement as HTMLElement).querySelector(
+      '.gui-snackbar-action',
+    ) as HTMLButtonElement;
+    expect(action.textContent?.trim()).toBe('Undo');
+
+    action.click();
+    expect(controller.activateAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a close button and dismisses on click', () => {
+    const fixture = setup(
+      { message: 'Saved', showClose: true, twoLine: false },
+      controller,
+    );
+    const close = (fixture.nativeElement as HTMLElement).querySelector(
+      '.gui-snackbar-close',
+    ) as HTMLButtonElement;
+    expect(close).not.toBeNull();
+
+    close.click();
+    expect(controller.dismiss).toHaveBeenCalledWith('dismiss');
+  });
+
+  it('marks the host data-two-line when two-line', () => {
+    const fixture = setup(
+      { message: 'A longer message', showClose: false, twoLine: true },
+      controller,
+    );
+    expect(
+      (fixture.nativeElement as HTMLElement).getAttribute('data-two-line'),
+    ).toBe('true');
+  });
+});

--- a/libs/ui/snackbar/src/snackbar.ts
+++ b/libs/ui/snackbar/src/snackbar.ts
@@ -1,0 +1,77 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ButtonComponent } from '@ngguide/ui/button';
+import { IconButtonComponent } from '@ngguide/ui/icon-button';
+import { IconComponent } from '@ngguide/ui/icon';
+import {
+  GUI_SNACKBAR_CONTROLLER,
+  GUI_SNACKBAR_DATA,
+} from './snackbar-config';
+
+/**
+ * M3 snackbar surface — the visual rendered into the overlay by {@link GuiSnackbar}.
+ *
+ * `role="status"` (polite live region semantics); container uses the inverse
+ * color roles. Reads its content from `GUI_SNACKBAR_DATA` and reports user
+ * intent (action / close) through the injected `GUI_SNACKBAR_CONTROLLER`.
+ */
+@Component({
+  selector: 'gui-snackbar',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, IconButtonComponent, IconComponent],
+  host: {
+    class: 'gui-snackbar',
+    role: 'status',
+    '[attr.data-two-line]': 'data.twoLine ? "true" : null',
+  },
+  template: `
+    <span class="gui-snackbar-label">{{ data.message }}</span>
+    @if (data.action) {
+      <button
+        gui-button
+        variant="text"
+        type="button"
+        class="gui-snackbar-action"
+        (click)="onAction()"
+      >
+        {{ data.action }}
+      </button>
+    }
+    @if (data.showClose) {
+      <button
+        gui-icon-button
+        type="button"
+        class="gui-snackbar-close"
+        aria-label="Dismiss"
+        (click)="onClose()"
+      >
+        <gui-icon>
+          <svg
+            viewBox="0 -960 960 960"
+            width="24"
+            height="24"
+            fill="currentColor"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"
+            />
+          </svg>
+        </gui-icon>
+      </button>
+    }
+  `,
+  styleUrl: './snackbar.css',
+})
+export class GuiSnackbarSurface {
+  protected readonly data = inject(GUI_SNACKBAR_DATA);
+  private readonly controller = inject(GUI_SNACKBAR_CONTROLLER);
+
+  protected onAction(): void {
+    this.controller.activateAction();
+  }
+
+  protected onClose(): void {
+    this.controller.dismiss('dismiss');
+  }
+}

--- a/libs/ui/src/styles/badge.css
+++ b/libs/ui/src/styles/badge.css
@@ -1,0 +1,51 @@
+/* M3 badge — styles for the corner graphic injected by the `[guiBadge]` directive.
+   The host carries `data-gui-badge-variant` (small|large) and, when hidden,
+   `data-gui-badge-hidden="true"`. */
+
+.gui-badge-host {
+  position: relative;
+}
+
+.gui-badge {
+  position: absolute;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
+  font-family: var(--md-sys-typescale-label-small-font);
+  font-weight: var(--md-sys-typescale-label-small-weight);
+  font-size: var(--md-sys-typescale-label-small-size);
+  line-height: var(--md-sys-typescale-label-small-line-height);
+  letter-spacing: var(--md-sys-typescale-label-small-tracking);
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Small dot — 6dp, 3dp corner, offset 6×6dp from the top-trailing corner. */
+.gui-badge-host[data-gui-badge-variant='small'] .gui-badge {
+  width: 6px;
+  height: 6px;
+  min-width: 0;
+  padding: 0;
+  border-radius: 3px;
+  top: 0;
+  inset-inline-end: 0;
+  transform: translate(3px, -3px);
+}
+
+/* Large numeric — 16dp min, 8dp corner, 4dp horizontal padding, offset 14×12dp. */
+.gui-badge-host[data-gui-badge-variant='large'] .gui-badge {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  top: 0;
+  inset-inline-end: 0;
+  transform: translate(50%, -50%);
+}
+
+.gui-badge-host[data-gui-badge-hidden='true'] .gui-badge {
+  display: none;
+}

--- a/libs/ui/src/styles/theme.css
+++ b/libs/ui/src/styles/theme.css
@@ -10,3 +10,4 @@
 @import './tokens/_state.css';
 @import './tokens/_motion.css';
 @import './overlay.css';
+@import './badge.css';

--- a/libs/ui/tooltip/ng-package.json
+++ b/libs/ui/tooltip/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/tooltip/src/index.ts
+++ b/libs/ui/tooltip/src/index.ts
@@ -1,0 +1,2 @@
+export * from './tooltip';
+export * from './rich-tooltip';

--- a/libs/ui/tooltip/src/rich-tooltip.css
+++ b/libs/ui/tooltip/src/rich-tooltip.css
@@ -1,0 +1,41 @@
+/* M3 rich tooltip — surface-container, on-surface-variant text, 12dp corner. */
+.gui-rich-tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  box-sizing: border-box;
+  max-width: 320px;
+  padding: 12px 16px;
+  border-radius: var(--md-sys-shape-corner-medium, 12px);
+  background-color: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface-variant);
+  box-shadow: var(--md-sys-elevation-level2);
+}
+
+.gui-rich-tooltip-subhead:empty,
+.gui-rich-tooltip-actions:empty {
+  display: none;
+}
+
+.gui-rich-tooltip-subhead {
+  color: var(--md-sys-color-on-surface);
+  font-family: var(--md-sys-typescale-title-small-font);
+  font-weight: var(--md-sys-typescale-title-small-weight);
+  font-size: var(--md-sys-typescale-title-small-size);
+  line-height: var(--md-sys-typescale-title-small-line-height);
+  letter-spacing: var(--md-sys-typescale-title-small-tracking);
+}
+
+.gui-rich-tooltip-body {
+  font-family: var(--md-sys-typescale-body-medium-font);
+  font-weight: var(--md-sys-typescale-body-medium-weight);
+  font-size: var(--md-sys-typescale-body-medium-size);
+  line-height: var(--md-sys-typescale-body-medium-line-height);
+  letter-spacing: var(--md-sys-typescale-body-medium-tracking);
+}
+
+.gui-rich-tooltip-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/libs/ui/tooltip/src/rich-tooltip.spec.ts
+++ b/libs/ui/tooltip/src/rich-tooltip.spec.ts
@@ -1,0 +1,105 @@
+import { Component } from '@angular/core';
+import { ApplicationRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiRichTooltip, GuiRichTooltipTrigger } from './rich-tooltip';
+
+@Component({
+  imports: [GuiRichTooltip, GuiRichTooltipTrigger],
+  template: `
+    <gui-rich-tooltip #rt>
+      <span guiRichTooltipSubhead>Storage</span>
+      Your files are encrypted at rest.
+      <div guiRichTooltipActions>
+        <button type="button" class="learn">Learn more</button>
+      </div>
+    </gui-rich-tooltip>
+    <button
+      type="button"
+      class="trigger"
+      [guiRichTooltipTrigger]="rt"
+      [closeDelay]="0"
+    >
+      trigger
+    </button>
+  `,
+})
+class HostComponent {}
+
+describe('GuiRichTooltip', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<HostComponent>>;
+
+  function trigger(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector(
+      'button.trigger',
+    ) as HTMLButtonElement;
+  }
+  function panel(): Element | null {
+    return document.querySelector('.gui-rich-tooltip');
+  }
+  function flush(): void {
+    TestBed.inject(ApplicationRef).tick();
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    document.body.appendChild(fixture.nativeElement);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.nativeElement.remove();
+  });
+
+  it('opens on pointer enter and projects subhead, body and actions', () => {
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    flush();
+
+    const p = panel();
+    expect(p).not.toBeNull();
+    expect(p?.getAttribute('role')).toBe('tooltip');
+    expect(p?.querySelector('[guiRichTooltipSubhead]')?.textContent?.trim()).toBe(
+      'Storage',
+    );
+    expect(p?.textContent).toContain('Your files are encrypted at rest.');
+    expect(p?.querySelector('.learn')).not.toBeNull();
+  });
+
+  it('sets aria-describedby on the trigger while open', () => {
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    flush();
+
+    const describedBy = trigger().getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).toBe(panel()?.id);
+  });
+
+  it('closes on Escape', () => {
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    flush();
+    expect(panel()).not.toBeNull();
+
+    trigger().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(panel()).toBeNull();
+    expect(trigger().getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('closes when the panel is clicked (e.g. an action)', () => {
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    flush();
+
+    (panel()?.querySelector('.learn') as HTMLButtonElement).dispatchEvent(
+      new Event('click', { bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(panel()).toBeNull();
+  });
+});

--- a/libs/ui/tooltip/src/rich-tooltip.ts
+++ b/libs/ui/tooltip/src/rich-tooltip.ts
@@ -1,0 +1,166 @@
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  ElementRef,
+  TemplateRef,
+  ViewContainerRef,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { GuiOverlayHandle, GuiPickerOverlay } from '@ngguide/ui/overlay';
+import { GuiTooltipPosition, tooltipPositions } from './tooltip';
+
+let nextRichId = 0;
+
+/**
+ * M3 rich tooltip panel. Projects an optional subhead (`[guiRichTooltipSubhead]`),
+ * a default body, and optional actions (`[guiRichTooltipActions]`, up to two
+ * `gui-button`s). Persistent and interactive — opened/closed by
+ * {@link GuiRichTooltipTrigger}. `role="tooltip"`, surface-container color roles.
+ */
+@Component({
+  selector: 'gui-rich-tooltip',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <ng-template>
+      <div class="gui-rich-tooltip" role="tooltip" [id]="id">
+        <div class="gui-rich-tooltip-subhead">
+          <ng-content select="[guiRichTooltipSubhead]" />
+        </div>
+        <div class="gui-rich-tooltip-body">
+          <ng-content />
+        </div>
+        <div class="gui-rich-tooltip-actions">
+          <ng-content select="[guiRichTooltipActions]" />
+        </div>
+      </div>
+    </ng-template>
+  `,
+  styleUrl: './rich-tooltip.css',
+})
+export class GuiRichTooltip {
+  private readonly vcr = inject(ViewContainerRef);
+  private readonly tpl = viewChild.required(TemplateRef);
+
+  readonly id = `gui-rich-tooltip-${nextRichId++}`;
+
+  /** Build a fresh portal of the panel content for attachment into the overlay. */
+  createPortal(): TemplatePortal {
+    return new TemplatePortal(this.tpl(), this.vcr);
+  }
+}
+
+/**
+ * Opens a {@link GuiRichTooltip} connected to its host. Persistent: stays open
+ * while the pointer is over the trigger OR the panel, closing only after a short
+ * grace delay once the pointer is over neither. Escape or a click inside the
+ * panel (e.g. an action) closes it. Sets `aria-describedby` while open.
+ */
+@Directive({
+  selector: '[guiRichTooltipTrigger]',
+  host: {
+    '[attr.aria-describedby]': 'open() ? panel().id : null',
+    '(pointerenter)': 'onTriggerEnter()',
+    '(pointerleave)': 'onTriggerLeave()',
+    '(focusin)': 'onTriggerEnter()',
+    '(focusout)': 'onTriggerLeave()',
+    '(keydown.escape)': 'close()',
+  },
+})
+export class GuiRichTooltipTrigger {
+  private readonly overlay = inject(GuiPickerOverlay);
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /** The panel this trigger controls. */
+  readonly panel = input.required<GuiRichTooltip>({
+    alias: 'guiRichTooltipTrigger',
+  });
+  readonly position = input<GuiTooltipPosition>('below');
+  /** Grace period (ms) before closing once the pointer leaves both surfaces. */
+  readonly closeDelay = input(150);
+
+  protected readonly open = signal(false);
+
+  private handle: GuiOverlayHandle | null = null;
+  private overTrigger = false;
+  private overPanel = false;
+  private closeTimer: ReturnType<typeof setTimeout> | null = null;
+  private panelEnter = () => this.setOverPanel(true);
+  private panelLeave = () => this.setOverPanel(false);
+  private panelClick = () => this.close();
+
+  protected onTriggerEnter(): void {
+    this.overTrigger = true;
+    this.show();
+  }
+
+  protected onTriggerLeave(): void {
+    this.overTrigger = false;
+    this.scheduleClose();
+  }
+
+  private setOverPanel(over: boolean): void {
+    this.overPanel = over;
+    if (over) {
+      this.cancelClose();
+    } else {
+      this.scheduleClose();
+    }
+  }
+
+  private show(): void {
+    if (this.open()) {
+      this.cancelClose();
+      return;
+    }
+    const positions: ConnectedPosition[] = tooltipPositions(this.position());
+    this.handle = this.overlay.openConnected(this.panel().createPortal(), {
+      origin: this.host.nativeElement,
+      positions,
+      panelClass: 'gui-rich-tooltip-pane',
+    });
+    const el = this.handle.ref.overlayElement;
+    el.addEventListener('pointerenter', this.panelEnter);
+    el.addEventListener('pointerleave', this.panelLeave);
+    el.addEventListener('click', this.panelClick);
+    this.open.set(true);
+  }
+
+  protected close(): void {
+    this.cancelClose();
+    if (!this.open()) {
+      return;
+    }
+    if (this.handle) {
+      const el = this.handle.ref.overlayElement;
+      el.removeEventListener('pointerenter', this.panelEnter);
+      el.removeEventListener('pointerleave', this.panelLeave);
+      el.removeEventListener('click', this.panelClick);
+      this.handle.close();
+      this.handle = null;
+    }
+    this.overPanel = false;
+    this.open.set(false);
+  }
+
+  private scheduleClose(): void {
+    this.cancelClose();
+    this.closeTimer = setTimeout(() => {
+      if (!this.overTrigger && !this.overPanel) {
+        this.close();
+      }
+    }, this.closeDelay());
+  }
+
+  private cancelClose(): void {
+    if (this.closeTimer != null) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
+  }
+}

--- a/libs/ui/tooltip/src/tooltip.css
+++ b/libs/ui/tooltip/src/tooltip.css
@@ -1,0 +1,18 @@
+/* M3 plain tooltip — inverse surface, 24dp tall, 8dp padding, extra-small corner. */
+:host {
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  min-height: 24px;
+  max-width: 200px;
+  padding: 4px 8px;
+  border-radius: var(--md-sys-shape-corner-extra-small, 4px);
+  background-color: var(--md-sys-color-inverse-surface);
+  color: var(--md-sys-color-inverse-on-surface);
+  font-family: var(--md-sys-typescale-body-small-font);
+  font-weight: var(--md-sys-typescale-body-small-weight);
+  font-size: var(--md-sys-typescale-body-small-size);
+  line-height: var(--md-sys-typescale-body-small-line-height);
+  letter-spacing: var(--md-sys-typescale-body-small-tracking);
+  pointer-events: none;
+}

--- a/libs/ui/tooltip/src/tooltip.spec.ts
+++ b/libs/ui/tooltip/src/tooltip.spec.ts
@@ -1,0 +1,110 @@
+import { Component } from '@angular/core';
+import { ApplicationRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiTooltip } from './tooltip';
+
+@Component({
+  imports: [GuiTooltip],
+  template: `<button
+    type="button"
+    [guiTooltip]="message"
+    [showDelay]="0"
+    [hideDelay]="0"
+    [disabled]="disabled"
+  >
+    trigger
+  </button>`,
+})
+class HostComponent {
+  message = 'Help';
+  disabled = false;
+}
+
+describe('GuiTooltip', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<HostComponent>>;
+
+  function trigger(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+  }
+  function panel(): Element | null {
+    return document.querySelector('gui-tooltip-panel');
+  }
+  function flush(): void {
+    TestBed.inject(ApplicationRef).tick();
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    document.body.appendChild(fixture.nativeElement);
+  });
+
+  afterEach(() => {
+    fixture.nativeElement.remove();
+  });
+
+  it('shows a tooltip on pointer enter and sets aria-describedby', () => {
+    fixture.detectChanges();
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    flush();
+
+    expect(panel()).not.toBeNull();
+    expect(panel()?.getAttribute('role')).toBe('tooltip');
+    expect(panel()?.textContent?.trim()).toBe('Help');
+
+    const describedBy = trigger().getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).toBe(panel()?.id);
+  });
+
+  it('removes the tooltip and aria-describedby on pointer leave', () => {
+    fixture.detectChanges();
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    trigger().dispatchEvent(new Event('pointerleave'));
+    fixture.detectChanges();
+
+    expect(panel()).toBeNull();
+    expect(trigger().getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('Escape hides the tooltip and keeps focus on the trigger', () => {
+    fixture.detectChanges();
+    trigger().focus();
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    flush();
+    expect(panel()).not.toBeNull();
+
+    trigger().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(panel()).toBeNull();
+    if (document.activeElement !== document.body) {
+      expect(document.activeElement).toBe(trigger());
+    }
+  });
+
+  it('does not open when disabled', () => {
+    fixture.componentInstance.disabled = true;
+    fixture.detectChanges();
+
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+
+    expect(panel()).toBeNull();
+    expect(trigger().getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('does not open with an empty message', () => {
+    fixture.componentInstance.message = '';
+    fixture.detectChanges();
+
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+
+    expect(panel()).toBeNull();
+  });
+});

--- a/libs/ui/tooltip/src/tooltip.ts
+++ b/libs/ui/tooltip/src/tooltip.ts
@@ -1,0 +1,219 @@
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  ElementRef,
+  InjectionToken,
+  Injector,
+  OnDestroy,
+  booleanAttribute,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { GuiOverlayHandle, GuiPickerOverlay } from '@ngguide/ui/overlay';
+
+export type GuiTooltipPosition = 'above' | 'below' | 'before' | 'after';
+
+let nextId = 0;
+
+interface GuiTooltipPanelData {
+  message: string;
+  id: string;
+  position: GuiTooltipPosition;
+}
+
+const GUI_TOOLTIP_DATA = new InjectionToken<GuiTooltipPanelData>(
+  'GUI_TOOLTIP_DATA',
+);
+
+/** Connected positions for each tooltip placement, with a sensible fallback. */
+export function tooltipPositions(
+  position: GuiTooltipPosition,
+): ConnectedPosition[] {
+  const gap = 8;
+  switch (position) {
+    case 'below':
+      return [
+        { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetY: gap },
+        { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetY: -gap },
+      ];
+    case 'before':
+      return [
+        { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -gap },
+        { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: gap },
+      ];
+    case 'after':
+      return [
+        { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: gap },
+        { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -gap },
+      ];
+    case 'above':
+    default:
+      return [
+        { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetY: -gap },
+        { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetY: gap },
+      ];
+  }
+}
+
+/** The plain-tooltip panel rendered into the overlay (non-interactive). */
+@Component({
+  selector: 'gui-tooltip-panel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'gui-tooltip',
+    role: 'tooltip',
+    '[id]': 'data.id',
+    '[attr.data-position]': 'data.position',
+  },
+  template: `{{ data.message }}`,
+  styleUrl: './tooltip.css',
+})
+export class GuiTooltipPanel {
+  protected readonly data = inject(GUI_TOOLTIP_DATA);
+}
+
+/**
+ * M3 plain tooltip — a short, non-interactive label shown on hover / focus /
+ * long-press. Sets `aria-describedby` on the trigger while visible (APG); Escape
+ * hides it without moving focus off the trigger.
+ */
+@Directive({
+  selector: '[guiTooltip]',
+  host: {
+    '[attr.aria-describedby]': 'describedBy()',
+    '(pointerenter)': 'onPointerEnter()',
+    '(pointerleave)': 'onPointerLeave()',
+    '(focusin)': 'scheduleShow()',
+    '(focusout)': 'hide()',
+    '(pointerdown)': 'onPointerDown()',
+    '(pointerup)': 'cancelLongPress()',
+    '(keydown.escape)': 'hide()',
+  },
+})
+export class GuiTooltip implements OnDestroy {
+  private readonly overlay = inject(GuiPickerOverlay);
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly injector = inject(Injector);
+
+  readonly message = input<string>('', { alias: 'guiTooltip' });
+  readonly position = input<GuiTooltipPosition>('above');
+  readonly showDelay = input(500);
+  readonly hideDelay = input(0);
+  readonly disabled = input(false, { transform: booleanAttribute });
+
+  protected readonly visible = signal(false);
+  protected readonly tooltipId = `gui-tooltip-${nextId++}`;
+  protected readonly describedBy = computed(() =>
+    this.visible() ? this.tooltipId : null,
+  );
+
+  private handle: GuiOverlayHandle | null = null;
+  private showTimer: ReturnType<typeof setTimeout> | null = null;
+  private hideTimer: ReturnType<typeof setTimeout> | null = null;
+  private longPressTimer: ReturnType<typeof setTimeout> | null = null;
+
+  protected onPointerEnter(): void {
+    this.scheduleShow();
+  }
+
+  protected onPointerLeave(): void {
+    this.cancelLongPress();
+    this.hide();
+  }
+
+  protected onPointerDown(): void {
+    // Touch long-press path.
+    this.longPressTimer = setTimeout(() => this.show(), this.showDelay());
+  }
+
+  protected cancelLongPress(): void {
+    if (this.longPressTimer != null) {
+      clearTimeout(this.longPressTimer);
+      this.longPressTimer = null;
+    }
+  }
+
+  protected scheduleShow(): void {
+    if (!this.canShow()) {
+      return;
+    }
+    this.clearTimers();
+    const delay = this.showDelay();
+    if (delay <= 0) {
+      this.show();
+    } else {
+      this.showTimer = setTimeout(() => this.show(), delay);
+    }
+  }
+
+  protected hide(): void {
+    this.clearTimers();
+    if (!this.visible()) {
+      return;
+    }
+    const delay = this.hideDelay();
+    if (delay <= 0) {
+      this.close();
+    } else {
+      this.hideTimer = setTimeout(() => this.close(), delay);
+    }
+  }
+
+  private canShow(): boolean {
+    return !this.disabled() && this.message().trim().length > 0;
+  }
+
+  private show(): void {
+    if (!this.canShow() || this.visible()) {
+      return;
+    }
+    const injector = Injector.create({
+      parent: this.injector,
+      providers: [
+        {
+          provide: GUI_TOOLTIP_DATA,
+          useValue: {
+            message: this.message(),
+            id: this.tooltipId,
+            position: this.position(),
+          } satisfies GuiTooltipPanelData,
+        },
+      ],
+    });
+    const portal = new ComponentPortal(GuiTooltipPanel, null, injector);
+    this.handle = this.overlay.openConnected(portal, {
+      origin: this.host.nativeElement,
+      positions: tooltipPositions(this.position()),
+      panelClass: 'gui-tooltip-pane',
+    });
+    this.visible.set(true);
+  }
+
+  private close(): void {
+    this.handle?.close();
+    this.handle = null;
+    this.visible.set(false);
+  }
+
+  private clearTimers(): void {
+    if (this.showTimer != null) {
+      clearTimeout(this.showTimer);
+      this.showTimer = null;
+    }
+    if (this.hideTimer != null) {
+      clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.clearTimers();
+    this.cancelLongPress();
+    this.close();
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,9 @@
       "@ngguide/ui/icon": ["libs/ui/icon/src/index.ts"],
       "@ngguide/ui/icon-button": ["libs/ui/icon-button/src/index.ts"],
       "@ngguide/ui/interaction": ["libs/ui/interaction/src/index.ts"],
+      "@ngguide/ui/loading-indicator": [
+        "libs/ui/loading-indicator/src/index.ts"
+      ],
       "@ngguide/ui/menu": ["libs/ui/menu/src/index.ts"],
       "@ngguide/ui/overlay": ["libs/ui/overlay/src/index.ts"],
       "@ngguide/ui/progress": ["libs/ui/progress/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -38,6 +38,7 @@
       "@ngguide/ui/radio": ["libs/ui/radio/src/index.ts"],
       "@ngguide/ui/segmented-button": ["libs/ui/segmented-button/src/index.ts"],
       "@ngguide/ui/slider": ["libs/ui/slider/src/index.ts"],
+      "@ngguide/ui/snackbar": ["libs/ui/snackbar/src/index.ts"],
       "@ngguide/ui/split-button": ["libs/ui/split-button/src/index.ts"],
       "@ngguide/ui/switch": ["libs/ui/switch/src/index.ts"],
       "@ngguide/ui/text-field": ["libs/ui/text-field/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,7 @@
       "@ngguide/ui/interaction": ["libs/ui/interaction/src/index.ts"],
       "@ngguide/ui/menu": ["libs/ui/menu/src/index.ts"],
       "@ngguide/ui/overlay": ["libs/ui/overlay/src/index.ts"],
+      "@ngguide/ui/progress": ["libs/ui/progress/src/index.ts"],
       "@ngguide/ui/radio": ["libs/ui/radio/src/index.ts"],
       "@ngguide/ui/segmented-button": ["libs/ui/segmented-button/src/index.ts"],
       "@ngguide/ui/slider": ["libs/ui/slider/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "baseUrl": ".",
     "paths": {
       "@ngguide/ui": ["libs/ui/src/index.ts"],
+      "@ngguide/ui/badge": ["libs/ui/badge/src/index.ts"],
       "@ngguide/ui/button": ["libs/ui/button/src/index.ts"],
       "@ngguide/ui/button-group": ["libs/ui/button-group/src/index.ts"],
       "@ngguide/ui/checkbox": ["libs/ui/checkbox/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -43,6 +43,7 @@
       "@ngguide/ui/switch": ["libs/ui/switch/src/index.ts"],
       "@ngguide/ui/text-field": ["libs/ui/text-field/src/index.ts"],
       "@ngguide/ui/theme": ["libs/ui/theme/src/index.ts"],
+      "@ngguide/ui/tooltip": ["libs/ui/tooltip/src/index.ts"],
       "@ngguide/ui/time-picker": ["libs/ui/time-picker/src/index.ts"]
     }
   },


### PR DESCRIPTION
## Communication components (M3)

Implements the **communication** spec — the M3 feedback family — as new
`@ngguide/ui/*` secondary entry points, built strictly from m3.material.io
(not an Angular Material wrapper). Standalone, zoneless, OnPush, signal-based
throughout. Purely additive: 6 independently-mergeable groups, no cutovers.

### What's new

| Entry point | Surface |
|---|---|
| `@ngguide/ui/overlay` (extended) | `openGlobalBottom` + `openConnected` on `GuiPickerOverlay` — floating openers that do **not** capture/restore focus (snackbar/tooltip must not steal focus) |
| `@ngguide/ui/badge` | `[guiBadge]` host directive — 6dp dot when empty, numeric badge with `"{max}+"` cap; `aria-hidden` graphic, meaning via host's own label |
| `@ngguide/ui/progress` | `gui-linear-progress` (CSS) + `gui-circular-progress` (SVG) — determinate + indeterminate, `role=progressbar` with `aria-valuenow` only when determinate |
| `@ngguide/ui/loading-indicator` | `gui-loading-indicator` — indeterminate SVG morphing cookie (deterministic trig path + declarative SMIL morph + CSS spin), default/contained variants |
| `@ngguide/ui/snackbar` | `GuiSnackbar` service (FIFO queue, one at a time) + `gui-snackbar` surface — polite `LiveAnnouncer`, auto-dismiss with pause-on-hover/focus, swipe + close, action ref; `role=status`, inverse color roles |
| `@ngguide/ui/tooltip` | `[guiTooltip]` plain directive (hover/focus/long-press, `aria-describedby`, Escape keeps focus) + `gui-rich-tooltip` persistent panel + trigger |

### Design notes

- Snackbar/tooltip overlays use a CDK-style DI pattern (data + controller via `Injector`) since the new openers attach the portal internally.
- Snackbar timer pauses on hover/focus via clear-and-restart (full duration) — no `Date.now`, errs toward giving the user adequate time (req 9.7).
- Loading indicator generates its shape with pure trig (SSR-stable) and morphs via SMIL gated on `prefers-reduced-motion`.
- Rich tooltip projects content through `<ng-content>` inside an `<ng-template>` + `TemplatePortal`.

### Testing

- **227 unit tests pass** (jsdom asserts state/ARIA/DOM); full `lint test build` green for `ui` + `web`; all 5 new entry points build via ng-packagr.
- **Browser-dogfooded** every component in `apps/web`. One bug found and fixed (`853f00e`): icon buttons clip overflow for their state layer, hiding the corner badge — demo now wraps clipping hosts in a non-clipping `<span guiBadge>` and the constraint is documented on the directive.

### Out of scope

Dialogs (containment category), wavy/expressive progress (deferred — classic flat only). Pixel geometry & overlay positioning are verified by browser dogfood, not jsdom.

Spec docs: `.specs/communication/{requirements,research,design,tasks}.md`.
