### PR TITLE
feat: M3 containment components (card, divider, list, dialog, bottom/side sheet, carousel)

### DIFF
--- a/.specs/containment/design.md
+++ b/.specs/containment/design.md
@@ -1,0 +1,612 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Design Document: Containment Components
+
+## Overview
+
+This design adds the M3 **containment** category to `@ngguide/ui` as seven secondary entry points:
+`card`, `divider`, `list`, `dialog`, `bottom-sheet`, `side-sheet`, `carousel`. The four overlay surfaces
+(dialog ×2 variants, modal bottom sheet, modal side sheet) are built on the headless **`@angular/cdk/dialog`
+`Dialog`** service for APG-complete modal behavior; standard (non-modal) sheets render inline without a focus
+trap. The carousel implements the true M3 **keyline sizing engine** (pure math + a client-side layout pass).
+Card, divider, and list are token-driven structural components reusing the existing interaction directives.
+
+### Key Changes
+
+1. **Seven new entry points** wired through `tsconfig.base.json` paths, `libs/ui/project.json` test `include`,
+   and (for global chrome) `libs/ui/src/styles/theme.css` `@import`s — following the snackbar/tooltip precedent.
+2. **Modal foundation = CDK `Dialog`** with three custom container components (`GuiDialogContainer`,
+   `GuiBottomSheetContainer`, `GuiSideSheetContainer`) swapped via `DialogConfig.container`; each provides M3
+   chrome, motion, and (sheets) the drag gesture. Imperative `GuiDialog`/`GuiBottomSheet`/`GuiSideSheet`
+   services wrap `Dialog.open`, **plus** declarative `[guiDialogTrigger]` / `[guiBottomSheetTrigger]` /
+   `[guiSideSheetTrigger]` directives that open a `TemplateRef` (CDK `Dialog.open` supports the `TemplateRef` overload).
+3. **Bottom-sheet drag-to-dismiss** via `@angular/cdk/drag-drop` (`cdkDragLockAxis="y"`, `cdkDragMoved`/`cdkDragEnded`
+   `distance`, `setFreeDragPosition` spring-back, `cdkDragConstrainPosition` to clamp upward).
+4. **Carousel keyline engine** — pure sizing functions (`small = clamp(large/3, 40, 56)`, `medium = (large+small)/2`,
+   per-layout arrangement) + a client-side `ResizeObserver`/scroll pass that morphs item widths between keylines.
+   SSR renders a static large-size first frame.
+5. **List with opt-in modes** (`action` list of controls / `listbox` with `createRovingFocus` + `aria-selected`),
+   **card with both actionable shapes** (whole-surface control + primary-action region), structural **divider**.
+6. **Compact-window signal** — a `GuiBreakpoint` service (the `GuiReducedMotion` `MediaMatcher` pattern) driving
+   full-screen-dialog auto-selection and carousel full-screen orientation; pure styling differences stay in CSS.
+7. **No new dependencies** — `@angular/cdk` is already a peer dependency at `^21.2.0`; `cdk/dialog`, `cdk/drag-drop`,
+   and `cdk/layout` are sub-paths of it.
+
+### Decisions
+
+| Problem Area | Chosen Variant | Why chosen | Reference |
+|-------------|----------------|------------|-----------|
+| 1. Modal overlay foundation | **B — CDK headless `Dialog`** | APG-complete (aria-modal/role/focus-trap/restore/autofocus) out of the box, lowest risk, reuses installed CDK; `container` swap renders dialog vs sheet chrome from one service. | research.md §1 |
+| 2. Open API + content projection | **C + imperative `open()`** | Declarative `TemplateRef` trigger for inline content (rich-tooltip pattern) **plus** a thin `open()` over `Dialog.open` to satisfy Req 16.2 (imperative open returning a ref). | research.md §2 |
+| 3. Bottom-sheet drag | **A — CDK drag-drop** | Purpose-built one-axis gesture (`lockAxis`, `distance`, `setFreeDragPosition`, `constrainPosition`); lowest risk; same CDK package. | research.md §3 |
+| 4. Carousel sizing | **B — JS keyline engine** | Only variant with true M3 keyline fidelity — mandated by the project's strict-M3 rule; sizing constants verified from Compose source. | research.md §4 |
+| 5. List semantics | **C — opt-in modes** | One component serves action-lists and selection-listboxes; covers Req 4/5/6 without forcing one APG pattern. | research.md §5 |
+| 6. Card actionability | **C — both modes** | Whole-surface control for simple cards + primary-action region for cards with inner actions; both M3 actionable shapes, APG-correct. | research.md §6 |
+| 7. Responsive detection | **C — hybrid** | CSS for pure styling; a `MediaMatcher` compact signal only where logic must branch (full-screen dialog choice, carousel orientation). | research.md §7 |
+
+**Cross-area note:** Decision 2 keeps the declarative trigger (catalogue C) *and adds* a thin imperative `open()`
+that — because Decision 1 is CDK Dialog — reduces to a near-trivial wrapper over `Dialog.open` + `DIALOG_DATA` +
+`DialogRef` (catalogue B's mechanics). The two are combined deliberately, not in conflict.
+
+## Architecture
+
+### Component Diagram
+
+```mermaid
+graph TB
+    subgraph "App"
+        APP[Host component / template]
+    end
+
+    subgraph "Overlay surfaces (@ngguide/ui/dialog, /bottom-sheet, /side-sheet)"
+        SVC[GuiDialog / GuiBottomSheet / GuiSideSheet services]
+        TRG["[guiDialogTrigger] / [guiBottomSheetTrigger] / [guiSideSheetTrigger]"]
+        CFG[GuiDialogConfig / GuiBottomSheetConfig / GuiSideSheetConfig]
+        CT[GuiDialogContainer / GuiBottomSheetContainer / GuiSideSheetContainer]
+        REF[GuiDialogRef wraps DialogRef]
+        DRAG[GuiSheetDragHandle - cdkDrag]
+    end
+
+    subgraph "Structural (@ngguide/ui/card, /divider, /list, /carousel)"
+        CARD[GuiCard + GuiCardPrimaryAction]
+        DIV[GuiDivider]
+        LIST[GuiList + GuiListItem]
+        CAR[GuiCarousel + GuiCarouselItem]
+        ENG[carousel-keylines.ts pure engine]
+    end
+
+    subgraph "Existing foundation"
+        CDKD["@angular/cdk/dialog Dialog"]
+        CDKDRAG["@angular/cdk/drag-drop"]
+        INT["@ngguide/ui/interaction (state-layer/ripple/focus-ring, createRovingFocus, GuiReducedMotion)"]
+        BP[GuiBreakpoint MediaMatcher signal]
+        TOK[M3 token CSS]
+    end
+
+    APP --> SVC
+    APP --> TRG
+    APP --> CARD & DIV & LIST & CAR
+    TRG --> SVC
+    SVC --> CFG
+    SVC --> CDKD
+    CDKD --> CT
+    CT --> DRAG
+    DRAG --> CDKDRAG
+    SVC --> REF
+    CAR --> ENG
+    CAR --> BP
+    CARD & LIST --> INT
+    CT --> BP
+    CARD & DIV & LIST & CAR & CT --> TOK
+```
+
+### Data Flow — opening a modal dialog (imperative)
+
+```mermaid
+sequenceDiagram
+    participant U as Host code
+    participant S as GuiDialog service
+    participant D as CDK Dialog
+    participant C as GuiDialogContainer
+    participant R as GuiDialogRef
+
+    U->>S: open(ContentCmp, { role, fullScreen, data })
+    S->>S: normalizeConfig() -> CDK DialogConfig (ariaModal, role, autoFocus, restoreFocus, hasBackdrop, backdropClass='gui-scrim', scrollStrategy=block(), container=GuiDialogContainer)
+    S->>D: Dialog.open(ContentCmp, cdkConfig)
+    D->>C: instantiate container (focus trap, scrim, aria-modal)
+    C-->>U: render M3 dialog surface + project content
+    S-->>U: return GuiDialogRef (wraps DialogRef)
+    U->>R: closed.subscribe(result)
+    Note over C,R: Escape / scrim click / action -> ref.close(result)
+    R-->>U: closed emits result; focus restored to opener
+```
+
+### Data Flow — bottom-sheet drag-to-dismiss
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant H as GuiSheetDragHandle (cdkDrag, lockAxis=y)
+    participant C as GuiBottomSheetContainer
+    participant R as DialogRef
+
+    U->>H: pointer drag down
+    H->>H: cdkDragMoved -> distance.y
+    H->>C: set scrim opacity ~ (1 - distance.y/height)
+    U->>H: release
+    H->>H: cdkDragEnded -> distance.y
+    alt distance.y > dismissThreshold
+        H->>R: close('swipe')
+    else
+        H->>H: setFreeDragPosition({x:0,y:0}) (CSS spring-back)
+    end
+```
+
+## Components and Interfaces
+
+### Shared overlay layer
+
+All three overlay families share a small internal pattern: a **config → CDK `DialogConfig` normalizer**, a
+**custom container** (extends CDK's `CdkDialogContainer` to add M3 chrome + motion), and a **ref wrapper**.
+The shared modal config lives in each entry point but follows one shape:
+
+```typescript
+// Common modal config surface (each family extends it). Path: libs/ui/<family>/src/<family>-config.ts
+export type GuiDialogRole = 'dialog' | 'alertdialog';
+
+export interface GuiModalConfigBase<D = unknown> {
+  data?: D;                         // injected via DIALOG_DATA into the content component
+  role?: GuiDialogRole;             // default 'dialog'
+  ariaLabel?: string;               // when no visible headline exists
+  ariaLabelledBy?: string;          // id of the headline element
+  disableClose?: boolean;           // Escape + scrim-click disabled (non-dismissible)
+  panelClass?: string | string[];
+  autoFocus?: 'dialog' | 'first-tabbable' | 'first-heading' | string; // default 'first-tabbable'
+  restoreFocus?: boolean;           // default true
+  injector?: Injector;              // parent injector for the content
+}
+```
+
+Normalization maps these onto the **verified** CDK `DialogConfig` fields (`ariaModal:true`, `role`, `ariaLabel`,
+`ariaLabelledBy`, `disableClose`, `autoFocus`, `restoreFocus`, `hasBackdrop`, `backdropClass`, `scrollStrategy`,
+`panelClass`, `data`, `container`, `injector`). Scroll-lock uses `Dialog`'s injected scroll strategy set to
+`block()`; the scrim uses `backdropClass:'gui-scrim'` styled from `--md-sys-color-scrim` at 32% (Req 12.1/12.6).
+
+### `@ngguide/ui/dialog`
+
+```typescript
+// Path: libs/ui/dialog/src/dialog-config.ts
+export type GuiDialogFullScreen = 'never' | 'compact' | 'always'; // Req 8 (compact-only) + auto
+
+export interface GuiDialogConfig<D = unknown> extends GuiModalConfigBase<D> {
+  fullScreen?: GuiDialogFullScreen;   // default 'never'; 'compact' uses GuiBreakpoint
+  maxWidth?: string;                  // default 'min(560px, calc(100% - 48px))' (M3 basic dialog)
+}
+
+export const GUI_DIALOG_DATA = DIALOG_DATA;       // re-export CDK token for content components
+// GuiDialogRef is the public ref; thin wrapper over CDK DialogRef.
+export interface GuiDialogRef<R = unknown> {
+  readonly closed: Observable<R | undefined>;
+  readonly backdropClick: Observable<MouseEvent>;
+  readonly keydownEvents: Observable<KeyboardEvent>;
+  close(result?: R): void;
+}
+```
+
+```typescript
+// Path: libs/ui/dialog/src/dialog.service.ts
+@Injectable({ providedIn: 'root' })
+export class GuiDialog {
+  private readonly cdkDialog = inject(Dialog);
+  private readonly breakpoint = inject(GuiBreakpoint);
+
+  open<R = unknown, D = unknown, C = unknown>(
+    content: ComponentType<C> | TemplateRef<C>,
+    config?: GuiDialogConfig<D>,
+  ): GuiDialogRef<R> {
+    const fullScreen = this.resolveFullScreen(config?.fullScreen);
+    const ref = this.cdkDialog.open<R, D, C>(content, {
+      ...normalizeModalConfig(config),
+      container: GuiDialogContainer,                 // M3 chrome + motion
+      maxWidth: config?.maxWidth ?? 'min(560px, calc(100% - 48px))',
+      panelClass: [fullScreen ? 'gui-dialog-fullscreen' : 'gui-dialog', ...asArray(config?.panelClass)],
+    });
+    return wrapDialogRef(ref);
+  }
+
+  private resolveFullScreen(mode: GuiDialogFullScreen = 'never'): boolean {
+    return mode === 'always' || (mode === 'compact' && this.breakpoint.isCompact());
+  }
+}
+```
+
+```typescript
+// Path: libs/ui/dialog/src/dialog.ts — structural slots projected into the container
+// Selectors for content authors to compose the M3 dialog anatomy:
+//   gui-dialog-icon, gui-dialog-headline (h2), gui-dialog-content, gui-dialog-actions
+// and the full-screen header: gui-dialog-fullscreen-header (close + title + confirm action).
+@Component({ selector: 'gui-dialog-headline', host: { class: 'gui-dialog-headline', role: 'heading', 'aria-level': '2' }, /* ... */ })
+export class GuiDialogHeadline {}
+// (GuiDialogIcon, GuiDialogContent, GuiDialogActions analogous — token-styled wrappers.)
+```
+
+```typescript
+// Path: libs/ui/dialog/src/dialog.trigger.ts — declarative open (Decision 2C)
+@Directive({
+  selector: '[guiDialogTrigger]',
+  host: { '(click)': 'open()' },
+})
+export class GuiDialogTrigger {
+  private readonly dialog = inject(GuiDialog);
+  readonly template = input.required<TemplateRef<unknown>>({ alias: 'guiDialogTrigger' });
+  readonly config = input<GuiDialogConfig>();        // alias 'guiDialogConfig'
+  protected open(): void { this.dialog.open(this.template(), this.config()); }
+}
+```
+
+`GuiDialogContainer extends CdkDialogContainer` adds: `data-fullscreen` host attr, M3 enter/exit animation
+(emphasized-decelerate in / emphasized-accelerate out via motion tokens), `surface-container-high` background,
+`corner-extra-large` (28dp) shape, `elevation-level3`. The basic dialog is centered (CDK global centered
+position by default); full-screen sets `maxWidth:100% / height:100%` and renders the top-app-bar header slot.
+
+### `@ngguide/ui/bottom-sheet` and `@ngguide/ui/side-sheet`
+
+Both expose **two modes**:
+- **Modal** — opened via the service (`GuiBottomSheet.open` / `GuiSideSheet.open`) on CDK `Dialog` with a custom
+  container; full APG modal (scrim, trap, restore, Escape). Bottom-sheet container hosts the drag handle.
+- **Standard** — a structural component (`<gui-bottom-sheet variant="standard" [(open)]>`) rendered inline as a
+  fixed-position surface, **no scrim, no focus trap** (Req 9.2 / 10.3), coexisting with page content.
+
+```typescript
+// Path: libs/ui/bottom-sheet/src/bottom-sheet-config.ts
+export interface GuiBottomSheetConfig<D = unknown> extends GuiModalConfigBase<D> {
+  showDragHandle?: boolean;     // default true
+  aboveFab?: boolean;           // raise bottom offset to clear a FAB
+  dismissThreshold?: number;    // px dragged-down to dismiss; default 96
+  maxWidth?: string;            // default '640px' on larger screens; full-width on compact
+}
+
+@Injectable({ providedIn: 'root' })
+export class GuiBottomSheet {
+  private readonly cdkDialog = inject(Dialog);
+  open<R, D, C>(content: ComponentType<C> | TemplateRef<C>, config?: GuiBottomSheetConfig<D>): GuiDialogRef<R> {
+    const ref = this.cdkDialog.open<R, D, C>(content, {
+      ...normalizeModalConfig(config),
+      container: GuiBottomSheetContainer,
+      panelClass: ['gui-bottom-sheet-pane', ...asArray(config?.panelClass)],
+      positionStrategy: bottomCenteredGlobalStrategy(),   // anchored to bottom edge
+    });
+    return wrapDialogRef(ref);
+  }
+}
+```
+
+```typescript
+// Path: libs/ui/bottom-sheet/src/bottom-sheet.ts — surface used by BOTH modes
+@Component({
+  selector: 'gui-bottom-sheet',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CdkDrag],
+  host: { class: 'gui-bottom-sheet-surface', '[attr.data-variant]': 'variant()' },
+  // template: optional <div class="gui-bottom-sheet-handle" cdkDrag cdkDragLockAxis="y" ...></div> + <ng-content/>
+})
+export class GuiBottomSheet /* surface */ {
+  readonly variant = input<'modal' | 'standard'>('standard');
+  readonly open = model(false);                 // standard mode toggle (two-way)
+  readonly showDragHandle = input(true, { transform: booleanAttribute });
+  protected onDragEnded(e: CdkDragEnd): void { /* distance.y > threshold -> dismiss; else setFreeDragPosition */ }
+}
+```
+
+`GuiSideSheetContainer` mirrors this for the **end** edge (slide-in from the right in LTR), `corner-large` (16dp),
+width `256–400px`; standard side sheet coexists without scrim. Side sheet has no drag gesture (M3 side sheets
+dismiss via the close affordance / scrim).
+
+### `@ngguide/ui/card` and `@ngguide/ui/divider`
+
+```typescript
+// Path: libs/ui/card/src/card.ts
+export type GuiCardVariant = 'elevated' | 'filled' | 'outlined';
+
+@Component({
+  selector: 'gui-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  styleUrl: './card.css',
+  host: {
+    class: 'gui-card',
+    '[attr.data-variant]': 'variant()',
+    '[attr.data-disabled]': 'disabled() ? "" : null',
+  },
+})
+export class GuiCard {
+  readonly variant = input<GuiCardVariant>('elevated');
+  readonly disabled = input(false, { transform: booleanAttribute });
+}
+
+// Whole-surface control mode (Variant A): apply to an <a> or a [role=button] host.
+@Directive({
+  selector: '[guiCardClickable]',
+  hostDirectives: [GuiStateLayerDirective, GuiRippleDirective, GuiFocusRingDirective],
+  host: {
+    '[attr.tabindex]': 'disabled() ? null : 0',
+    '[attr.role]': 'isAnchor ? null : "button"',
+    '(click)': 'activate($event)',
+    '(keydown.enter)': 'activate($event)',
+    '(keydown.space)': 'activate($event)',
+  },
+})
+export class GuiCardClickable { /* emits (cardActivate); guards disabled */ }
+
+// Primary-action region (Variant B): a clickable sub-region; action buttons live outside it.
+@Directive({
+  selector: '[guiCardPrimaryAction]',
+  hostDirectives: [GuiStateLayerDirective, GuiRippleDirective, GuiFocusRingDirective],
+  host: { tabindex: '0', role: 'button', '(click)': 'activate($event)', '(keydown.enter)': 'activate($event)', '(keydown.space)': 'activate($event)' },
+})
+export class GuiCardPrimaryAction { /* (primaryAction) output */ }
+```
+
+Card variant tokens (verified): elevated = `surface-container-low` + `elevation-level1` (hover `level2`, dragged
+`level4`); filled = `surface-container-highest` + `level0` (hover `level1`); outlined = `surface` + `level0` +
+`outline-variant` 1px border (focus border → `on-surface`). Corner `medium` (12dp). Disabled = 0.38 opacity, no
+state layers, no activation.
+
+```typescript
+// Path: libs/ui/divider/src/divider.ts
+export type GuiDividerInset = 'none' | 'inset' | 'middle-inset';
+
+@Component({
+  selector: 'gui-divider',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '',
+  styleUrl: './divider.css',
+  host: {
+    class: 'gui-divider',
+    role: 'separator',
+    '[attr.aria-orientation]': 'orientation()',
+    '[attr.data-inset]': 'inset()',
+  },
+})
+export class GuiDivider {
+  readonly inset = input<GuiDividerInset>('none');
+  readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
+}
+```
+
+Divider: 1px, `outline-variant`; `inset` = 16px leading inset; `middle-inset` = 16px both sides.
+
+### `@ngguide/ui/list`
+
+```typescript
+// Path: libs/ui/list/src/list.ts
+export type GuiListMode = 'action' | 'listbox';
+
+@Component({
+  selector: 'gui-list',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  styleUrl: './list.css',
+  host: {
+    class: 'gui-list',
+    '[attr.role]': 'mode() === "listbox" ? "listbox" : "list"',
+    '[attr.aria-multiselectable]': 'mode() === "listbox" ? (multiselectable() ? "true" : "false") : null',
+    '(keydown)': 'onKeydown($event)',
+  },
+})
+export class GuiList {
+  readonly mode = input<GuiListMode>('action');
+  readonly multiselectable = input(false, { transform: booleanAttribute });
+  private readonly items = contentChildren(GuiListItem);
+  private manager?: FocusKeyManager<GuiListItem>;     // built via createRovingFocus in listbox mode
+  protected onKeydown(e: KeyboardEvent): void { this.manager?.onKeydown(e); }
+}
+
+// Path: libs/ui/list/src/list-item.ts
+@Component({
+  selector: 'gui-list-item',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  // template projects: [guiListItemLeading], headline (default), [guiListItemSupporting], [guiListItemTrailing]
+  styleUrl: './list-item.css',
+  host: {
+    class: 'gui-list-item',
+    '[attr.data-lines]': 'lines()',
+    '[attr.role]': 'listMode() === "listbox" ? "option" : (interactive() ? null : "listitem")',
+    '[attr.aria-selected]': 'listMode() === "listbox" ? (selected() ? "true" : "false") : null',
+    '[attr.aria-disabled]': 'disabled() ? "true" : null',
+    '[attr.data-selected]': 'selected() ? "" : null',
+  },
+})
+export class GuiListItem implements FocusableOption {
+  readonly lines = input<1 | 2 | 3>(1);
+  readonly interactive = input(false, { transform: booleanAttribute }); // action mode
+  readonly selectable = input(false, { transform: booleanAttribute });  // listbox mode
+  readonly selected = model(false);
+  readonly disabled = input(false, { transform: booleanAttribute });
+  focus(): void { /* FocusableOption for the key manager */ }
+}
+```
+
+List tokens (verified): heights 56/72/88dp; leading icon 24 / avatar 40 / image 56dp; headline `body-large`,
+supporting `body-medium`, trailing supporting `label-small`; 16dp start/end padding; container `surface`;
+selected container `secondary-container` (Req 6.3). In `listbox` mode the list owns a `createRovingFocus`
+manager (single tab stop + arrow/typeahead/home-end); in `action` mode items contain their own native
+`<button>`/`<a>` and rely on natural tab order. Trailing checkbox/switch in action mode carry their own
+accessible state; the item does not duplicate it (Req 6.4).
+
+### `@ngguide/ui/carousel`
+
+```typescript
+// Path: libs/ui/carousel/src/carousel-keylines.ts — PURE engine (no Date.now/random; SSR-safe, deterministic)
+export type GuiCarouselLayout = 'multi-browse' | 'uncontained' | 'hero' | 'full-screen';
+
+export const MIN_SMALL_ITEM = 40;   // dp (verified, Compose CarouselDefaults)
+export const MAX_SMALL_ITEM = 56;   // dp (verified)
+
+export interface KeylineArrangement {
+  large: number;            // px
+  medium: number;           // px (0 if layout has no medium)
+  small: number;            // px
+  largeCount: number;
+  mediumCount: number;
+  smallCount: number;
+}
+
+/** small = clamp(large/3, 40, 56); medium = (large+small)/2 — verified M3 rules. */
+export function arrange(
+  layout: GuiCarouselLayout,
+  viewportWidth: number,
+  opts: { preferredLargeWidth: number; itemSpacing: number; itemCount: number },
+): KeylineArrangement { /* per-layout fit; drops small below 80px width; hero start/center variants */ }
+
+/** Interpolated size/clip for an item given its distance from the focal keyline. */
+export function maskForOffset(arrangement: KeylineArrangement, scrollOffset: number, index: number): { width: number; clipInset: number } { /* ... */ }
+```
+
+```typescript
+// Path: libs/ui/carousel/src/carousel.ts
+@Component({
+  selector: 'gui-carousel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="gui-carousel-track" #track><ng-content /></div>`,
+  styleUrl: './carousel.css',
+  host: { class: 'gui-carousel', '[attr.data-layout]': 'effectiveLayout()', role: 'group', 'aria-roledescription': 'carousel' },
+})
+export class GuiCarousel {
+  private readonly breakpoint = inject(GuiBreakpoint);
+  private readonly reducedMotion = inject(GuiReducedMotion);
+  readonly layout = input<GuiCarouselLayout>('multi-browse');
+  readonly preferredLargeWidth = input(186, { transform: numberAttribute });
+  readonly itemSpacing = input(8, { transform: numberAttribute });
+  private readonly items = contentChildren(GuiCarouselItem);
+  // effectiveLayout(): full-screen on compact uses vertical orientation (Req 11.6).
+  // afterNextRender(): set up ResizeObserver(track) + scroll listener -> recompute arrange() and apply
+  //   item widths/clip via signals. On the server / first frame, items render at large size (static).
+}
+
+// Path: libs/ui/carousel/src/carousel-item.ts
+@Component({
+  selector: 'gui-carousel-item',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: { class: 'gui-carousel-item', '[style.width.px]': 'width()', '[style.scroll-snap-align]': '"start"' },
+})
+export class GuiCarouselItem { readonly width = signal<number | null>(null); /* set by the engine */ }
+```
+
+The carousel uses native scroll + `scroll-snap` for momentum/snapping; the engine recomputes item widths on
+`ResizeObserver` and morphs sizes between keylines on `scroll`. Item corner = `extra-large` (28dp). Under
+reduced motion, size morphing is disabled (items render at their arranged sizes without per-scroll interpolation).
+
+### `GuiBreakpoint` (compact-window signal)
+
+```typescript
+// Path: libs/ui/overlay/src/breakpoint.ts (or a small shared util) — mirrors GuiReducedMotion
+@Injectable({ providedIn: 'root' })
+export class GuiBreakpoint {
+  private readonly mql = inject(MediaMatcher).matchMedia('(max-width: 599.98px)'); // M3 compact < 600dp
+  private readonly compact = signal(this.mql.matches);
+  readonly isCompact: Signal<boolean> = this.compact.asReadonly();
+  constructor() { this.mql.addEventListener?.('change', (e) => this.compact.set(e.matches)); }
+}
+```
+
+## Data Models
+
+The containment category introduces no persisted data. The "models" are the public config/ref types:
+`GuiModalConfigBase`, `GuiDialogConfig`, `GuiBottomSheetConfig`, `GuiSideSheetConfig`, `GuiDialogRef`,
+`KeylineArrangement`, and the component input unions (`GuiCardVariant`, `GuiDividerInset`, `GuiListMode`,
+`GuiCarouselLayout`). All are defined above.
+
+## Data Flow Completeness
+
+This is a component library, so the "layers" are the entry-point wiring rather than schema→DB→API. Each new
+entry point must appear in every layer below (a missing layer = build/test failure, the analogue of a dropped field):
+
+| Entry point | tsconfig path | ng-package.json + index.ts | Component/Service files | Global CSS @import | project.json test include | apps/web demo |
+|-------------|--------------|----------------------------|-------------------------|--------------------|---------------------------|---------------|
+| card | `@ngguide/ui/card` | `libs/ui/card/{ng-package.json,src/index.ts}` | `card.ts`, `card.css`, `card.spec.ts` | `styles/card.css` (if global chrome) | `../card/src/card.spec.ts` | card section |
+| divider | `@ngguide/ui/divider` | ✓ | `divider.ts`, `.css`, `.spec.ts` | N/A (component CSS only) | `../divider/src/divider.spec.ts` | divider section |
+| list | `@ngguide/ui/list` | ✓ | `list.ts`, `list-item.ts`, CSS, specs | `styles/list.css` | `../list/src/{list,list-item}.spec.ts` | list section |
+| dialog | `@ngguide/ui/dialog` | ✓ | `dialog-config.ts`, `dialog.ts`, `dialog.service.ts`, `dialog.trigger.ts`, `dialog-container.ts`, CSS, specs | `styles/dialog.css` (scrim/surface) | `../dialog/src/{dialog,dialog.service}.spec.ts` | dialog buttons |
+| bottom-sheet | `@ngguide/ui/bottom-sheet` | ✓ | `bottom-sheet-config.ts`, `bottom-sheet.ts`, `bottom-sheet.service.ts`, `bottom-sheet-container.ts`, CSS, specs | `styles/bottom-sheet.css` | `../bottom-sheet/src/{bottom-sheet,bottom-sheet.service}.spec.ts` | sheet button |
+| side-sheet | `@ngguide/ui/side-sheet` | ✓ | `side-sheet-config.ts`, `side-sheet.ts`, `side-sheet.service.ts`, `side-sheet-container.ts`, CSS, specs | `styles/side-sheet.css` | `../side-sheet/src/{side-sheet,side-sheet.service}.spec.ts` | sheet button |
+| carousel | `@ngguide/ui/carousel` | ✓ | `carousel-keylines.ts`, `carousel.ts`, `carousel-item.ts`, CSS, specs | `styles/carousel.css` (if global) | `../carousel/src/{carousel,carousel-keylines,carousel-item}.spec.ts` | carousel section |
+
+Schema / migration / API-DTO layers are **N/A** (no backend). `GuiBreakpoint` lives under `@ngguide/ui/overlay`
+(or a shared util) and needs its own spec appended to `include`. After editing `project.json`, run
+`pnpm exec nx reset`. `libs/ui/package.json` needs **no change** (`@angular/cdk ^21.2.0` already a peer dep).
+
+## Error Handling
+
+| Condition | Handling |
+|-----------|----------|
+| `open()` with neither component nor template | Throw a descriptive error before calling CDK (developer error). |
+| Modal opened during SSR | `GuiBreakpoint`/`MediaMatcher` returns non-match on server; services are client-only in practice (no overlay on server render). Container animations gate on `afterNextRender`. |
+| `disableClose` + Escape/scrim | Suppressed (no close); documented (Req 12.4/12.5 exceptions). |
+| Carousel with 0 items / width 0 | `arrange()` returns an empty/degenerate arrangement; no NaN widths; track renders empty. |
+| Carousel item smaller than `MIN_SMALL_ITEM*2` available | Engine drops small items per M3 (verified rule); logged via a dev-only guard if the container is too narrow for any layout. |
+| List `listbox` mode with focusable trailing controls | Documented anti-pattern; `listbox` mode expects selection via the option, not nested controls (use `action` mode for rows with their own controls). |
+| Reduced motion | All enter/exit + carousel morph animations disabled via `GuiReducedMotion`; open/close + arranged sizes still apply (Req 15). |
+| Stacked modals | CDK `Dialog` stacks overlays in DOM order; Escape targets the top-most ref; restore-focus unwinds in reverse (Req 12.8) — verified behavior to be asserted in tests. |
+
+## Testing Strategy
+
+### Approach
+
+Vitest native builder (`@nx/angular:unit-test`), zoneless, jsdom. Each entry point gets ≥1 spec (the runner has
+no `passWithNoTests`). Overlay specs append the surface to `document.body` and flush via
+`TestBed.inject(ApplicationRef).tick()` (snackbar/rich-tooltip precedent). Avoid the NG0100 anti-pattern: set
+inputs before a single `detectChanges()` per test; never mutate-then-second-detectChanges; one fixture per
+`it()` to avoid the shared-ApplicationRef re-check trap. Keylines are pure → tested as plain functions.
+
+### Unit Tests (representative)
+
+```typescript
+describe('GuiDialog', () => {
+  it('opens with role=dialog + aria-modal and restores focus on close', () => {
+    const opener = document.createElement('button'); document.body.appendChild(opener); opener.focus();
+    const ref = TestBed.inject(GuiDialog).open(DialogContentCmp, { ariaLabel: 'Test' });
+    TestBed.inject(ApplicationRef).tick();
+    const surface = document.querySelector('.gui-dialog');
+    expect(surface?.getAttribute('aria-modal')).toBe('true');
+    expect(surface?.getAttribute('role')).toBe('dialog');
+    ref.close('ok');
+    TestBed.inject(ApplicationRef).tick();
+    expect(document.activeElement).toBe(opener);
+  });
+});
+
+describe('carousel-keylines', () => {
+  it('multi-browse: small = clamp(large/3, 40, 56), medium = midpoint', () => {
+    const a = arrange('multi-browse', 360, { preferredLargeWidth: 186, itemSpacing: 8, itemCount: 6 });
+    expect(a.small).toBeGreaterThanOrEqual(40);
+    expect(a.small).toBeLessThanOrEqual(56);
+    expect(a.medium).toBeCloseTo((a.large + a.small) / 2, 0);
+  });
+});
+
+describe('GuiBottomSheet drag', () => {
+  it('dismisses when dragged past threshold, springs back otherwise', () => { /* simulate cdkDragEnded distance.y */ });
+});
+
+describe('GuiListItem', () => {
+  it('listbox mode exposes role=option + aria-selected; action mode is listitem', () => { /* ... */ });
+});
+```
+
+### Edge Cases
+
+1. **Escape on stacked modals** → only top-most closes; focus returns to the modal beneath (Req 12.8).
+2. **Full-screen dialog on compact** → `fullScreen:'compact'` picks full-screen only when `GuiBreakpoint.isCompact()`.
+3. **Standard sheet** → no scrim, no focus trap, page behind remains interactive and scrollable (Req 9.2/10.3).
+4. **Drag below threshold** → `setFreeDragPosition({x:0,y:0})` spring-back; sheet stays open.
+5. **Carousel resize** → `ResizeObserver` re-arranges without leaving disallowed partial items (Req 11.5).
+6. **Actionable card with inner buttons** → use primary-action region; whole-surface mode documented as invalid with nested controls.
+7. **Reduced motion** → no enter/exit or scroll-morph animation; state changes still apply.
+8. **Disabled card / list item** → no activation event, no state layers, 0.38 opacity.
+9. **SSR render** → carousel items render at large size; no `matchMedia`/`ResizeObserver` access on the server; hydrates without layout shift.
+```

--- a/.specs/containment/requirements.md
+++ b/.specs/containment/requirements.md
@@ -1,0 +1,375 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Requirements Document
+
+## Introduction
+
+The **containment** category delivers the Material Design 3 (M3) containment / surface components for
+`@ngguide/ui`, published as secondary entry points. These are the surfaces that *hold and group*
+content: cards that frame a single subject, dividers that separate content, lists that present a
+vertical run of related items, dialogs that interrupt for a focused task or decision, bottom and side
+sheets that surface supplementary content from a screen edge, and carousels that present a scrollable
+run of visually prominent items.
+
+Every component's anatomy, variants, states, measurements, motion, and accessibility behavior must
+trace 1:1 to the published M3 guideline at [m3.material.io](https://m3.material.io/) and the relevant
+WAI-ARIA Authoring Practices (APG) pattern. Where M3 is ambiguous, the open question is documented in
+research rather than guessed.
+
+This category covers seven component families:
+1. **Card** — elevated, filled, and outlined containers for a single piece of content; optionally actionable.
+2. **Divider** — a thin line that groups content within a list or container (full-width, inset, middle-inset).
+3. **List** — a continuous, vertical run of one-, two-, or three-line rows with leading/trailing elements; optionally interactive and selectable.
+4. **Dialog** — a modal surface for a focused task or decision; **basic** (centered) and **full-screen** (compact-window) variants.
+5. **Bottom sheet** — a surface anchored to the bottom edge holding supplementary content; **modal** and **standard** variants, with a drag handle and swipe-to-dismiss.
+6. **Side sheet** — a surface anchored to a side edge holding supplementary content; **modal** and **standard** variants.
+7. **Carousel** — a scrollable run of items in the M3 **multi-browse**, **uncontained**, **hero**, and **full-screen** layouts.
+
+Navigation surfaces (navigation drawer, rail, bar, top app bar, tabs) are explicitly **out of scope**
+here — they belong to the `navigation` category. The menu *control* and chips belong to `selection`;
+snackbar and tooltips belong to `communication`.
+
+## Glossary
+
+- **Surface**: A container that holds content and carries an M3 color role and (optionally) elevation.
+- **Card**: A surface that frames a single, self-contained piece of content and its actions. M3 defines
+  three variants — **elevated**, **filled**, **outlined**.
+- **Actionable card**: A card whose entire surface (or a primary region of it) responds to interaction
+  (hover/focus/press), showing a state layer and acting as a single control.
+- **Divider**: A thin, non-interactive line that separates or groups content. M3 variants by inset:
+  **full-width**, **inset** (indented on the leading side), **middle-inset** (indented on both sides).
+- **List**: A vertical, continuous index of related rows.
+- **List item**: One row of a list. M3 supports **one-line**, **two-line**, and **three-line** densities.
+- **Leading element**: Content at the start of a list item — icon, avatar, image, or video thumbnail.
+- **Trailing element**: Content at the end of a list item — supporting text, icon, or a selection control.
+- **Interactive list item**: A list item that responds to hover/focus/press and activates on click/Enter.
+- **Selectable list item**: A list item that carries a selection control (checkbox/switch) or a selected state.
+- **Dialog**: A modal surface that interrupts the user to communicate information or request a decision.
+  **Basic dialog** is centered with optional headline, supporting text, and up to two text actions;
+  **full-screen dialog** fills a compact window with a top app bar (close/back + confirm action).
+- **Bottom sheet**: A surface that slides up from the bottom edge. **Modal** blocks the rest of the UI
+  behind a scrim; **standard** coexists with the content behind it.
+- **Side sheet**: A surface that slides in from a side (end) edge. **Modal** blocks behind a scrim;
+  **standard** coexists with content.
+- **Drag handle**: A small affordance at the top of a bottom sheet indicating it can be dragged/resized/dismissed.
+- **Carousel**: A horizontally scrollable run of items sized per an M3 layout strategy.
+- **Carousel layouts**: **multi-browse** (mixed large/medium/small items), **uncontained** (uniform items
+  that scroll past the edge), **hero** (one large focal item + a peeking next item), **full-screen**
+  (one item filling the viewport, vertical on compact).
+- **Scrim**: A translucent overlay that dims and blocks the content behind a modal surface.
+- **Focus trap**: Keeping keyboard focus within a modal surface while it is open.
+- **Restore focus**: Returning focus to the element that opened the surface once it closes.
+- **Scroll lock**: Preventing the page behind a modal surface from scrolling while it is open.
+- **Reduced motion**: The user preference requesting minimized or eliminated non-essential animation.
+- **Compact window**: The M3 compact window size class (narrow viewports, e.g. phones).
+- **APG**: WAI-ARIA Authoring Practices Guide.
+- **Secondary entry point**: A separately importable sub-path of the published package (e.g. `@ngguide/ui/card`).
+
+## Requirements
+
+### Requirement 1: Card — anatomy and variants
+
+**User Story:** As an app developer, I want an M3 card in elevated, filled, and outlined variants, so
+that I can frame a single subject's content and actions consistently with the design system.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a card surface in three variants: **elevated**, **filled**, and **outlined**.
+2. WHEN the elevated variant is used THEN the system SHALL render the M3 elevated-card container color
+   and the M3 resting elevation for an elevated card.
+3. WHEN the filled variant is used THEN the system SHALL render the M3 filled-card container color and
+   no resting elevation.
+4. WHEN the outlined variant is used THEN the system SHALL render the M3 outlined-card container color
+   with the M3 outline-variant border and no resting elevation.
+5. THE system SHALL apply the M3 card corner-radius shape to every variant.
+6. THE system SHALL allow arbitrary content to be placed inside the card (media, text, actions) without
+   prescribing a fixed internal layout beyond M3 container padding/shape.
+7. THE system SHALL clip card content to the card's rounded corners so that full-bleed media follows the
+   card shape.
+
+### Requirement 2: Card — actionable behavior and states
+
+**User Story:** As an app developer, I want an optional actionable card, so that a whole card can behave
+as a single control with the correct M3 interaction states.
+
+#### Acceptance Criteria
+
+1. WHEN a card is marked actionable THEN the system SHALL expose it to assistive technology and keyboard
+   users as a single activatable control (focusable, activatable with Enter/Space, with an accessible name).
+2. WHEN the pointer hovers, focuses, or presses an actionable card THEN the system SHALL display the M3
+   hover, focus, and pressed state layers at the M3 state-layer opacities.
+3. WHEN an elevated actionable card is hovered or pressed THEN the system SHALL apply the M3 elevation
+   change defined for those states.
+4. WHEN an actionable card is activated THEN the system SHALL emit an activation event the developer can handle.
+5. WHEN a card is disabled THEN the system SHALL present the M3 disabled container/content treatment and
+   SHALL NOT emit activation events or show interaction state layers.
+6. THE system SHALL NOT add interaction states, focusability, or a control role to a non-actionable card.
+
+### Requirement 3: Divider
+
+**User Story:** As an app developer, I want an M3 divider, so that I can separate or group content within
+lists and containers.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a divider rendered with the M3 divider thickness and the M3 outline-variant color.
+2. THE system SHALL support **full-width**, **inset**, and **middle-inset** variants, applying the M3 inset
+   distance on the indicated side(s).
+3. THE system SHALL expose the divider to assistive technology as a non-focusable separator that conveys
+   it is a divider rather than meaningful content.
+4. THE system SHALL NOT make the divider focusable or interactive.
+
+### Requirement 4: List — anatomy and line densities
+
+**User Story:** As an app developer, I want M3 list items in one-, two-, and three-line densities, so that
+I can present rows of related content at the correct height and spacing.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a list container that arranges its items as a continuous vertical run.
+2. THE system SHALL provide list items in **one-line**, **two-line**, and **three-line** densities, each
+   rendered at the corresponding M3 minimum row height and internal padding.
+3. WHEN a list item has a headline and supporting text THEN the system SHALL render the headline with the
+   M3 list headline typescale and the supporting text with the M3 list supporting-text typescale.
+4. WHEN supporting text exceeds the lines available for the chosen density THEN the system SHALL truncate
+   it per M3 (no overflow past the item's reserved lines).
+5. THE system SHALL allow dividers to be placed between list items.
+
+### Requirement 5: List — leading and trailing elements
+
+**User Story:** As an app developer, I want to place leading and trailing elements in a list item, so that
+I can show icons, avatars, images, supporting text, or controls in the M3 positions.
+
+#### Acceptance Criteria
+
+1. THE system SHALL support a leading element that is an icon, an avatar, an image, or a video thumbnail,
+   positioned and sized per the M3 list anatomy for that element type.
+2. THE system SHALL support a trailing element that is supporting text, an icon, or a selection control.
+3. THE system SHALL align leading and trailing elements to the M3 vertical alignment for the item's density.
+4. WHEN no leading element is present THEN the system SHALL apply the M3 text inset for items without a leading element.
+
+### Requirement 6: List — interactive and selectable items
+
+**User Story:** As an app developer, I want list items that can be interactive or selectable, so that users
+can activate rows or choose items with correct M3 states and accessibility.
+
+#### Acceptance Criteria
+
+1. WHEN a list item is marked interactive THEN the system SHALL make it focusable and activatable with
+   pointer and keyboard, displaying the M3 hover, focus, and pressed state layers.
+2. WHEN an interactive list item is activated THEN the system SHALL emit an activation event the developer can handle.
+3. WHEN a list item is selectable THEN the system SHALL communicate its selected/unselected state to
+   assistive technology and render the M3 selected-item container treatment when selected.
+4. WHEN a list item carries a trailing checkbox or switch THEN the system SHALL keep the control's state and
+   the item's selected state in sync, and SHALL expose a single, non-duplicated accessible state to AT.
+5. WHEN a list item is disabled THEN the system SHALL present the M3 disabled treatment and SHALL NOT emit
+   activation events or show interaction state layers.
+6. WHEN keyboard focus moves through an interactive list THEN the system SHALL follow the APG list/listbox
+   focus model appropriate to whether the list is a presentation of links/buttons or a selection listbox.
+
+### Requirement 7: Dialog — basic (centered) modal
+
+**User Story:** As an app developer, I want an M3 basic dialog, so that I can interrupt the user for a
+focused decision or short message with up to two actions.
+
+#### Acceptance Criteria
+
+1. WHEN a basic dialog is opened THEN the system SHALL present a centered modal surface with the M3 dialog
+   container color, corner shape, elevation, and max-width constraints.
+2. THE system SHALL support an optional leading icon, an optional headline, optional supporting text/content,
+   and an actions area with up to two text actions aligned per M3.
+3. WHEN the dialog is opened THEN the system SHALL apply the shared modal overlay behavior of Requirement 12
+   (scrim, focus trap, restore focus, Escape to dismiss, scroll lock, dialog semantics).
+4. WHEN the user activates an action or dismisses the dialog THEN the system SHALL emit a result that the
+   opener receives, indicating which action (or a dismissal) closed the dialog.
+5. WHEN dialog content is taller than the available height THEN the system SHALL scroll the content region
+   while keeping the headline and actions visible per M3.
+6. THE system SHALL allow the dialog to be opened imperatively from developer code and to be closed
+   programmatically, returning a result to the caller.
+
+### Requirement 8: Dialog — full-screen
+
+**User Story:** As an app developer, I want an M3 full-screen dialog on compact windows, so that I can host
+a longer, self-contained task that needs the whole screen.
+
+#### Acceptance Criteria
+
+1. WHEN a full-screen dialog is opened THEN the system SHALL fill the window with the M3 full-screen dialog
+   surface and a top app bar containing a close/back affordance, a title, and a confirming action.
+2. WHEN the user activates the close/back affordance or presses Escape THEN the system SHALL close the dialog
+   and emit a dismissal result.
+3. WHEN the user activates the confirming action THEN the system SHALL emit a confirm result the opener receives.
+4. THE system SHALL apply the shared modal overlay behavior of Requirement 12, except the surface fills the
+   window rather than presenting a centered card.
+5. THE system SHALL scroll the dialog body independently of the fixed top app bar when content overflows.
+
+### Requirement 9: Bottom sheet — modal, standard, and drag
+
+**User Story:** As an app developer, I want an M3 bottom sheet in modal and standard variants, so that I can
+surface supplementary content from the bottom edge, optionally draggable.
+
+#### Acceptance Criteria
+
+1. WHEN a modal bottom sheet is opened THEN the system SHALL slide a surface up from the bottom edge with
+   the M3 bottom-sheet container color, top corner shape, and elevation, and SHALL apply the shared modal
+   overlay behavior of Requirement 12.
+2. WHEN a standard bottom sheet is opened THEN the system SHALL present the surface without a scrim and
+   without blocking interaction with the content behind it.
+3. THE system SHALL optionally render a drag handle at the top of the bottom sheet per M3.
+4. WHEN the user drags the sheet (or drag handle) downward beyond the M3 dismissal threshold THEN the system
+   SHALL dismiss the sheet; WHEN the drag does not exceed the threshold THEN the system SHALL settle the
+   sheet back to its open position.
+5. WHEN the sheet content exceeds the available height THEN the system SHALL scroll the content within the
+   sheet rather than past the screen edge.
+6. WHEN the user swipes/drags to dismiss or activates a dismissal control THEN the system SHALL emit a
+   dismissal event the opener receives.
+7. WHEN a drag gesture is in progress THEN the system SHALL not select page text or trigger native scroll on
+   the page behind the sheet.
+
+### Requirement 10: Side sheet — modal and standard
+
+**User Story:** As an app developer, I want an M3 side sheet in modal and standard variants, so that I can
+surface supplementary content from a side edge.
+
+#### Acceptance Criteria
+
+1. WHEN a side sheet is opened THEN the system SHALL slide a surface in from the end edge with the M3
+   side-sheet container color, corner shape, elevation, and width constraints.
+2. WHEN the modal variant is used THEN the system SHALL apply the shared modal overlay behavior of
+   Requirement 12 (scrim, focus trap, restore focus, Escape, scroll lock, dialog semantics).
+3. WHEN the standard variant is used THEN the system SHALL present the surface without a scrim and without
+   blocking interaction with the content beside it.
+4. THE system SHALL support an optional header region (title + close affordance) and an actions region per M3.
+5. WHEN the user activates the close affordance or (modal only) presses Escape THEN the system SHALL close
+   the side sheet and emit a dismissal event.
+6. WHEN side-sheet content overflows THEN the system SHALL scroll the content region within the sheet.
+
+### Requirement 11: Carousel — layouts and items
+
+**User Story:** As an app developer, I want an M3 carousel in its four layouts, so that I can present a
+scrollable run of visually prominent items.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a carousel that arranges its items horizontally in a scrollable run.
+2. THE system SHALL support the **multi-browse**, **uncontained**, **hero**, and **full-screen** layouts,
+   sizing items per the M3 strategy for the chosen layout.
+3. WHEN the multi-browse or hero layout is used THEN the system SHALL size items into large/medium/small (or
+   large + peeking) roles per the M3 sizing rules, including the smaller item peeking at the trailing edge.
+4. THE system SHALL clip each carousel item to the M3 carousel item corner shape.
+5. WHEN the available width changes THEN the system SHALL re-fit the visible items per the layout's sizing
+   strategy without leaving partially-cut items in disallowed positions for that layout.
+6. WHEN the full-screen layout is used on a compact window THEN the system SHALL present one item filling the
+   viewport and scroll vertically per M3.
+
+### Requirement 12: Shared modal overlay behavior
+
+**User Story:** As a keyboard and screen-reader user, I want every modal containment surface to trap focus,
+restore it, and be dismissible, so that modal surfaces are operable and accessible per APG.
+
+#### Acceptance Criteria
+
+1. WHEN any modal surface (basic dialog, full-screen dialog, modal bottom sheet, modal side sheet) opens THEN
+   the system SHALL render a scrim that dims and blocks pointer interaction with the content behind it.
+2. WHEN a modal surface opens THEN the system SHALL move keyboard focus into the surface and SHALL keep focus
+   within the surface (focus trap) until it closes.
+3. WHEN a modal surface closes THEN the system SHALL return focus to the element that had focus before it opened.
+4. WHEN the user presses Escape while a modal surface is open THEN the system SHALL close it and emit a
+   dismissal result, unless the surface is explicitly configured as non-dismissible.
+5. WHEN the user clicks the scrim THEN the system SHALL close the surface and emit a dismissal result, unless
+   configured as non-dismissible.
+6. WHEN a modal surface is open THEN the system SHALL prevent the page behind it from scrolling (scroll lock)
+   and restore the prior scroll behavior on close.
+7. THE system SHALL expose each modal surface with the appropriate dialog semantics (a dialog role and modal
+   state) and an accessible name derived from its headline/title.
+8. WHEN multiple modal surfaces are stacked THEN the system SHALL direct Escape and focus trapping to the
+   top-most surface and restore focus in reverse order as they close.
+
+### Requirement 13: Token and theming compliance
+
+**User Story:** As a design-system maintainer, I want every containment component styled only from the M3
+token contract, so that theming and light/dark switching work without per-component overrides.
+
+#### Acceptance Criteria
+
+1. THE system SHALL derive every color, shape, elevation, typography, and state-layer value from the
+   published `--md-sys-*` token contract.
+2. THE system SHALL NOT hard-code color, corner-radius, elevation, or typography values that bypass the token contract.
+3. WHEN the active theme switches between light and dark (or contrast levels) THEN every containment
+   component SHALL update to the new token values without component-level changes.
+4. THE system SHALL reuse the shared interaction primitives (state-layer / ripple / focus-ring) for all
+   interactive containment surfaces rather than re-implementing interaction states.
+
+### Requirement 14: Accessibility
+
+**User Story:** As a user relying on assistive technology, I want containment components to follow APG and
+meet WCAG 2.2 AA, so that I can perceive and operate them.
+
+#### Acceptance Criteria
+
+1. THE system SHALL implement dialogs and modal sheets per the APG Dialog (Modal) pattern, including
+   `role`, modal state, labeling, focus management, and Escape handling.
+2. THE system SHALL implement interactive/selectable lists per the applicable APG pattern (list of controls
+   vs. listbox) including keyboard operation and selection state exposure.
+3. THE system SHALL ensure every interactive containment surface is reachable and operable by keyboard alone.
+4. THE system SHALL render a visible focus indicator on every focusable containment surface, meeting the
+   WCAG 2.2 AA non-text-contrast and focus-appearance requirements.
+5. THE system SHALL NOT convey state (selected, disabled, expanded) by color alone.
+
+### Requirement 15: Motion and reduced motion
+
+**User Story:** As a user who is sensitive to motion, I want containment transitions to respect my reduced-
+motion preference, so that opening surfaces does not cause discomfort.
+
+#### Acceptance Criteria
+
+1. WHEN a dialog, sheet, or carousel transition plays THEN the system SHALL use the M3 motion duration and
+   easing tokens for that transition.
+2. WHEN the user has requested reduced motion THEN the system SHALL minimize or remove non-essential
+   enter/exit and scroll animations while preserving the open/closed and scroll *state* changes.
+3. THE system SHALL keep all open/close and selection behavior fully functional when animations are reduced or removed.
+
+### Requirement 16: Packaging and developer API surface
+
+**User Story:** As an app developer, I want each containment component published as its own importable entry
+point, so that I can import only what I use.
+
+#### Acceptance Criteria
+
+1. THE system SHALL publish each containment family as a secondary entry point of the package (e.g.
+   `@ngguide/ui/card`, `/divider`, `/list`, `/dialog`, `/bottom-sheet`, `/side-sheet`, `/carousel`).
+2. THE system SHALL provide an imperative way to open dialogs and sheets from developer code that returns a
+   handle/result, in addition to any declarative usage.
+3. THE system SHALL render correctly under server-side rendering and rehydrate without layout shift or errors,
+   and SHALL operate without relying on a change-detection zone.
+4. THE system SHALL behave deterministically (no reliance on wall-clock time or randomness in its rendered
+   output) so that snapshots and server/client output match.
+
+## Constraints
+
+- **M3 fidelity** — every visual and behavioral choice must trace to a specific guideline at
+  m3.material.io; ambiguities are recorded as open questions in research, not improvised. (Project rule
+  inherited from `vision.md`.)
+- **Built from scratch** — components are implemented directly against the M3 spec and the project's own
+  token + interaction foundation; they are not wrappers around Angular Material.
+- **Token contract** — components must consume the existing `--md-sys-*` token contract defined by the
+  `m3-tokens` spec; they must not define their own color/shape/elevation values. (Existing integration.)
+- **Interaction foundation** — interactive surfaces and modal/overlay behavior must build on the existing
+  `m3-interaction-foundation` primitives (state-layer/ripple/focus-ring and the shared overlay/focus
+  utilities) rather than re-implementing them. (Existing integration.)
+- **Zoneless + standalone + OnPush + signals** — components must work in a zoneless app, be standalone,
+  use OnPush change detection, and use signal inputs, consistent with the rest of the library.
+- **Secondary entry points** — each family ships as its own `@ngguide/ui/<name>` entry point, matching the
+  established library packaging.
+
+## Non-functional Requirements
+
+- **Accessibility**: Meets WCAG 2.2 AA; dialogs and modal sheets conform to the APG Dialog (Modal) pattern;
+  interactive lists conform to the applicable APG list/listbox pattern.
+- **SSR safety**: Renders under server-side rendering and rehydrates without errors or layout shift; no use
+  of wall-clock time or randomness in rendered output (deterministic).
+- **Theming**: Light/dark and contrast-level switching is reflected by all components purely through token
+  changes, with no per-component style overrides required.

--- a/.specs/containment/research.md
+++ b/.specs/containment/research.md
@@ -1,0 +1,596 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Research: Containment Components
+
+## Problem Statement
+
+The `containment` category adds seven M3 component families (card, divider, list, dialog, bottom sheet,
+side sheet, carousel) to `@ngguide/ui`. Four of them (dialog × 2, bottom sheet, side sheet) are modal
+overlay surfaces that must satisfy the full APG Dialog (Modal) pattern; the carousel needs a non-trivial
+M3 keyline sizing engine; the list needs APG-correct interaction/selection semantics. This research
+catalogues the implementation variants per decision area, grounded in the existing codebase foundation
+(`GuiPickerOverlay`, interaction directives, `createRovingFocus`, the M3 token set) and verified Angular
+CDK v21 / M3 spec evidence. No variant is selected here — `spec:design` decides.
+
+**Foundation already in place (verified in code):**
+- `GuiPickerOverlay` (`libs/ui/overlay/src/picker-overlay.ts`) exposes `openModal` (scrim
+  `gui-overlay-scrim`, `ConfigurableFocusTrapFactory` trap + `focusInitialElementWhenReady`, restore-focus
+  via captured `previouslyFocused`, `scrollStrategies.block()`, Escape + backdrop-click close),
+  `openDocked`, `openConnected`, `openGlobalBottom`; returns a `GuiOverlayHandle { ref, closed, close() }`.
+- Data-into-portal pattern: `Injector.create({ parent, providers:[{provide: GUI_*_DATA…}] })` +
+  `new ComponentPortal(Comp, null, injector)` (snackbar, tooltip).
+- Interaction primitives: `GuiStateLayerDirective`, `GuiRippleDirective`, `GuiFocusRingDirective`,
+  `GuiReducedMotion`, and `createRovingFocus()` (wraps CDK `FocusKeyManager`) — all in `@ngguide/ui/interaction`.
+- `@angular/cdk` **21.2.13** installed; overlay/portal/a11y already used; **drag-drop and BreakpointObserver
+  not yet used anywhere**.
+- Full M3 token set incl. `--md-sys-color-scrim`, `surface-container-*`, `outline-variant`,
+  `--md-sys-elevation-level0..5`, `--md-sys-shape-corner-*`, discrete typescale tokens, motion duration/easing.
+
+## Problem Areas
+
+### 1. Modal overlay foundation
+
+_Related requirements: 7, 8, 9, 10, 12_
+
+The shared scrim + focus-trap + restore-focus + scroll-lock + Escape + dialog-semantics + stacking layer
+used by basic dialog, full-screen dialog, modal bottom sheet, and modal side sheet.
+
+#### Variant A: Extend the existing `GuiPickerOverlay.openModal`
+
+**How it works:** Reuse `openModal` as-is for centered dialogs; add the missing APG bits in the *content*
+components (set `role="dialog"`/`alertdialog`, `aria-modal="true"`, `aria-labelledby` on the surface) and
+extend the service with sheet-shaped openers (`openModalSheet({ side:'bottom'|'end' })`) that swap the
+global position strategy, mirroring how `openGlobalBottom`/`openConnected` were already added. Stacking is
+handled by CDK's overlay container DOM order; Escape/focus already target the active overlay's `keydownEvents`.
+
+**Pros:**
+- Smallest new surface; one overlay abstraction for the whole library (consistent with snackbar/tooltip/menu).
+- Focus-trap, restore-focus, `block()` scroll-lock, scrim, Escape, backdrop-click already implemented and tested.
+- No new dependency footprint.
+
+**Cons:**
+- `openModal` currently uses `TemplatePortal`; sheets/dialogs that open imperatively with data need the
+  generic-`Portal` treatment (already done for `openGlobalBottom`) — a small refactor.
+- APG attributes (`aria-modal`, `role`, labelledby) are not set centrally today — each content component
+  must wire them, risking drift; could be centralized via a config like the existing `openModal` `ariaLabel`.
+- Multi-modal stacking (Escape routes to top-most, restore in reverse order — Req 12.8) is **not explicitly
+  implemented**; relies on CDK DOM-order + per-overlay `keydownEvents`, needs verification.
+
+**Effort:** Low–Medium | **Risk:** Medium (stacking + scroll-lock layout-shift edge cases)
+**Codebase fit:** Direct extension of `libs/ui/overlay/src/picker-overlay.ts`; matches the precedent of
+adding `openGlobalBottom`/`openConnected` during the communication spec.
+**Evidence:** `openModal` body (scrim/trap/block/restore) read in `picker-overlay.ts`. [cdk-overlay]
+confirms `OverlayRef.keydownEvents()/backdropClick()/detachments()`, `GlobalPositionStrategy`
+(`bottom/end/centerHorizontally`), `scrollStrategies.block()`. Overlay z-index/stacking order is
+**needs investigation** (not in fetched CDK docs; DOM-order stacking is inferred). [cdk-blockscroll]
+BlockScrollStrategy exact layout-shift mechanism is **needs investigation**.
+
+#### Variant B: Adopt the headless CDK `@angular/cdk/dialog` `Dialog` service
+
+**How it works:** Use CDK's unstyled `Dialog` service as the foundation. `Dialog.open(Component, config)`
+returns a `DialogRef`; config carries `hasBackdrop`, `backdropClass`, `disableClose`, `autoFocus`
+(`'dialog'|'first-tabbable'|'first-heading'|selector`), `restoreFocus`, `ariaModal`, `ariaLabel`,
+`ariaLabelledBy`, `role` (`'dialog'|'alertdialog'`), `scrollStrategy`, `panelClass`, `width/height/maxWidth`,
+`data` (injected via `DIALOG_DATA`), `providers`, and **`container`** (swap the container component — one
+service can render a dialog container vs a bottom-sheet container vs a side-sheet container). `DialogRef`
+exposes `close(result)`, `closed`, `backdropClick`, `keydownEvents`, `outsidePointerEvents`, `disableClose`.
+
+**Pros:**
+- APG-complete out of the box: `aria-modal`, `role`, focus trap, restore-focus, Escape, autofocus targeting
+  — exactly Req 12 + Req 14.1, maintained by the Angular team.
+- `container` swap + `providers` gives dialog/bottom-sheet/side-sheet *one* opener with three styled containers.
+- `DIALOG_DATA` + `DialogRef` replace the bespoke `GUI_*_DATA`/controller token plumbing.
+
+**Cons:**
+- Introduces a *second* overlay abstraction beside `GuiPickerOverlay` (which would still own picker/tooltip/
+  snackbar) — two patterns in one library unless picker is later migrated too.
+- Drag-to-dismiss for bottom sheet still must be layered on top (CDK Dialog has no drag).
+- Default scroll strategy for CDK Dialog must be set to `block()` explicitly; styling is 100% ours (a plus and a cost).
+
+**Effort:** Medium | **Risk:** Low (battle-tested, already shipped in installed `@angular/cdk` 21.2.13)
+**Codebase fit:** New dependency-on-CDK-Dialog; diverges from the single-`GuiPickerOverlay` story but uses
+the same underlying CDK overlay the project already depends on.
+**Evidence:** Full `DialogConfig`/`DialogRef`/`DIALOG_DATA` surface verified against the `/angular/components`
+golden API files. [cdk-dialog] Confirmed present in v21; Escape-closes-by-default; `container`/`providers`
+swap confirmed.
+
+#### Variant C: Purpose-built `GuiModalOverlay` from raw CDK Overlay primitives
+
+**How it works:** A new dedicated service composing `Overlay.create` + `ConfigurableFocusTrapFactory` +
+`scrollStrategies.block()` + an explicit stack registry (array of open handles; Escape/restore driven by the
+registry to satisfy Req 12.8 precisely), with first-class `role`/`aria-modal`/labelledby config and
+side-aware position strategies. Essentially a richer sibling of `openModal` built specifically for containment.
+
+**Pros:**
+- Total control over stacking order, restore-focus chains, and APG attribute centralization (Req 12.8 done deliberately).
+- Single tailored abstraction for all four modal surfaces; no reliance on CDK Dialog's opinions.
+- Can host the drag interaction natively (sheet handle integrated).
+
+**Cons:**
+- Most code to write and test; re-implements much of what CDK Dialog already does correctly.
+- Higher risk of subtle a11y bugs that CDK Dialog has already fixed (focus restoration timing, anchor elements).
+
+**Effort:** High | **Risk:** Medium–High
+**Codebase fit:** New file under `libs/ui/overlay/`; conceptually consistent but duplicates CDK Dialog effort.
+**Evidence:** Same CDK Overlay/a11y primitives as Variant A. [cdk-overlay][cdk-a11y]
+
+---
+
+### 2. Imperative open API + content projection
+
+_Related requirements: 7.6, 16.2_
+
+How developers open dialogs/sheets and how content + a result channel are wired.
+
+#### Variant A: Bespoke service + `ComponentPortal` + DI tokens (snackbar pattern)
+
+**How it works:** A `GuiDialog`/`GuiBottomSheet` service with `open(Component, config): GuiDialogRef`.
+Internally `Injector.create({ parent, providers:[{provide: GUI_DIALOG_DATA, useValue}, {provide:
+GUI_DIALOG_REF, useValue: ref}] })` + `new ComponentPortal(Component, null, injector)` handed to the chosen
+opener from Area 1. The ref exposes `closed`/`afterDismissed`/`result` Subjects — exactly the snackbar `SnackbarRefImpl` shape.
+
+**Pros:**
+- Identical to the already-shipped snackbar/tooltip plumbing; consistent mental model across the library.
+- Full control over the ref API surface and naming.
+
+**Cons:**
+- Hand-rolls data injection + ref lifecycle that CDK Dialog provides for free (only worth it if Area 1 ≠ B).
+- Component-only content (no inline template content unless a TemplatePortal path is added).
+
+**Effort:** Low–Medium | **Risk:** Low
+**Codebase fit:** Mirrors `libs/ui/snackbar/src/snackbar.service.ts`.
+**Evidence:** snackbar `Injector.create` + `ComponentPortal` + ref Subjects read in code.
+
+#### Variant B: CDK `Dialog.open()` + `DIALOG_DATA` + `DialogRef`
+
+**How it works:** Thin `GuiDialog.open(Component, {data,…})` delegating to CDK `Dialog`; content components
+`inject(DIALOG_DATA)` and `inject(DialogRef)` to read data and `close(result)`. Result flows through
+`DialogRef.closed`.
+
+**Pros:**
+- Near-zero plumbing; data, ref, result, focus, and a11y all handled.
+- `DialogRef.close(result)` → `closed: Observable<result>` is exactly Req 7.4/7.6/16.2.
+
+**Cons:**
+- Couples this area to Area 1 Variant B (CDK Dialog foundation).
+- Ref API is CDK's, not ours (naming/shape less tailored).
+
+**Effort:** Low | **Risk:** Low
+**Codebase fit:** New (CDK Dialog), but reuses installed CDK.
+**Evidence:** `Dialog.open` / `DIALOG_DATA` / `DialogRef.close/closed` verified. [cdk-dialog]
+**Cross-area:** only makes sense if Area 1 = B.
+
+#### Variant C: Declarative trigger + `TemplatePortal` (rich-tooltip pattern)
+
+**How it works:** A `[guiDialogTrigger]="tpl"` directive (and/or `<gui-dialog><ng-template>…`) projecting an
+inline `<ng-template>` via `TemplatePortal(tpl, vcr)` into the opener, like `GuiRichTooltip.createPortal()`.
+Content lives in the host component's template; the trigger toggles open/closed.
+
+**Pros:**
+- Inline, declarative content with the host's own bindings — no separate component or DI tokens.
+- Reuses the confirmed `<ng-content>`-in-`<ng-template>` + `TemplatePortal` projection pattern (rich tooltip).
+
+**Cons:**
+- Imperative "open from code and await a result" is awkward; better for static/inline dialogs than dynamic ones.
+- Result/handle wiring is less natural than a service ref.
+
+**Effort:** Medium | **Risk:** Low–Medium
+**Codebase fit:** Mirrors `libs/ui/tooltip/src/rich-tooltip.ts`.
+**Evidence:** rich-tooltip `TemplatePortal` projection read in code.
+
+_Note: A and C are not mutually exclusive — a service `open()` for dynamic dialogs plus a declarative trigger
+for inline ones is a common combined offering. Listed separately so the design can pick one or both._
+
+---
+
+### 3. Bottom-sheet drag / swipe gesture
+
+_Related requirements: 9.3, 9.4, 9.6, 9.7_
+
+Drag the sheet (or handle) down to dismiss past a threshold, else spring back; suppress page scroll/selection mid-drag.
+
+#### Variant A: CDK drag-drop (`cdkDrag`)
+
+**How it works:** Put `cdkDrag cdkDragLockAxis="y"` on the sheet; `cdkDragConstrainPosition` clamps upward
+past the rest position; `cdkDragMoved` drives live `distance.y` (fade the scrim); on `cdkDragEnded` read
+`distance.y` — past threshold → `ref.close()`, else `setFreeDragPosition({x:0,y:0})` with a CSS transition for spring-back.
+
+**Pros:**
+- Purpose-built gesture engine; `lockAxis`, `distance`, `setFreeDragPosition`, `constrainPosition` all exist.
+- Handles pointer capture, touch, and momentum edges the team would otherwise hand-roll.
+
+**Cons:**
+- First use of `@angular/cdk/drag-drop` in the repo (new directive surface, but same CDK package).
+- Slightly heavyweight for a one-axis drag.
+
+**Effort:** Medium | **Risk:** Low
+**Codebase fit:** New CDK module; no existing precedent in the repo.
+**Evidence:** `cdkDragLockAxis`, `cdkDragMoved {distance,pointerPosition}`, `cdkDragEnded {distance}`,
+`setFreeDragPosition`, `cdkDragConstrainPosition` verified; suited to drag-then-dismiss-or-spring-back. [cdk-dragdrop]
+
+#### Variant B: Raw pointer events (snackbar-swipe pattern)
+
+**How it works:** `pointerdown`/`pointermove`/`pointerup` on the handle/sheet; track `deltaY`; translate the
+sheet via `transform`; on release, past threshold → close, else animate back. `touch-action: none` +
+`user-select: none` during drag. This is the same approach the snackbar already uses for horizontal swipe (>80px).
+
+**Pros:**
+- Zero new dependencies; same technique already in `snackbar.service.ts`.
+- Fully deterministic and easy to reason about for SSR/zoneless.
+
+**Cons:**
+- Hand-rolls velocity/inertia, pointer capture, and multi-touch correctness that CDK already solved.
+- More edge-case test surface (cancel, pointercancel, scroll conflict).
+
+**Effort:** Medium | **Risk:** Medium
+**Codebase fit:** Mirrors the snackbar swipe handler.
+**Evidence:** snackbar pointer-swipe (>80px) read in code; no `Date.now` used there (Req 16.4-safe).
+
+#### Variant C: Native CSS scroll-snap sheet
+
+**How it works:** Render the sheet as a scroll container whose snap points are "open" and "dismissed";
+dragging is native scroll; crossing the snap boundary dismisses.
+
+**Pros:**
+- Minimal JS; native momentum.
+
+**Cons:**
+- Hard to map "scrolled to dismissed snap point" back to a clean `close(reason)` event and scrim fade.
+- Drag *handle* affordance and threshold semantics don't map cleanly to scroll-snap; M3 expects a draggable surface.
+
+**Effort:** Low–Medium | **Risk:** Medium–High (behavioral fidelity)
+**Codebase fit:** No precedent.
+**Evidence:** needs investigation (no fetched source for scroll-snap-driven dismissal ergonomics).
+
+---
+
+### 4. Carousel layout & sizing engine
+
+_Related requirements: 11_
+
+M3 carousel: items continuously resize between large/medium/small as they approach the edges (keyline model),
+across multi-browse, uncontained, hero, full-screen layouts.
+
+#### Variant A: CSS scroll-snap, fixed per-layout widths (no keyline masking)
+
+**How it works:** A flex/scroll row with `scroll-snap-type: x mandatory`, items at fixed widths per layout
+(large/medium/small computed once via CSS custom properties / container queries), `scroll-snap-align`, items
+clipped to the carousel item corner shape. No JS resize as items scroll.
+
+**Pros:**
+- Simplest; SSR-safe, deterministic, no scroll listeners.
+- Native momentum + snapping.
+
+**Cons:**
+- **Diverges from M3**: items don't continuously expand/collapse between sizes (the defining M3 carousel
+  behavior). Effectively a styled scroller, not the keyline carousel.
+- "Peeking smallest item" and parallax are approximations.
+
+**Effort:** Low | **Risk:** Low (but M3-fidelity gap — conflicts with the strict-M3 rule)
+**Codebase fit:** Pure CSS; aligns with the repo's CSS-token approach.
+**Evidence:** M3 carousel uses keyline masking (continuous resize), not fixed sizes. [m3-carousel-src]
+
+#### Variant B: Full JS keyline sizing engine (port of the M3 algorithm)
+
+**How it works:** Port the Compose Material3 keyline model: define keylines along the scroll axis; on scroll,
+interpolate each item's size/clip between the keyline before and after its center. Implement the verified
+sizing rules — small `= clamp(large/3, 40dp, 56dp)`, medium `= (large+small)/2`, multi-browse caps non-focal
+items at 2 and drops small below 80dp width; hero start/center-aligned with 1–2 small; uncontained resizes
+only the last cut-off item; full-screen = single item, vertical on compact. Drive item width/`clip-path` via a
+scroll listener + `ResizeObserver`.
+
+**Pros:**
+- True M3 fidelity (the only variant that matches the strict-M3 rule for the carousel's core behavior).
+- All four layouts share one engine.
+
+**Cons:**
+- Highest effort and the largest test surface in the category; scroll-driven layout math.
+- Scroll listeners + zoneless: must update via signals/`afterRenderEffect` without a zone; keep math pure/deterministic.
+- SSR: must render a sensible static first frame before the engine runs client-side.
+
+**Effort:** High | **Risk:** High
+**Codebase fit:** New; no precedent in the repo for scroll-driven sizing.
+**Evidence:** Verified sizing constants and keyline model from Compose Material3 source: small=large/3 clamp
+[40dp,56dp], medium=(large+small)/2, multi-browse max 2 non-focal + drop <80dp, hero variants, uncontained
+last-item resize, `MinSmallItemSize=40dp`/`MaxSmallItemSize=56dp`, item corner = extra-large/28dp. [m3-carousel-src][mca-carousel]
+Parallax multiplier + exact full-screen compact thresholds are **needs investigation** (spec page JS-only).
+
+#### Variant C: Hybrid — CSS scroll-snap + `ResizeObserver` arrangement (discrete sizes, no per-pixel masking)
+
+**How it works:** Native scroll-snap for scrolling/snapping; a `ResizeObserver`-driven arrangement computes
+large/medium/small *target* widths per layout (using the verified sizing rules) and assigns each item a size
+class by its position, but without continuous per-frame keyline interpolation. Items change size at snap
+boundaries rather than every scroll pixel.
+
+**Pros:**
+- Much of the M3 visual structure (large + medium + peeking small) without a per-frame scroll engine.
+- `ResizeObserver` only (no high-frequency scroll math); easier zoneless/SSR story than Variant B.
+
+**Cons:**
+- Not the continuous keyline morph — a partial-fidelity middle ground; still a deviation from strict M3.
+- Snap-boundary size changes can look steppy versus M3's smooth interpolation.
+
+**Effort:** Medium | **Risk:** Medium
+**Codebase fit:** New, but lighter than B.
+**Evidence:** Same verified sizing constants as Variant B. [m3-carousel-src] Continuous-vs-discrete fidelity
+tradeoff is inference, not a fetched M3 statement.
+
+---
+
+### 5. List semantics & selection model
+
+_Related requirements: 4, 5, 6_
+
+Anatomy/densities are token-driven; the decision is the interaction/selection semantics.
+
+#### Variant A: Presentation list of controls (APG list + button/link)
+
+**How it works:** `role="list"`/`listitem` (or native `<ul>/<li>`); interactive items render a nested
+`<button>`/`<a>` (or apply the interaction directives to a focusable item). Selection is conveyed by the
+trailing control's own state (checkbox/switch). Keyboard = natural tab order (or `createRovingFocus` for a
+single tab stop with arrow navigation).
+
+**Pros:**
+- Simple, robust; matches "a list of actions/links".
+- Trailing checkbox/switch carry their own a11y state — no custom selection role needed.
+
+**Cons:**
+- Not a single-select "listbox"; for choose-one-of-many semantics this isn't the APG-correct role.
+- Must avoid double-announcing (item + control) — keep one accessible name (Req 6.4).
+
+**Effort:** Medium | **Risk:** Low–Medium
+**Codebase fit:** Reuses interaction directives + optional `createRovingFocus` (chip-set precedent).
+**Evidence:** `createRovingFocus` (FocusKeyManager) read in `chip-set.ts`; APG list/button. [apg-dialog reference set]; list token values (56/72/88dp, leading 24/40/56dp, body-large/body-medium, 16dp insets) verified. [m3-list-src]
+
+#### Variant B: Listbox (`role="listbox"`/`option`)
+
+**How it works:** `role="listbox"` container + `role="option"` items with `aria-selected`; single/multi-select
+managed via CDK `ListKeyManager`/`ActiveDescendantKeyManager` (active-descendant) or `FocusKeyManager`
+(roving). Selected items render the M3 secondary-container treatment.
+
+**Pros:**
+- APG-correct for selection lists (single/multi); first-class `aria-selected` state.
+- CDK key managers provide typeahead, wrap, home/end, page up/down.
+
+**Cons:**
+- Listbox options shouldn't contain independently-focusable controls — conflicts with trailing checkbox/switch
+  rows (Req 5.2/6.4) unless modeled as multi-select options rather than nested controls.
+- More semantics to get right; overkill for plain link/action lists.
+
+**Effort:** Medium–High | **Risk:** Medium
+**Codebase fit:** Reuses CDK `ListKeyManager` family (re-exported from `@ngguide/ui/interaction`).
+**Evidence:** `ListKeyManager`/`FocusKeyManager`/`ActiveDescendantKeyManager` full surface verified. [cdk-a11y]
+
+#### Variant C: Unopinionated structure + opt-in behavior directives
+
+**How it works:** Ship the list/list-item as pure structure + tokens (heights, leading/trailing slots, dividers,
+selected styling via `[attr.aria-selected]`/`data-selected`), and expose interaction as opt-in (`interactive`,
+`selectable` inputs) that the consumer or a higher-level component wires to the right role. Provide both an
+"action list" mode (Variant A semantics) and a "listbox" mode (Variant B semantics) behind a `mode` input.
+
+**Pros:**
+- One component covers links, action rows, and selection lists; consumer picks semantics.
+- Avoids forcing one APG pattern onto all uses.
+
+**Cons:**
+- Larger API; must document which mode maps to which APG pattern to avoid misuse.
+- More test matrix (both modes).
+
+**Effort:** Medium–High | **Risk:** Medium
+**Codebase fit:** Combines A and B; reuses interaction + key managers.
+**Evidence:** Same as A and B.
+
+---
+
+### 6. Static surfaces — card & divider (and actionable-card a11y)
+
+_Related requirements: 1, 2, 3_
+
+Divider is trivial (`role="separator"`, 1dp `outline-variant`, inset variants). The real decision is how an
+*actionable* card exposes itself without nesting interactive controls illegally.
+
+#### Variant A: Whole-surface control (card is one button/anchor)
+
+**How it works:** Actionable card host is the control: `<a gui-card>` for navigation or `role="button"` +
+`tabindex` + Enter/Space activation for actions, with `hostDirectives:[StateLayer,Ripple,FocusRing]` (the
+button precedent). Emits an activation event.
+
+**Pros:**
+- Simplest; one focus stop; matches the button component pattern exactly.
+- Clean for cards whose entire surface is a single action (e.g. a tappable media card).
+
+**Cons:**
+- **Nesting violation**: interactive elements (buttons/links) inside a card that is itself a button/link is
+  invalid and breaks AT. Unsuitable for cards that contain their own action buttons (a common M3 card).
+
+**Effort:** Low | **Risk:** Medium (misuse when consumers add inner buttons)
+**Codebase fit:** Mirrors `button.ts` (hostDirectives + activation).
+**Evidence:** button activation + hostDirectives read in code; APG forbids interactive-in-interactive (inferred from APG dialog/general APG nesting guidance — [apg]).
+
+#### Variant B: Primary-action region (clickable area + separate actions)
+
+**How it works:** The card stays a non-interactive container; a designated **primary-action region**
+(`[guiCardPrimaryAction]`, e.g. media + headline) is the single control (button/anchor with the interaction
+directives), while action buttons live in a separate, non-overlapping region of the card. This is the M3
+"card with a primary action plus supplemental actions" structure.
+
+**Pros:**
+- APG-correct: no nested interactive controls; supports cards with their own action buttons.
+- Matches M3 actionable-card guidance (primary action + secondary actions).
+
+**Cons:**
+- Slightly more structure/markup; consumers must place content in the right slot.
+
+**Effort:** Medium | **Risk:** Low
+**Codebase fit:** New slotting convention; interaction directives reused on the region.
+**Evidence:** Card variant tokens (elevated=surface-container-low/level1, hover level2, dragged level4;
+filled=surface-container-highest/level0; outlined=surface/level0 + outline-variant 1dp; corner-medium 12dp)
+verified. [m3-card-src] Nesting rule [apg].
+
+#### Variant C: Offer both modes
+
+**How it works:** Support a fully-clickable card (Variant A) for simple cases *and* a primary-action region
+(Variant B) for cards with inner actions, selected by how the consumer composes the card.
+
+**Pros:** Covers both M3 actionable-card shapes.
+**Cons:** Two code paths + docs to prevent the nesting mistake.
+**Effort:** Medium | **Risk:** Low–Medium
+**Codebase fit:** Union of A and B.
+**Evidence:** As A and B.
+
+_Component-vs-directive sub-choice (orthogonal): `gui-card` element + `gui-divider` element (host data-attrs,
+matches most existing components) vs `[guiCard]`/`[guiDivider]` attribute directives (matches badge). Low-stakes;
+design can pick to match the prevailing convention._
+
+---
+
+### 7. Responsive / compact-window detection
+
+_Related requirements: 8 (full-screen dialog is compact-only), 11.6 (carousel full-screen vertical on compact)_
+
+#### Variant A: CSS-only (media / container queries)
+
+**How it works:** Express compact-window differences purely in CSS (`@media (max-width: 599px)` or container
+queries). Full-screen dialog styling and carousel full-screen vertical layout are CSS-driven; no JS branch.
+
+**Pros:**
+- SSR-safe and deterministic (Req 16.3/16.4); no `matchMedia` on the server.
+- Zero runtime cost; aligns with the repo's CSS-token approach.
+
+**Cons:**
+- Component *logic* can't branch on the breakpoint (e.g. "auto-pick full-screen vs basic dialog by window size")
+  — only styling differs. If the design wants logic branches, CSS alone is insufficient.
+
+**Effort:** Low | **Risk:** Low
+**Codebase fit:** Pure CSS.
+**Evidence:** M3 compact breakpoint < 600dp verified. [m3-breakpoints]
+
+#### Variant B: CDK `BreakpointObserver` / `MediaMatcher` signal
+
+**How it works:** A reactive signal of the compact breakpoint (reusing the `GuiReducedMotion` `MediaMatcher`
+precedent, or CDK `BreakpointObserver.observe(Breakpoints.Handset)`), letting components branch logic (choose
+dialog type, switch carousel orientation) reactively.
+
+**Pros:**
+- Enables logic branches, not just styling; one source of truth for "is compact".
+- `MediaMatcher` already used SSR-safely in `reduced-motion.ts` (server → non-match, re-evaluates on client).
+
+**Cons:**
+- SSR returns non-matching first frame → must avoid layout shift on hydration (Req 16.3).
+- Slightly more machinery than CSS for cases CSS already covers.
+
+**Effort:** Low–Medium | **Risk:** Low–Medium (hydration shift)
+**Codebase fit:** Mirrors `GuiReducedMotion` (`MediaMatcher` signal).
+**Evidence:** `BreakpointObserver.observe/isMatched` + `Breakpoints.Handset` verified; SSR behavior inferred,
+**needs investigation** for exact server matcher. [cdk-breakpoints] `MediaMatcher` SSR-safe usage read in `reduced-motion.ts`.
+
+#### Variant C: Hybrid (CSS for styling, signal for the few logic branches)
+
+**How it works:** Use CSS for all pure-styling responsive differences; introduce a compact signal only where a
+component genuinely needs to *branch behavior* (e.g. carousel orientation, optional auto-full-screen dialog).
+
+**Pros:** Minimizes JS; keeps SSR-sensitive logic to the few places that need it.
+**Cons:** Two mechanisms to keep coherent.
+**Effort:** Low–Medium | **Risk:** Low
+**Codebase fit:** CSS + the `GuiReducedMotion` pattern.
+**Evidence:** As A and B.
+
+## Variant Catalogue at a glance
+
+| Problem Area | Variant | Effort | Risk | Codebase fit |
+|-------------|---------|--------|------|--------------|
+| 1. Modal foundation | A: Extend `GuiPickerOverlay.openModal` | L–M | M | Direct extension of overlay service |
+| 1. Modal foundation | B: CDK headless `Dialog` service | M | L | New CDK-Dialog use; same installed CDK |
+| 1. Modal foundation | C: New `GuiModalOverlay` from raw CDK | H | M–H | New, duplicates CDK Dialog |
+| 2. Open API | A: Bespoke service + ComponentPortal + DI tokens | L–M | L | Snackbar precedent |
+| 2. Open API | B: CDK `Dialog.open` + `DIALOG_DATA` + `DialogRef` | L | L | Needs Area 1=B |
+| 2. Open API | C: Declarative trigger + `TemplatePortal` | M | L–M | Rich-tooltip precedent |
+| 3. Sheet drag | A: CDK drag-drop | M | L | New CDK module |
+| 3. Sheet drag | B: Raw pointer events | M | M | Snackbar swipe precedent |
+| 3. Sheet drag | C: CSS scroll-snap | L–M | M–H | No precedent |
+| 4. Carousel | A: CSS scroll-snap fixed widths | L | L (M3-gap) | Pure CSS |
+| 4. Carousel | B: Full JS keyline engine | H | H | New scroll-driven sizing |
+| 4. Carousel | C: Hybrid scroll-snap + ResizeObserver | M | M | New, lighter than B |
+| 5. List | A: Presentation list of controls | M | L–M | Interaction dirs + roving |
+| 5. List | B: Listbox role + key manager | M–H | M | CDK ListKeyManager |
+| 5. List | C: Unopinionated + opt-in modes | M–H | M | Union of A+B |
+| 6. Card/divider | A: Whole-surface control | L | M | Button precedent |
+| 6. Card/divider | B: Primary-action region | M | L | New slotting |
+| 6. Card/divider | C: Both modes | M | L–M | Union |
+| 7. Responsive | A: CSS-only | L | L | Pure CSS |
+| 7. Responsive | B: BreakpointObserver/MediaMatcher signal | L–M | L–M | ReducedMotion precedent |
+| 7. Responsive | C: Hybrid | L–M | L | CSS + signal |
+
+## Cross-area dependencies
+
+- **Area 2 Variant B** (CDK `Dialog.open` + `DIALOG_DATA`) only makes sense if **Area 1 = Variant B** (CDK
+  Dialog foundation); the CDK ref/data come from that service. If Area 1 ≠ B, use Area 2 Variant A or C.
+- **Area 1 Variant B** largely *resolves* Area 2 for free (CDK Dialog gives data injection + ref + result).
+- **Area 3** (sheet drag) layers on whatever Area 1 picks — CDK Dialog (1B) has no drag, so the drag variant
+  (3A/3B) is additive regardless.
+- **Area 7 Variant B/C** (compact signal) is what lets **Area 8/full-screen dialog** auto-select by window size
+  and **carousel full-screen** (Area 4) switch orientation; if Area 7 = A (CSS-only), those become styling-only.
+
+## Codebase Insights
+
+- `GuiPickerOverlay.openModal` already implements the hard 80% of APG modal (trap, restore, scrim, block,
+  Escape, backdrop). The gap is centralizing `role`/`aria-modal`/labelledby and **multi-modal stacking order**
+  (Req 12.8), which is currently implicit in CDK overlay DOM order — verify or make explicit.
+- The snackbar (`Injector.create` + `ComponentPortal` + ref Subjects) and rich-tooltip (`TemplatePortal`
+  projection) give two proven content-projection templates to copy.
+- `createRovingFocus` (FocusKeyManager) is already used by `chip-set.ts` for horizontal roving — directly
+  reusable for lists.
+- `GuiReducedMotion` shows the SSR-safe `MediaMatcher` signal pattern to copy for compact-window detection.
+- `@angular/cdk/drag-drop` and `@angular/cdk/layout` (BreakpointObserver) are installed but unused — first use
+  here; no module wiring needed for standalone directives.
+- Every required token exists (`--md-sys-color-scrim`, `surface-container-*`, `outline-variant`,
+  `elevation-level0..5`, `shape-corner-*`, discrete typescale, motion). No new tokens needed.
+- Global component CSS for directive-only surfaces ships via `libs/ui/src/styles/*.css` `@import`ed in
+  `theme.css` (overlay.css/badge.css precedent) — applies to scrim/sheet/dialog global styles.
+
+## Sources
+
+- [cdk-dialog] `@angular/cdk/dialog` `Dialog`/`DialogConfig`/`DialogRef`/`DIALOG_DATA` — context7 `/angular/components`
+  golden `goldens/cdk/dialog/index.api.md` + `src/cdk/dialog/dialog.md` — fetched 2026-06-03
+- [cdk-overlay] CDK Overlay `Overlay.create`/`OverlayConfig`/`OverlayRef`/`GlobalPositionStrategy`/`ScrollStrategyOptions` —
+  context7 `/angular/components` `goldens/cdk/overlay/index.api.md` + `src/cdk/overlay/*.md` — fetched 2026-06-03
+- [cdk-a11y] CDK A11y `ConfigurableFocusTrapFactory`/`FocusTrap`/`FocusMonitor`/`ListKeyManager`/`FocusKeyManager`/
+  `ActiveDescendantKeyManager`/`LiveAnnouncer` — context7 `/angular/components` `goldens/cdk/a11y/index.api.md` — fetched 2026-06-03
+- [cdk-dragdrop] CDK Drag-Drop `cdkDrag`/`cdkDragLockAxis`/`cdkDragMoved`/`cdkDragEnded`/`setFreeDragPosition`/
+  `cdkDragConstrainPosition` — context7 `/angular/components` `goldens/cdk/drag-drop/index.api.md` — fetched 2026-06-03
+- [cdk-breakpoints] CDK Layout `BreakpointObserver`/`Breakpoints` — context7 `/angular/components` `goldens/cdk/layout/index.api.md` — fetched 2026-06-03
+- [cdk-blockscroll] CDK `BlockScrollStrategy` — context7 `/angular/components` `src/cdk/overlay/scroll/scroll-strategy.md` — fetched 2026-06-03
+- [m3-card-src] M3 card tokens (Elevated/Filled/Outlined CardTokens, ElevationTokens) — AndroidX Compose Material3
+  `…/tokens/{Elevated,Filled,Outlined}CardTokens.kt`, `ElevationTokens.kt` — fetched 2026-06-03
+- [m3-list-src] M3 list tokens (`ListTokens.kt`, `ListItem.kt`) — AndroidX Compose Material3 — fetched 2026-06-03
+- [m3-carousel-src] M3 carousel keyline model + sizing (`carousel/Carousel.kt`, `Keylines.kt`) — AndroidX Compose Material3 — fetched 2026-06-03
+- [mca-carousel] Material Components Android Carousel docs — https://github.com/material-components/material-components-android/blob/master/docs/components/Carousel.md — fetched 2026-06-03
+- [m3-divider-src] M3 `DividerTokens.kt` + Material Web divider docs — AndroidX Compose Material3 /
+  https://github.com/material-components/material-web/blob/main/docs/components/divider.md — fetched 2026-06-03
+- [m3-dialog-tok] M3 dialog/sheet tokens (Material Web `_md-comp-dialog.scss`, Compose `SheetBottomTokens.kt`, MDC SideSheet/Dialog docs) — fetched 2026-06-03
+- [m3-breakpoints] M3 breakpoints (compact < 600dp) — https://m3.material.io/foundations/layout/breakpoints/overview — fetched 2026-06-03
+- [apg] WAI-ARIA APG Modal Dialog + Alert Dialog patterns — https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/ and /alertdialog/ — fetched 2026-06-03
+
+## Open Questions
+
+- [ ] M3 dialog / sheet **motion durations** (exact enter/exit duration tokens) — only the easing pairing
+      (emphasized decelerate enter / accelerate exit) is verified; durations are inferred (≈400ms/200ms). Confirm in design.
+- [ ] **Overlay stacking / z-index order** for nested modals (Req 12.8) — CDK DOM-order stacking is inferred,
+      not documented; verify whether an explicit stack registry is needed.
+- [ ] **BlockScrollStrategy** exact layout-shift behavior (does it set `position:fixed` on `<html>`?) — confirm to avoid hydration/scrollbar jump.
+- [ ] Carousel **parallax multiplier** and **full-screen compact vertical-scroll thresholds** — not fetchable
+      from the JS-rendered spec page; would need the agent-browser skill or design-time decision.
+- [ ] Bottom-sheet **drag-to-dismiss numeric threshold** and **larger-screen max-width** — implementation-defined
+      in M3; pick a concrete value in design.
+- [ ] Dialog **scrim color role** exact name on m3.material.io (token `--md-sys-color-scrim` exists; M3 page prose unfetched).
+- [ ] Side-sheet **default edge** (end assumed) and **motion** specifics — confirm against M3 page in design.
+
+## Next Steps
+
+`spec:design containment` will pick one variant per problem area and produce the technical design.
+
+If new directions surface during design, run `spec:research containment` again — it will extend this
+catalogue rather than overwrite it.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -261,7 +261,7 @@ Modal + standard side sheet on the end edge. Depends on Group A. Blast radius: *
 Pure keyline engine + components implementing the four M3 layouts. Independent of the overlay foundation.
 Blast radius: **safe**.
 
-- [ ] 24. Keyline sizing engine (pure)
+- [x] 24. Keyline sizing engine (pure)
   - Scaffold `@ngguide/ui/carousel` (+ wiring).
   - `carousel-keylines.ts`: `GuiCarouselLayout`, `MIN_SMALL_ITEM=40`, `MAX_SMALL_ITEM=56`,
     `KeylineArrangement`, `arrange(layout, viewportWidth, opts)` (small=clamp(large/3,40,56),
@@ -271,7 +271,7 @@ Blast radius: **safe**.
   - Test (`carousel-keylines.spec.ts`): the verified sizing rules per layout; small clamp; drop-below-threshold.
   - _Requirements: 11.2, 11.3, 11.5, 16.4_
 
-- [ ] 25. Carousel + item components
+- [x] 25. Carousel + item components
   - `carousel.ts`: `GuiCarousel` (`gui-carousel`, OnPush, `layout`, `preferredLargeWidth` default 186,
     `itemSpacing` default 8, host `role=group`+`aria-roledescription=carousel`+`data-layout`); injects
     `GuiBreakpoint` + `GuiReducedMotion`; `afterNextRender` sets up `ResizeObserver(track)` + scroll listener
@@ -282,7 +282,7 @@ Blast radius: **safe**.
     items get widths from the engine after layout.
   - _Requirements: 11.1, 11.4, 16.3, 16.4_
 
-- [ ] 26. Layouts, full-screen orientation, reduced motion + demo
+- [x] 26. Layouts, full-screen orientation, reduced motion + demo
   - `GuiCarousel.effectiveLayout()`: full-screen layout switches to vertical orientation on compact
     (`GuiBreakpoint.isCompact()`); under `GuiReducedMotion`, disable per-scroll size morphing (items render at
     arranged sizes). Verify multi-browse/uncontained/hero/full-screen all render per the engine.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -103,13 +103,13 @@ Two structural entry points reusing tokens + interaction directives; no overlay 
   - Export from index; test (`divider.spec.ts`): `role=separator`, `data-inset` reflects input, not focusable.
   - _Requirements: 3.1–3.4, 13.1, 14.5_
 
-- [ ] 7. Demo — card + divider
+- [x] 7. Demo — card + divider
   - `apps/web/src/app/app.component.ts/.html`: import `GuiCard`/`GuiCardClickable`/`GuiCardPrimaryAction`/
     `GuiDivider`; add a containment demo section showing all three card variants, a clickable card, a
     primary-action card with separate action buttons, and the three divider insets.
   - _Requirements: 1, 2, 3_
 
-- [ ] 8. Checkpoint — Group B verification
+- [x] 8. Checkpoint — Group B verification
   - `pnpm exec nx test ui` (card + divider specs pass); `nx test web` if demo wiring added bindings.
   - `pnpm exec nx run-many -t lint build --projects=ui,web` green; both new entry points build via ng-packagr.
   - Confirm `@ngguide/ui/card` and `@ngguide/ui/divider` resolve from `tsconfig.base.json` paths.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -67,7 +67,7 @@ Blast radius: **safe** — additive helpers, inert until a later group imports t
   - Add `@import './scrim.css';` to `libs/ui/src/styles/theme.css` (after `badge.css`).
   - _Requirements: 12.1, 15.2_
 
-- [ ] 4. Checkpoint — Group A verification
+- [x] 4. Checkpoint — Group A verification
   - Run new specs: `pnpm exec nx test ui` (breakpoint + modal specs pass).
   - Run existing overlay spec to catch regressions: confirm `picker-overlay.spec.ts` still green.
   - `pnpm exec nx run-many -t lint build --projects=ui` green; confirm `@ngguide/ui/overlay` still builds.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -290,7 +290,7 @@ Blast radius: **safe**.
   - Test: full-screen compact orientation; reduced-motion disables morph; resize re-arranges (Req 11.5/11.6).
   - _Requirements: 11.5, 11.6, 15.1, 15.2, 15.3_
 
-- [ ] 27. Final checkpoint — everything green
+- [x] 27. Final checkpoint — everything green
   - Full suite: `pnpm exec nx run-many -t lint test build --projects=ui,web` green.
   - All seven entry points (`card, divider, list, dialog, bottom-sheet, side-sheet, carousel`) build via
     ng-packagr and resolve from `tsconfig.base.json`.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -77,7 +77,7 @@ Blast radius: **safe** — additive helpers, inert until a later group imports t
 
 Two structural entry points reusing tokens + interaction directives; no overlay dependency. Blast radius: **safe**.
 
-- [ ] 5. Card entry point
+- [x] 5. Card entry point
   - Scaffold `@ngguide/ui/card` (+ wiring steps 1–4 from the Overview; card ships `styles/card.css` only if
     a global rule is needed — prefer component `card.css`).
   - `libs/ui/card/src/card.ts`: `GuiCard` (`selector: gui-card`, OnPush, `variant` input

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -182,7 +182,7 @@ Depends on Group A (modal foundation). Blast radius: **coupled to Group A** (imp
     + header; content scrolls; reduced-motion disables animation.
   - _Requirements: 7.1, 7.3, 7.5, 8.1, 8.2, 8.4, 8.5, 15.1, 15.2, 15.3_
 
-- [ ] 15. Declarative trigger + demo
+- [x] 15. Declarative trigger + demo
   - `dialog.trigger.ts`: `[guiDialogTrigger]` directive (`TemplateRef` input + optional `guiDialogConfig`,
     opens on click via `GuiDialog`).
   - apps/web: import `GuiDialog` + slots + trigger; add buttons opening a basic dialog (icon/headline/2
@@ -190,7 +190,7 @@ Depends on Group A (modal foundation). Blast radius: **coupled to Group A** (imp
   - Test: trigger opens the template; Escape + scrim-click close (unless `disableClose`).
   - _Requirements: 7.2, 8.2, 8.3, 12.4, 12.5, 16.2_
 
-- [ ] 16. Checkpoint — Group D verification
+- [x] 16. Checkpoint — Group D verification
   - `pnpm exec nx test ui` (dialog specs pass) + existing overlay specs green.
   - lint + build green for `ui`,`web`; `@ngguide/ui/dialog` builds; demo opens/closes both dialog types with
     focus trap + restore verified in the browser.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -94,7 +94,7 @@ Two structural entry points reusing tokens + interaction directives; no overlay 
     suppresses activation + state layers; primary-action region emits independently.
   - _Requirements: 1.1–1.7, 2.1–2.6, 13.1–13.4, 14.3, 14.4_
 
-- [ ] 6. Divider entry point
+- [x] 6. Divider entry point
   - Scaffold `@ngguide/ui/divider` (+ wiring).
   - `libs/ui/divider/src/divider.ts`: `GuiDivider` (`gui-divider`, OnPush, `inset`
     `none|inset|middle-inset`, `orientation` `horizontal|vertical`, host `role=separator` +

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -118,7 +118,7 @@ Two structural entry points reusing tokens + interaction directives; no overlay 
 
 One entry point with container + item, both `action` and `listbox` modes; reuses `createRovingFocus`. Blast radius: **safe**.
 
-- [ ] 9. List container + item structure
+- [x] 9. List container + item structure
   - Scaffold `@ngguide/ui/list` (+ wiring; ships `styles/list.css` or component CSS).
   - `libs/ui/list/src/list.ts`: `GuiList` (`gui-list`, OnPush, `mode` `action|listbox`, `multiselectable`,
     host role `list|listbox` + `aria-multiselectable` in listbox mode, `(keydown)` delegating to the manager).
@@ -134,7 +134,7 @@ One entry point with container + item, both `action` and `listbox` modes; reuses
     listbox mode role listbox/option + `aria-selected`; disabled item not activatable.
   - _Requirements: 4.1–4.5, 5.1–5.4, 6.5, 13.1–13.4_
 
-- [ ] 10. List interaction + selection
+- [x] 10. List interaction + selection
   - `GuiList`: in `listbox` mode build a `createRovingFocus(items, {orientation:'vertical'})` manager
     (single tab stop, arrow/typeahead/home-end), wire `onKeydown`; toggle `selected` on Enter/Space/click;
     honor `multiselectable`. In `action` mode rely on nested native controls + natural tab order.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -235,7 +235,7 @@ Modal (CDK Dialog + drag) and standard (inline) variants. Depends on Group A. Bl
 
 Modal + standard side sheet on the end edge. Depends on Group A. Blast radius: **coupled to Group A**.
 
-- [ ] 21. Side-sheet config, service, container (modal)
+- [x] 21. Side-sheet config, service, container (modal)
   - Scaffold `@ngguide/ui/side-sheet` (+ wiring; `styles/side-sheet.css`).
   - `side-sheet-config.ts`: `GuiSideSheetConfig<D>` extending `GuiModalConfigBase` (`maxWidth` default 400px).
   - `side-sheet.service.ts`: `GuiSideSheet` injecting CDK `Dialog`; `open()` with
@@ -245,7 +245,7 @@ Modal + standard side sheet on the end edge. Depends on Group A. Blast radius: *
   - Export from index. Test (`side-sheet.service.spec.ts`): opens end-anchored modal with scrim + trap; Escape/close emits.
   - _Requirements: 10.1, 10.2, 10.5, 10.6, 12.1–12.7, 15.1, 15.2, 16.2_
 
-- [ ] 22. Side-sheet header/actions + standard inline mode + demo
+- [x] 22. Side-sheet header/actions + standard inline mode + demo
   - `side-sheet.ts`: surface with header slot (title + close affordance) and actions slot; standard variant
     (`variant="standard"`, `[(open)]`) renders inline without scrim/trap (coexists).
   - apps/web: import `GuiSideSheet`; add a modal side sheet (header + close + actions) and a toggled standard one.

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -48,7 +48,7 @@ Blast radius: **safe** — additive helpers, inert until a later group imports t
     `matches` and updates on `change`. Append the spec to `project.json` `include`; `pnpm exec nx reset`.
   - _Requirements: 8, 11.6, 16.3_
 
-- [ ] 2. Shared modal config + normalizer + ref wrapper
+- [x] 2. Shared modal config + normalizer + ref wrapper
   - Create `libs/ui/overlay/src/modal.ts`: `GuiDialogRole`, `GuiModalConfigBase<D>`, the `GuiDialogRef<R>`
     interface, `normalizeModalConfig(config)` mapping onto CDK `DialogConfig`
     (`ariaModal:true`, `role`, `ariaLabel`, `ariaLabelledBy`, `disableClose`, `autoFocus` default

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -1,0 +1,332 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Implementation Plan: Containment Components
+
+## Overview
+
+Adds the M3 containment category to `@ngguide/ui` as seven new secondary entry points (card, divider, list,
+dialog, bottom-sheet, side-sheet, carousel) plus a small shared overlay foundation. The work is purely
+additive — every change creates new files or new entry points; nothing existing is removed or rewired — so
+each group simply lands new, independently importable surface area.
+
+The plan is split into 7 groups in dependency order. Each group is independently mergeable — build, lint, and
+the full Vitest suite stay green with only that group (and earlier ones) applied. Group A ships the shared
+modal foundation that the dialog and sheet groups consume; the card, divider, list, and carousel groups
+depend only on the existing token + interaction foundation and could land in any order.
+
+There are **no cutovers** — the plan is purely additive (new entry points, no production behaviour change).
+
+### Per-entry-point wiring (applies to every new entry point)
+
+Each new `@ngguide/ui/<name>` requires the same wiring (verified against the snackbar/tooltip precedent):
+1. Scaffold: `pnpm exec nx g @nx/angular:library-secondary-entry-point --library=ui --name=<name> --skipModule`
+   (creates `libs/ui/<name>/{ng-package.json, src/index.ts, src/<name>.ts, src/<name>.spec.ts}`).
+2. Add the path alias to `tsconfig.base.json` `paths` (alphabetical): `"@ngguide/ui/<name>": ["libs/ui/<name>/src/index.ts"]`.
+3. Append every spec file to the `test.options.include` array in `libs/ui/project.json`, then run `pnpm exec nx reset`.
+4. If the entry point ships global chrome (scrim/surface/structural rules a directive can't carry), add
+   `libs/ui/src/styles/<name>.css` and `@import './<name>.css';` to `libs/ui/src/styles/theme.css`.
+5. `libs/ui/package.json` needs **no change** — `@angular/cdk ^21.2.0` is already a peer dependency, so
+   `@angular/cdk/dialog`, `/drag-drop`, and `/layout` are available.
+
+## Tasks
+
+### Group A — Shared overlay foundation (new feature surface)
+
+Extends the existing `@ngguide/ui/overlay` entry point with the compact-window signal, the shared modal
+config/normalizer/ref helpers, and the global scrim stylesheet that the dialog and sheet groups consume.
+Blast radius: **safe** — additive helpers, inert until a later group imports them.
+
+- [x] 1. `GuiBreakpoint` compact-window signal
+  - Create `libs/ui/overlay/src/breakpoint.ts`: `@Injectable({providedIn:'root'})` injecting `MediaMatcher`
+    from `@angular/cdk/layout`, exposing `isCompact: Signal<boolean>` from `matchMedia('(max-width: 599.98px)')`
+    — mirror `libs/ui/interaction/src/reduced-motion.ts` exactly (SSR-safe `addEventListener?.`).
+  - Export it from `libs/ui/overlay/src/index.ts`.
+  - Test (`libs/ui/overlay/src/breakpoint.spec.ts`): mock `MediaMatcher`; assert initial value tracks
+    `matches` and updates on `change`. Append the spec to `project.json` `include`; `pnpm exec nx reset`.
+  - _Requirements: 8, 11.6, 16.3_
+
+- [ ] 2. Shared modal config + normalizer + ref wrapper
+  - Create `libs/ui/overlay/src/modal.ts`: `GuiDialogRole`, `GuiModalConfigBase<D>`, the `GuiDialogRef<R>`
+    interface, `normalizeModalConfig(config)` mapping onto CDK `DialogConfig`
+    (`ariaModal:true`, `role`, `ariaLabel`, `ariaLabelledBy`, `disableClose`, `autoFocus` default
+    `'first-tabbable'`, `restoreFocus` default `true`, `hasBackdrop:true`, `backdropClass:'gui-scrim'`,
+    `data`, `injector`, `panelClass`), and `wrapDialogRef(ref: DialogRef): GuiDialogRef` (re-exposes
+    `closed`/`backdropClick`/`keydownEvents`/`close`). Re-export CDK `DIALOG_DATA` as `GUI_DIALOG_DATA`.
+  - Set the CDK Dialog scroll strategy to `block()` (Req 12.6) via the normalizer/config default.
+  - Export all from `libs/ui/overlay/src/index.ts`.
+  - Test (`libs/ui/overlay/src/modal.spec.ts`): `normalizeModalConfig` sets `ariaModal:true` + scrim class +
+    block scroll; `disableClose` propagates; `wrapDialogRef` forwards `close(result)`→`closed`. Add to `include`; reset.
+  - _Requirements: 12.1, 12.2, 12.3, 12.4, 12.6, 12.7, 14.1_
+
+- [ ] 3. Global scrim stylesheet
+  - Create `libs/ui/src/styles/scrim.css`: `.gui-scrim` backdrop using `--md-sys-color-scrim` at 32% opacity,
+    with an `@media (prefers-reduced-motion: reduce)` fade fallback (overlay.css precedent).
+  - Add `@import './scrim.css';` to `libs/ui/src/styles/theme.css` (after `badge.css`).
+  - _Requirements: 12.1, 15.2_
+
+- [ ] 4. Checkpoint — Group A verification
+  - Run new specs: `pnpm exec nx test ui` (breakpoint + modal specs pass).
+  - Run existing overlay spec to catch regressions: confirm `picker-overlay.spec.ts` still green.
+  - `pnpm exec nx run-many -t lint build --projects=ui` green; confirm `@ngguide/ui/overlay` still builds.
+  - Confirm the new helpers are exported and unused by anything yet (inert until Group D/E/F).
+
+### Group B — Card + Divider (new feature surface)
+
+Two structural entry points reusing tokens + interaction directives; no overlay dependency. Blast radius: **safe**.
+
+- [ ] 5. Card entry point
+  - Scaffold `@ngguide/ui/card` (+ wiring steps 1–4 from the Overview; card ships `styles/card.css` only if
+    a global rule is needed — prefer component `card.css`).
+  - `libs/ui/card/src/card.ts`: `GuiCard` (`selector: gui-card`, OnPush, `variant` input
+    `elevated|filled|outlined`, `disabled`, host `data-variant`/`data-disabled`); `GuiCardClickable`
+    (`[guiCardClickable]`, hostDirectives state-layer/ripple/focus-ring, role/button + Enter/Space/click,
+    `cardActivate` output, disabled guard); `GuiCardPrimaryAction` (`[guiCardPrimaryAction]`, same interaction
+    set, `primaryAction` output).
+  - `libs/ui/card/src/card.css`: variant tokens — elevated `surface-container-low`+`elevation-level1`
+    (hover `level2`, dragged `level4`); filled `surface-container-highest`+`level0` (hover `level1`);
+    outlined `surface`+`level0`+`outline-variant` 1px (focus border `on-surface`); corner `medium`; clip
+    content to corners; disabled 0.38 opacity + no state layers.
+  - Export from `libs/ui/card/src/index.ts`.
+  - Test (`card.spec.ts`): reflects `variant`→`data-variant`; clickable emits on click/Enter; disabled
+    suppresses activation + state layers; primary-action region emits independently.
+  - _Requirements: 1.1–1.7, 2.1–2.6, 13.1–13.4, 14.3, 14.4_
+
+- [ ] 6. Divider entry point
+  - Scaffold `@ngguide/ui/divider` (+ wiring).
+  - `libs/ui/divider/src/divider.ts`: `GuiDivider` (`gui-divider`, OnPush, `inset`
+    `none|inset|middle-inset`, `orientation` `horizontal|vertical`, host `role=separator` +
+    `aria-orientation` + `data-inset`).
+  - `libs/ui/divider/src/divider.css`: 1px `outline-variant`; `inset`=16px leading; `middle-inset`=16px both.
+  - Export from index; test (`divider.spec.ts`): `role=separator`, `data-inset` reflects input, not focusable.
+  - _Requirements: 3.1–3.4, 13.1, 14.5_
+
+- [ ] 7. Demo — card + divider
+  - `apps/web/src/app/app.component.ts/.html`: import `GuiCard`/`GuiCardClickable`/`GuiCardPrimaryAction`/
+    `GuiDivider`; add a containment demo section showing all three card variants, a clickable card, a
+    primary-action card with separate action buttons, and the three divider insets.
+  - _Requirements: 1, 2, 3_
+
+- [ ] 8. Checkpoint — Group B verification
+  - `pnpm exec nx test ui` (card + divider specs pass); `nx test web` if demo wiring added bindings.
+  - `pnpm exec nx run-many -t lint build --projects=ui,web` green; both new entry points build via ng-packagr.
+  - Confirm `@ngguide/ui/card` and `@ngguide/ui/divider` resolve from `tsconfig.base.json` paths.
+
+### Group C — List (new feature surface)
+
+One entry point with container + item, both `action` and `listbox` modes; reuses `createRovingFocus`. Blast radius: **safe**.
+
+- [ ] 9. List container + item structure
+  - Scaffold `@ngguide/ui/list` (+ wiring; ships `styles/list.css` or component CSS).
+  - `libs/ui/list/src/list.ts`: `GuiList` (`gui-list`, OnPush, `mode` `action|listbox`, `multiselectable`,
+    host role `list|listbox` + `aria-multiselectable` in listbox mode, `(keydown)` delegating to the manager).
+  - `libs/ui/list/src/list-item.ts`: `GuiListItem` (`gui-list-item`, OnPush, `lines` 1|2|3, `interactive`,
+    `selectable`, `selected` model, `disabled`; host role `option|listitem|null`, `aria-selected`/
+    `aria-disabled`/`data-selected`; projects `[guiListItemLeading]`, headline, `[guiListItemSupporting]`,
+    `[guiListItemTrailing]`); implements `FocusableOption`.
+  - CSS: heights 56/72/88dp per `lines`; leading icon 24 / avatar 40 / image 56dp; headline `body-large`,
+    supporting `body-medium`, trailing supporting `label-small`; 16dp start/end padding; container `surface`;
+    selected container `secondary-container`; text inset when no leading element.
+  - Export both from index.
+  - Test (`list.spec.ts`, `list-item.spec.ts`): density→`data-lines`; action mode role list/listitem;
+    listbox mode role listbox/option + `aria-selected`; disabled item not activatable.
+  - _Requirements: 4.1–4.5, 5.1–5.4, 6.5, 13.1–13.4_
+
+- [ ] 10. List interaction + selection
+  - `GuiList`: in `listbox` mode build a `createRovingFocus(items, {orientation:'vertical'})` manager
+    (single tab stop, arrow/typeahead/home-end), wire `onKeydown`; toggle `selected` on Enter/Space/click;
+    honor `multiselectable`. In `action` mode rely on nested native controls + natural tab order.
+  - Ensure trailing checkbox/switch state and item selected state stay in sync without double-announcing (Req 6.4).
+  - Test: roving focus moves with arrows + wraps; selection toggles `aria-selected`; single vs multi select;
+    trailing-control sync exposes one accessible state.
+  - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.6, 14.2, 14.3_
+
+- [ ] 11. Demo — list
+  - apps/web: import `GuiList`/`GuiListItem`; add a 1/2/3-line action list (leading icon/avatar, trailing
+    text/icon) and a selectable listbox with checkboxes.
+  - _Requirements: 4, 5, 6_
+
+- [ ] 12. Checkpoint — Group C verification
+  - `pnpm exec nx test ui` (list specs pass); lint + build green for `ui` (and `web` if demo added).
+  - Confirm `@ngguide/ui/list` builds and roving focus works in the demo (keyboard arrows).
+
+### Group D — Dialog (new feature surface)
+
+Basic + full-screen dialog on CDK `Dialog` via a custom container, imperative `open()` + declarative trigger.
+Depends on Group A (modal foundation). Blast radius: **coupled to Group A** (imports its helpers).
+
+- [ ] 13. Dialog config, service, ref, anatomy slots
+  - Scaffold `@ngguide/ui/dialog` (+ wiring; `styles/dialog.css`).
+  - `dialog-config.ts`: `GuiDialogFullScreen` (`never|compact|always`), `GuiDialogConfig<D>` extending
+    `GuiModalConfigBase`, re-export `GUI_DIALOG_DATA`.
+  - `dialog.service.ts`: `@Injectable({providedIn:'root'}) GuiDialog` injecting CDK `Dialog` + `GuiBreakpoint`;
+    `open(content: ComponentType|TemplateRef, config)` → `Dialog.open` with `container: GuiDialogContainer`,
+    `maxWidth` default `min(560px, calc(100% - 48px))`, full-screen resolution via `GuiBreakpoint`; returns
+    `wrapDialogRef(ref)`.
+  - `dialog.ts`: anatomy slot components/directives — `GuiDialogHeadline` (h2/role=heading), `GuiDialogIcon`,
+    `GuiDialogContent`, `GuiDialogActions` — token-styled wrappers.
+  - Export all from index. Test (`dialog.service.spec.ts`): opens with `role=dialog`+`aria-modal`; `close(r)`
+    emits on `closed`; restore-focus returns to opener; `fullScreen:'compact'` honors the breakpoint signal.
+  - _Requirements: 7.1, 7.2, 7.4, 7.6, 8.1, 12.1–12.7, 16.2_
+
+- [ ] 14. Dialog container (M3 chrome + motion) + full-screen layout
+  - `dialog-container.ts`: `GuiDialogContainer extends CdkDialogContainer` — `surface-container-high`,
+    `corner-extra-large` (28dp), `elevation-level3`, centered; enter (emphasized-decelerate) / exit
+    (emphasized-accelerate) via motion tokens, disabled under `GuiReducedMotion`; full-screen mode
+    (`data-fullscreen`) fills the window with a top-app-bar header slot (close/back + title + confirm) and
+    scrolls the body independently.
+  - `dialog.css`: basic + full-screen surface rules, scrollable content region keeping headline/actions visible.
+  - Test (`dialog.spec.ts`): container renders headline/content/actions; full-screen sets `data-fullscreen`
+    + header; content scrolls; reduced-motion disables animation.
+  - _Requirements: 7.1, 7.3, 7.5, 8.1, 8.2, 8.4, 8.5, 15.1, 15.2, 15.3_
+
+- [ ] 15. Declarative trigger + demo
+  - `dialog.trigger.ts`: `[guiDialogTrigger]` directive (`TemplateRef` input + optional `guiDialogConfig`,
+    opens on click via `GuiDialog`).
+  - apps/web: import `GuiDialog` + slots + trigger; add buttons opening a basic dialog (icon/headline/2
+    actions) and a full-screen dialog, plus a declarative `<ng-template>` trigger example.
+  - Test: trigger opens the template; Escape + scrim-click close (unless `disableClose`).
+  - _Requirements: 7.2, 8.2, 8.3, 12.4, 12.5, 16.2_
+
+- [ ] 16. Checkpoint — Group D verification
+  - `pnpm exec nx test ui` (dialog specs pass) + existing overlay specs green.
+  - lint + build green for `ui`,`web`; `@ngguide/ui/dialog` builds; demo opens/closes both dialog types with
+    focus trap + restore verified in the browser.
+
+### Group E — Bottom sheet (new feature surface)
+
+Modal (CDK Dialog + drag) and standard (inline) variants. Depends on Group A. Blast radius: **coupled to Group A**.
+
+- [ ] 17. Bottom-sheet config, service, container
+  - Scaffold `@ngguide/ui/bottom-sheet` (+ wiring; `styles/bottom-sheet.css`).
+  - `bottom-sheet-config.ts`: `GuiBottomSheetConfig<D>` extending `GuiModalConfigBase`
+    (`showDragHandle` default true, `aboveFab`, `dismissThreshold` default 96, `maxWidth` default `640px`).
+  - `bottom-sheet.service.ts`: `GuiBottomSheet` injecting CDK `Dialog`; `open()` with
+    `container: GuiBottomSheetContainer`, a bottom-centered global position strategy, scrim + block scroll.
+  - `bottom-sheet-container.ts`: `extends CdkDialogContainer` — `surface-container-low`,
+    `corner-extra-large-top` (28dp top), `elevation-level1`, slide-up enter / slide-down exit (emphasized
+    easing, reduced-motion aware), initial height capped at ~50% with internal scroll.
+  - Export from index. Test (`bottom-sheet.service.spec.ts`): opens bottom-anchored modal with scrim + trap; `close` emits.
+  - _Requirements: 9.1, 9.5, 12.1–12.7, 15.1, 15.2, 16.2_
+
+- [ ] 18. Drag handle + dismiss/spring-back + standard inline mode
+  - `bottom-sheet.ts`: `GuiBottomSheet` surface component used by both modes — drag handle (32×4dp
+    `on-surface-variant`) with `CdkDrag cdkDragLockAxis="y"`, `cdkDragConstrainPosition` clamping upward;
+    `cdkDragMoved`→fade scrim by `distance.y/height`; `cdkDragEnded`→ if `distance.y > dismissThreshold`
+    `close('swipe')` else `setFreeDragPosition({x:0,y:0})` spring-back; `touch-action:none`/`user-select:none`
+    during drag. Standard variant (`variant="standard"`, `[(open)]` model) renders fixed-position inline,
+    **no scrim, no focus trap** (coexists).
+  - Test (`bottom-sheet.spec.ts`): drag past threshold dismisses; below springs back; standard mode renders
+    without scrim and leaves the page interactive.
+  - _Requirements: 9.2, 9.3, 9.4, 9.6, 9.7_
+
+- [ ] 19. Demo — bottom sheet
+  - apps/web: import `GuiBottomSheet` (service + surface); add a button opening a modal sheet (drag handle,
+    drag-to-dismiss) and a toggled standard sheet.
+  - _Requirements: 9_
+
+- [ ] 20. Checkpoint — Group E verification
+  - `pnpm exec nx test ui` (bottom-sheet specs pass); lint + build green for `ui`,`web`.
+  - `@ngguide/ui/bottom-sheet` builds; browser: drag-to-dismiss + spring-back + standard coexistence verified.
+
+### Group F — Side sheet (new feature surface)
+
+Modal + standard side sheet on the end edge. Depends on Group A. Blast radius: **coupled to Group A**.
+
+- [ ] 21. Side-sheet config, service, container (modal)
+  - Scaffold `@ngguide/ui/side-sheet` (+ wiring; `styles/side-sheet.css`).
+  - `side-sheet-config.ts`: `GuiSideSheetConfig<D>` extending `GuiModalConfigBase` (`maxWidth` default 400px).
+  - `side-sheet.service.ts`: `GuiSideSheet` injecting CDK `Dialog`; `open()` with
+    `container: GuiSideSheetContainer`, end-anchored global position strategy, scrim + block scroll.
+  - `side-sheet-container.ts`: `extends CdkDialogContainer` — end edge, width 256–400px, `corner-large` (16dp),
+    appropriate container color + elevation, slide-in/out (emphasized easing, reduced-motion aware).
+  - Export from index. Test (`side-sheet.service.spec.ts`): opens end-anchored modal with scrim + trap; Escape/close emits.
+  - _Requirements: 10.1, 10.2, 10.5, 10.6, 12.1–12.7, 15.1, 15.2, 16.2_
+
+- [ ] 22. Side-sheet header/actions + standard inline mode + demo
+  - `side-sheet.ts`: surface with header slot (title + close affordance) and actions slot; standard variant
+    (`variant="standard"`, `[(open)]`) renders inline without scrim/trap (coexists).
+  - apps/web: import `GuiSideSheet`; add a modal side sheet (header + close + actions) and a toggled standard one.
+  - Test (`side-sheet.spec.ts`): header/close/actions render; standard mode no scrim, page interactive.
+  - _Requirements: 10.3, 10.4, 10.5, 10.6_
+
+- [ ] 23. Checkpoint — Group F verification
+  - `pnpm exec nx test ui` (side-sheet specs pass); lint + build green for `ui`,`web`.
+  - `@ngguide/ui/side-sheet` builds; browser: modal open/close + standard coexistence verified.
+
+### Group G — Carousel (new feature surface)
+
+Pure keyline engine + components implementing the four M3 layouts. Independent of the overlay foundation.
+Blast radius: **safe**.
+
+- [ ] 24. Keyline sizing engine (pure)
+  - Scaffold `@ngguide/ui/carousel` (+ wiring).
+  - `carousel-keylines.ts`: `GuiCarouselLayout`, `MIN_SMALL_ITEM=40`, `MAX_SMALL_ITEM=56`,
+    `KeylineArrangement`, `arrange(layout, viewportWidth, opts)` (small=clamp(large/3,40,56),
+    medium=(large+small)/2; multi-browse caps non-focal at 2 + drops small below 80px; hero start/center
+    variants; uncontained resizes last cut-off item; full-screen single item) and
+    `maskForOffset(arrangement, scrollOffset, index)`. Pure — no `Date.now`/`Math.random` (Req 16.4).
+  - Test (`carousel-keylines.spec.ts`): the verified sizing rules per layout; small clamp; drop-below-threshold.
+  - _Requirements: 11.2, 11.3, 11.5, 16.4_
+
+- [ ] 25. Carousel + item components
+  - `carousel.ts`: `GuiCarousel` (`gui-carousel`, OnPush, `layout`, `preferredLargeWidth` default 186,
+    `itemSpacing` default 8, host `role=group`+`aria-roledescription=carousel`+`data-layout`); injects
+    `GuiBreakpoint` + `GuiReducedMotion`; `afterNextRender` sets up `ResizeObserver(track)` + scroll listener
+    that recompute `arrange()` and assign item widths/clip via signals; SSR/first frame renders items at large size.
+  - `carousel-item.ts`: `GuiCarouselItem` (`gui-carousel-item`, width signal set by engine, `scroll-snap-align`).
+  - `carousel.css`: native scroll + `scroll-snap`, item corner `extra-large` (28dp).
+  - Export both from index. Test (`carousel.spec.ts`): renders items; `data-layout` reflects input;
+    items get widths from the engine after layout.
+  - _Requirements: 11.1, 11.4, 16.3, 16.4_
+
+- [ ] 26. Layouts, full-screen orientation, reduced motion + demo
+  - `GuiCarousel.effectiveLayout()`: full-screen layout switches to vertical orientation on compact
+    (`GuiBreakpoint.isCompact()`); under `GuiReducedMotion`, disable per-scroll size morphing (items render at
+    arranged sizes). Verify multi-browse/uncontained/hero/full-screen all render per the engine.
+  - apps/web: import `GuiCarousel`/`GuiCarouselItem`; add a demo with a layout switcher across all four layouts.
+  - Test: full-screen compact orientation; reduced-motion disables morph; resize re-arranges (Req 11.5/11.6).
+  - _Requirements: 11.5, 11.6, 15.1, 15.2, 15.3_
+
+- [ ] 27. Final checkpoint — everything green
+  - Full suite: `pnpm exec nx run-many -t lint test build --projects=ui,web` green.
+  - All seven entry points (`card, divider, list, dialog, bottom-sheet, side-sheet, carousel`) build via
+    ng-packagr and resolve from `tsconfig.base.json`.
+  - Every requirement (1–16) traces to a shipped task (see Notes traceability).
+  - Browser dogfood: card variants/actionable, divider insets, list densities + listbox selection, basic +
+    full-screen dialog, modal + standard bottom sheet (drag), modal + standard side sheet, all four carousel layouts.
+
+## Notes
+
+### Scope boundaries
+
+- **Navigation surfaces** (drawer/rail/bar, top app bar, tabs) are out of scope — they live in the `navigation` spec.
+- **Standard (non-modal) sheets** deliberately do **not** use CDK `Dialog` (which always traps focus); they render
+  as inline fixed-position surfaces so they can coexist with page content (Req 9.2 / 10.3).
+- **Carousel parallax multiplier** and exact **dialog/sheet motion durations** were unverifiable from the
+  JS-rendered M3 spec pages (research Open Questions); the implementation uses the verified easing pairing and a
+  reasonable duration token, to be confirmed during dogf/test-plan.
+
+### Requirements traceability (group → requirements)
+
+- Group A → 8, 11.6, 12.1–12.7, 14.1, 16.3
+- Group B → 1, 2, 3, 13, 14.3–14.5
+- Group C → 4, 5, 6, 14.2, 14.3
+- Group D → 7, 8, 12, 15, 16.2
+- Group E → 9, 12, 15, 16.2
+- Group F → 10, 12, 15, 16.2
+- Group G → 11, 15, 16.3, 16.4
+- Cross-cutting 13 (tokens) and 14 (a11y) are exercised by every group's components; 16 (packaging/SSR/zoneless)
+  by every entry point's scaffold + specs.
+
+### Codebase verification findings
+
+- `@angular/cdk` is already a peer dependency of `libs/ui/package.json` (`^21.2.0`) — `cdk/dialog`,
+  `cdk/drag-drop`, `cdk/layout` need no dependency change.
+- CDK `Dialog.open` supports both `ComponentType` and `TemplateRef` overloads, and `DialogConfig.container`
+  allows swapping the container component — both verified in `@angular/cdk` 21.2.13 typings.
+- `createRovingFocus` (FocusKeyManager wrapper) and `GuiReducedMotion`/`MediaMatcher` patterns exist and are
+  reused as-is.
+- After every `libs/ui/project.json` `include` edit, run `pnpm exec nx reset` (daemon caches stale options).

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -157,7 +157,7 @@ One entry point with container + item, both `action` and `listbox` modes; reuses
 Basic + full-screen dialog on CDK `Dialog` via a custom container, imperative `open()` + declarative trigger.
 Depends on Group A (modal foundation). Blast radius: **coupled to Group A** (imports its helpers).
 
-- [ ] 13. Dialog config, service, ref, anatomy slots
+- [x] 13. Dialog config, service, ref, anatomy slots
   - Scaffold `@ngguide/ui/dialog` (+ wiring; `styles/dialog.css`).
   - `dialog-config.ts`: `GuiDialogFullScreen` (`never|compact|always`), `GuiDialogConfig<D>` extending
     `GuiModalConfigBase`, re-export `GUI_DIALOG_DATA`.
@@ -171,7 +171,7 @@ Depends on Group A (modal foundation). Blast radius: **coupled to Group A** (imp
     emits on `closed`; restore-focus returns to opener; `fullScreen:'compact'` honors the breakpoint signal.
   - _Requirements: 7.1, 7.2, 7.4, 7.6, 8.1, 12.1–12.7, 16.2_
 
-- [ ] 14. Dialog container (M3 chrome + motion) + full-screen layout
+- [x] 14. Dialog container (M3 chrome + motion) + full-screen layout
   - `dialog-container.ts`: `GuiDialogContainer extends CdkDialogContainer` — `surface-container-high`,
     `corner-extra-large` (28dp), `elevation-level3`, centered; enter (emphasized-decelerate) / exit
     (emphasized-accelerate) via motion tokens, disabled under `GuiReducedMotion`; full-screen mode

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -61,7 +61,7 @@ Blast radius: **safe** — additive helpers, inert until a later group imports t
     block scroll; `disableClose` propagates; `wrapDialogRef` forwards `close(result)`→`closed`. Add to `include`; reset.
   - _Requirements: 12.1, 12.2, 12.3, 12.4, 12.6, 12.7, 14.1_
 
-- [ ] 3. Global scrim stylesheet
+- [x] 3. Global scrim stylesheet
   - Create `libs/ui/src/styles/scrim.css`: `.gui-scrim` backdrop using `--md-sys-color-scrim` at 32% opacity,
     with an `@media (prefers-reduced-motion: reduce)` fade fallback (overlay.css precedent).
   - Add `@import './scrim.css';` to `libs/ui/src/styles/theme.css` (after `badge.css`).

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -222,12 +222,12 @@ Modal (CDK Dialog + drag) and standard (inline) variants. Depends on Group A. Bl
     without scrim and leaves the page interactive.
   - _Requirements: 9.2, 9.3, 9.4, 9.6, 9.7_
 
-- [ ] 19. Demo — bottom sheet
+- [x] 19. Demo — bottom sheet
   - apps/web: import `GuiBottomSheet` (service + surface); add a button opening a modal sheet (drag handle,
     drag-to-dismiss) and a toggled standard sheet.
   - _Requirements: 9_
 
-- [ ] 20. Checkpoint — Group E verification
+- [x] 20. Checkpoint — Group E verification
   - `pnpm exec nx test ui` (bottom-sheet specs pass); lint + build green for `ui`,`web`.
   - `@ngguide/ui/bottom-sheet` builds; browser: drag-to-dismiss + spring-back + standard coexistence verified.
 

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -199,7 +199,7 @@ Depends on Group A (modal foundation). Blast radius: **coupled to Group A** (imp
 
 Modal (CDK Dialog + drag) and standard (inline) variants. Depends on Group A. Blast radius: **coupled to Group A**.
 
-- [ ] 17. Bottom-sheet config, service, container
+- [x] 17. Bottom-sheet config, service, container
   - Scaffold `@ngguide/ui/bottom-sheet` (+ wiring; `styles/bottom-sheet.css`).
   - `bottom-sheet-config.ts`: `GuiBottomSheetConfig<D>` extending `GuiModalConfigBase`
     (`showDragHandle` default true, `aboveFab`, `dismissThreshold` default 96, `maxWidth` default `640px`).
@@ -211,7 +211,7 @@ Modal (CDK Dialog + drag) and standard (inline) variants. Depends on Group A. Bl
   - Export from index. Test (`bottom-sheet.service.spec.ts`): opens bottom-anchored modal with scrim + trap; `close` emits.
   - _Requirements: 9.1, 9.5, 12.1–12.7, 15.1, 15.2, 16.2_
 
-- [ ] 18. Drag handle + dismiss/spring-back + standard inline mode
+- [x] 18. Drag handle + dismiss/spring-back + standard inline mode
   - `bottom-sheet.ts`: `GuiBottomSheet` surface component used by both modes — drag handle (32×4dp
     `on-surface-variant`) with `CdkDrag cdkDragLockAxis="y"`, `cdkDragConstrainPosition` clamping upward;
     `cdkDragMoved`→fade scrim by `distance.y/height`; `cdkDragEnded`→ if `distance.y > dismissThreshold`

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -143,12 +143,12 @@ One entry point with container + item, both `action` and `listbox` modes; reuses
     trailing-control sync exposes one accessible state.
   - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.6, 14.2, 14.3_
 
-- [ ] 11. Demo — list
+- [x] 11. Demo — list
   - apps/web: import `GuiList`/`GuiListItem`; add a 1/2/3-line action list (leading icon/avatar, trailing
     text/icon) and a selectable listbox with checkboxes.
   - _Requirements: 4, 5, 6_
 
-- [ ] 12. Checkpoint — Group C verification
+- [x] 12. Checkpoint — Group C verification
   - `pnpm exec nx test ui` (list specs pass); lint + build green for `ui` (and `web` if demo added).
   - Confirm `@ngguide/ui/list` builds and roving focus works in the demo (keyboard arrows).
 

--- a/.specs/containment/tasks.md
+++ b/.specs/containment/tasks.md
@@ -252,7 +252,7 @@ Modal + standard side sheet on the end edge. Depends on Group A. Blast radius: *
   - Test (`side-sheet.spec.ts`): header/close/actions render; standard mode no scrim, page interactive.
   - _Requirements: 10.3, 10.4, 10.5, 10.6_
 
-- [ ] 23. Checkpoint — Group F verification
+- [x] 23. Checkpoint — Group F verification
   - `pnpm exec nx test ui` (side-sheet specs pass); lint + build green for `ui`,`web`.
   - `@ngguide/ui/side-sheet` builds; browser: modal open/close + standard coexistence verified.
 

--- a/.specs/containment/test-plan.md
+++ b/.specs/containment/test-plan.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-06-03
 updated: 2026-06-03
+status: executed
 ---
 
 # Manual Test Plan: Containment Components
@@ -37,8 +38,8 @@ says so.
 
 ## Test Scenarios
 
-- [ ] 1. Card — variants, actionability, states
-  - [ ] 1.1 Three variants render with the correct M3 surface
+- [x] 1. Card — variants, actionability, states
+  - [x] 1.1 Three variants render with the correct M3 surface
     - **Preconditions:** Demo open at the "Card & Divider" section.
     - **Steps:**
       1. Locate the row of three cards labelled elevated / filled / outlined.
@@ -47,13 +48,13 @@ says so.
       filled = surface-container-highest with **no** shadow; outlined = surface with **no** shadow
       and a 1px outline-variant border. All three share the same medium (12dp) corner radius.
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 13.1_
-  - [ ] 1.2 Content clips to the rounded corners
+  - [x] 1.2 Content clips to the rounded corners
     - **Preconditions:** Demo open.
     - **Steps:**
       1. Inspect a card containing full-bleed content (or temporarily add an image that fills the card).
     - **Expected:** Content is clipped to the card's rounded corners; nothing spills past the radius.
     - _Requirements: 1.6, 1.7_
-  - [ ] 1.3 Whole-surface clickable card behaves as one control
+  - [x] 1.3 Whole-surface clickable card behaves as one control
     - **Preconditions:** Demo open; "Last card action" readout visible.
     - **Steps:**
       1. Hover the "Clickable card" — observe the state layer.
@@ -62,13 +63,13 @@ says so.
     - **Expected:** Hover/focus/press show M3 state layers; the card is a single Tab stop with a
       visible focus indicator; Enter, Space, and click each set the readout to "clickable card".
     - _Requirements: 2.1, 2.2, 2.4, 13.4, 14.3, 14.4_
-  - [ ] 1.4 Elevated actionable card raises on hover/press
+  - [x] 1.4 Elevated actionable card raises on hover/press
     - **Preconditions:** Demo open.
     - **Steps:**
       1. Inspect the elevated clickable card's `box-shadow` at rest, then while hovering.
     - **Expected:** The shadow increases on hover (resting level 1 → level 2) per M3.
     - _Requirements: 2.3_
-  - [ ] 1.5 Primary-action region is independent of card action buttons
+  - [x] 1.5 Primary-action region is independent of card action buttons
     - **Preconditions:** Demo open; the outlined "Primary-action card" with Share/Save buttons.
     - **Steps:**
       1. Click the card body (above the divider). Note the readout.
@@ -77,14 +78,17 @@ says so.
     - **Expected:** Body click sets readout to "primary action"; Share/Save set "share"/"save"
       independently; the primary-action region and each button are separately focusable.
     - _Requirements: 2.1, 2.4, 14.3_
-  - [ ] 1.6 Disabled card suppresses interaction
+  - [s] 1.6 Disabled card suppresses interaction
     - **Preconditions:** Temporarily set `disabled` on the clickable card (or use a disabled demo card).
     - **Steps:**
       1. Observe the card's opacity. 2. Hover and click it. 3. Try to Tab to it.
     - **Expected:** Card shows the 0.38 disabled treatment, emits **no** activation event, shows
       **no** state layer, and is not focusable (skipped in Tab order).
     - _Requirements: 2.5, 2.6_
-  - [ ] 1.7 Non-actionable card has no control semantics
+    - **SKIPPED:** The playground exposes no disabled clickable card and a `disabled` signal input
+      can't be driven from the browser (attribute mutation doesn't update the Angular signal). Covered
+      by `card.spec.ts`. Needs a demo prop to dogfood in-browser.
+  - [x] 1.7 Non-actionable card has no control semantics
     - **Preconditions:** Demo open; the three plain variant cards.
     - **Steps:**
       1. With a screen reader on, navigate onto a plain card. 2. Try to Tab to it.
@@ -92,8 +96,8 @@ says so.
       hover/press state layer.
     - _Requirements: 2.6_
 
-- [ ] 2. Divider
-  - [ ] 2.1 Thickness, color, and the three insets
+- [x] 2. Divider
+  - [x] 2.1 Thickness, color, and the three insets
     - **Preconditions:** Demo open; the divider inset examples (none / inset / middle-inset) and the
       divider inside the primary-action card.
     - **Steps:**
@@ -102,7 +106,7 @@ says so.
     - **Expected:** 1px line in outline-variant; `inset` is indented 16px on the leading edge only;
       `middle-inset` is indented 16px on both edges; `none` is full-width.
     - _Requirements: 3.1, 3.2, 13.1_
-  - [ ] 2.2 Divider is a non-focusable separator
+  - [x] 2.2 Divider is a non-focusable separator
     - **Preconditions:** Demo open; screen reader on.
     - **Steps:**
       1. Navigate to a divider with the screen reader. 2. Try to Tab to it.
@@ -110,21 +114,25 @@ says so.
       not reachable by Tab.
     - _Requirements: 3.3, 3.4, 14.5_
 
-- [ ] 3. List — densities, leading/trailing, action vs listbox
-  - [ ] 3.1 One/two/three-line densities at the correct heights
+- [!] 3. List — densities, leading/trailing, action vs listbox
+  - [x] 3.1 One/two/three-line densities at the correct heights
     - **Preconditions:** Demo open at the "List" section (action list).
     - **Steps:**
       1. Inspect the min-height of the 1-, 2-, and 3-line rows.
     - **Expected:** Heights are 56 / 72 / 88dp respectively; headline uses the body-large typescale,
       supporting text uses body-medium, trailing supporting text uses label-small.
     - _Requirements: 4.1, 4.2, 4.3, 13.1_
-  - [ ] 3.2 Long supporting text truncates within the reserved lines
+  - [!] 3.2 Long supporting text truncates within the reserved lines
     - **Preconditions:** Action list; the 3-line row with a long description.
     - **Steps:**
       1. Narrow the container and observe the supporting text.
     - **Expected:** Supporting text truncates within the row's reserved lines; nothing overflows the row.
     - _Requirements: 4.4_
-  - [ ] 3.3 Leading and trailing elements positioned per M3
+    - **FAILED:** The supporting text has no `-webkit-line-clamp`/ellipsis (computed `overflow:visible`,
+      `line-clamp:none`). With the demo's short copy it happens to fit in 2 lines, but injecting longer
+      text grows the 3-line row from 88px to 168px (6 lines) instead of truncating — the row just
+      expands. Fix: clamp supporting text to its reserved line count in `list-item.css`.
+  - [x] 3.3 Leading and trailing elements positioned per M3
     - **Preconditions:** Action list with leading icons and trailing supporting text; dividers between rows.
     - **Steps:**
       1. Confirm leading icons sit at the start with 16dp inset; trailing text at the end.
@@ -132,21 +140,21 @@ says so.
     - **Expected:** Leading icon ~24dp at the start, 16dp insets, trailing text aligned to the end;
       dividers separate rows.
     - _Requirements: 4.5, 5.1, 5.2, 5.3_
-  - [ ] 3.4 Text inset when no leading element
+  - [x] 3.4 Text inset when no leading element
     - **Preconditions:** A list row with no leading element.
     - **Steps:**
       1. Compare the headline start position of a row with a leading icon vs one without.
     - **Expected:** The row without a leading element applies the M3 text inset (headline starts at the
       16dp content inset, not under a missing leading slot).
     - _Requirements: 5.4_
-  - [ ] 3.5 Action list uses natural tab order
+  - [x] 3.5 Action list uses natural tab order
     - **Preconditions:** Action list whose rows host native controls/links.
     - **Steps:**
       1. Tab through the list.
     - **Expected:** Each interactive control is its own Tab stop in document order; the list is `role=list`
       and rows are `role=listitem`; no roving single-tab-stop behavior.
     - _Requirements: 6.1, 6.2, 6.6, 14.2_
-  - [ ] 3.6 Listbox: roving focus + selection
+  - [x] 3.6 Listbox: roving focus + selection
     - **Preconditions:** Demo open; the selectable listbox (multi-select).
     - **Steps:**
       1. Tab into the listbox (lands on one option only).
@@ -157,23 +165,29 @@ says so.
       Enter/Space/click toggle selection; selected rows render the secondary-container treatment and
       expose `aria-selected=true`; multi-select keeps multiple selected.
     - _Requirements: 6.3, 6.6, 14.2, 14.3, 14.5_
-  - [ ] 3.7 Selected state is not conveyed by color alone
+    - **PASSED (with note):** Single tab stop ✓, arrows wrap (Date→Apple) ✓, Home/End ✓, Enter/Space/click
+      toggle selection ✓, `aria-selected=true` + secondary-container (`#4a4458`) ✓, multi-select keeps
+      [Apple,Banana,Cherry] ✓. **Type-ahead does NOT move focus** (no jump on `c`/`d`/`b`) — optional in
+      the APG listbox pattern and not mandated by Req 6.6, so recorded as pass; worth wiring up later.
+  - [x] 3.7 Selected state is not conveyed by color alone
     - **Preconditions:** Listbox with a selected option; screen reader on.
     - **Steps:**
       1. Select an option and listen to the announcement.
     - **Expected:** Selection is exposed via `aria-selected` (announced "selected"), not only the
       container color change.
     - _Requirements: 6.3, 14.5_
-  - [ ] 3.8 Disabled list option stays discoverable but inert
+  - [s] 3.8 Disabled list option stays discoverable but inert
     - **Preconditions:** Add a `disabled` option to the listbox.
     - **Steps:**
       1. Arrow onto the disabled option. 2. Press Enter/Space and click it.
     - **Expected:** Option is still reachable by arrow keys (M3 keeps disabled options discoverable),
       shows the dimmed treatment, exposes `aria-disabled=true`, and does **not** toggle selection.
     - _Requirements: 6.5, 14.5_
+    - **SKIPPED:** The playground listbox has no disabled option and `disabled` is a signal input not
+      drivable from the browser. Covered by `list-item.spec.ts`. Needs a demo prop to dogfood.
 
-- [ ] 4. Dialog — basic and full-screen
-  - [ ] 4.1 Basic dialog surface and anatomy
+- [x] 4. Dialog — basic and full-screen
+  - [x] 4.1 Basic dialog surface and anatomy
     - **Preconditions:** Demo open at "Dialog"; click "Basic dialog".
     - **Steps:**
       1. Inspect the dialog surface color, corner radius, elevation, and max-width.
@@ -181,20 +195,20 @@ says so.
     - **Expected:** Centered surface, surface-container-high, 28dp corners, elevation level 3, max
       width ≈ min(560px, 100%−48px); icon + headline (h2) + content + ≤3 end-aligned text buttons.
     - _Requirements: 7.1, 7.2, 13.1_
-  - [ ] 4.2 Basic dialog returns a result to the opener
+  - [x] 4.2 Basic dialog returns a result to the opener
     - **Preconditions:** Basic dialog open. (Optionally watch the console/readout if wired.)
     - **Steps:**
       1. Click "Reset" — note close. 2. Reopen and click "Cancel". 3. Reopen and press Escape.
     - **Expected:** Each path closes the dialog and the opener receives a distinct result
       ("reset" vs undefined for Cancel/Escape) — verify via the returned `closed` value.
     - _Requirements: 7.4, 7.6, 16.2_
-  - [ ] 4.3 Tall dialog content scrolls; headline + actions stay visible
+  - [x] 4.3 Tall dialog content scrolls; headline + actions stay visible
     - **Preconditions:** Basic dialog with content taller than the viewport (lengthen the demo content).
     - **Steps:**
       1. Open it and scroll the body.
     - **Expected:** Only the content region scrolls; the headline and action row remain visible/pinned.
     - _Requirements: 7.5_
-  - [ ] 4.4 Full-screen dialog fills the window with a top app bar
+  - [x] 4.4 Full-screen dialog fills the window with a top app bar
     - **Preconditions:** Demo open; click "Full-screen dialog".
     - **Steps:**
       1. Confirm the surface fills the window edge-to-edge with a top bar (close ✕ + title + Save).
@@ -202,34 +216,36 @@ says so.
     - **Expected:** Edge-to-edge surface, no corner radius; top app bar with close/back, title, and a
       confirming action; the body scrolls independently of the fixed top bar.
     - _Requirements: 8.1, 8.5_
-  - [ ] 4.5 Full-screen close vs confirm results
+  - [x] 4.5 Full-screen close vs confirm results
     - **Preconditions:** Full-screen dialog open.
     - **Steps:**
       1. Click ✕ (or press Escape) — note result. 2. Reopen and click "Save".
     - **Expected:** Close/back/Escape emit a dismissal; "Save" emits a confirm result ("saved") to the opener.
     - _Requirements: 8.2, 8.3_
-  - [ ] 4.6 `fullScreen: 'compact'` auto-selection
+  - [s] 4.6 `fullScreen: 'compact'` auto-selection
     - **Preconditions:** A dialog opened with `fullScreen: 'compact'` (adjust the demo config or add a button).
     - **Steps:**
       1. Open it on a wide viewport. 2. Narrow the window below 600px and reopen.
     - **Expected:** Basic (centered) on the wide viewport; full-screen on the compact viewport.
     - _Requirements: 8.1_
-  - [ ] 4.7 Declarative trigger opens the inline template
+    - **SKIPPED:** No demo button opens a dialog with `fullScreen: 'compact'` (the demo uses
+      `'always'`). Covered by `dialog.service.spec.ts`. Needs a demo button to dogfood in-browser.
+  - [x] 4.7 Declarative trigger opens the inline template
     - **Preconditions:** Demo open; "Basic dialog" uses `[guiDialogTrigger]`.
     - **Steps:**
       1. Click the trigger button.
     - **Expected:** The inline `<ng-template>` content opens as the dialog without any imperative code.
     - _Requirements: 7.2_
 
-- [ ] 5. Bottom sheet — modal, drag, standard
-  - [ ] 5.1 Modal bottom sheet anatomy
+- [!] 5. Bottom sheet — modal, drag, standard
+  - [x] 5.1 Modal bottom sheet anatomy
     - **Preconditions:** Demo open at "Bottom sheet"; click "Modal sheet".
     - **Steps:**
       1. Inspect the surface color, top corner shape, elevation, and the drag handle.
     - **Expected:** Surface slides up from the bottom; surface-container-low, 28dp top corners,
       elevation level 1; a 32×4dp drag handle in on-surface-variant; initial height capped ~50%.
     - _Requirements: 9.1, 13.1_
-  - [ ] 5.2 Drag past threshold dismisses; short drag springs back
+  - [x] 5.2 Drag past threshold dismisses; short drag springs back
     - **Preconditions:** Modal sheet open.
     - **Steps:**
       1. Drag the handle down a small amount (< ~96px) and release.
@@ -238,19 +254,19 @@ says so.
     - **Expected:** Short drag settles back to the open position; long drag dismisses the sheet (closing
       with a `'swipe'` result); the scrim fades proportionally to the downward drag distance.
     - _Requirements: 9.3, 9.4, 9.6_
-  - [ ] 5.3 No text selection / page scroll during drag
+  - [x] 5.3 No text selection / page scroll during drag
     - **Preconditions:** Modal sheet open over page content.
     - **Steps:**
       1. Drag the handle and observe the page behind and any text under the pointer.
     - **Expected:** No page text gets selected and the page behind does not scroll during the drag.
     - _Requirements: 9.7_
-  - [ ] 5.4 Sheet content scrolls within the sheet
+  - [x] 5.4 Sheet content scrolls within the sheet
     - **Preconditions:** Modal sheet with content taller than its ~50% height.
     - **Steps:**
       1. Scroll inside the sheet.
     - **Expected:** Content scrolls within the sheet, not past the screen edge.
     - _Requirements: 9.5_
-  - [ ] 5.5 Standard bottom sheet coexists with the page
+  - [!] 5.5 Standard bottom sheet coexists with the page
     - **Preconditions:** Demo open; click "Toggle standard sheet".
     - **Steps:**
       1. With the standard sheet open, click/scroll/select text on the page behind it.
@@ -259,34 +275,51 @@ says so.
     - **Expected:** No scrim; the page behind stays fully interactive and scrollable; dragging down
       dismisses (sets open=false); the toggle button opens/closes it.
     - _Requirements: 9.2, 9.4_
-  - [ ] 5.6 Drag handle can be hidden
+    - **FAILED:** No scrim ✓, host `pointer-events:none` (page interactive) ✓, toggle open/close slides
+      the surface off-screen ✓, and drag-down sets `open=false` ✓ — BUT after any drag the dismissed
+      sheet **stays visible on screen** instead of sliding away. `onDragEnded` calls
+      `event.source.setFreeDragPosition({x:0,y:0})` (bottom-sheet.ts:69), which writes an inline
+      `transform: translate3d(0,0,0)` that overrides the CSS closed state
+      `.gui-bottom-sheet-surface{transform:translateY(100%)}`. The clean (no-drag) toggle path hides
+      correctly; the bug is drag-specific. Fix: clear the inline drag transform on close (e.g. reset to
+      `''`/null) so the CSS slide-out applies, or animate the dismiss via the open state.
+  - [s] 5.6 Drag handle can be hidden
     - **Preconditions:** Open a modal sheet with `showDragHandle: false`.
     - **Steps:**
       1. Confirm no handle is rendered.
     - **Expected:** No drag handle; the sheet still opens/closes via scrim/Escape/controls.
     - _Requirements: 9.3_
+    - **SKIPPED:** No demo opens a modal sheet with `showDragHandle: false`. The `@if (showDragHandle())`
+      gate is covered by the bottom-sheet specs. Needs a demo button to dogfood in-browser.
 
-- [ ] 6. Side sheet — modal and standard
-  - [ ] 6.1 Modal side sheet anatomy
+- [!] 6. Side sheet — modal and standard
+  - [x] 6.1 Modal side sheet anatomy
     - **Preconditions:** Demo open at "Side sheet"; click "Modal side sheet".
     - **Steps:**
       1. Inspect the surface — edge, width, corner shape, elevation, header (title + close), actions.
     - **Expected:** Slides in from the end edge; 256–400dp wide; 16dp corners on the inner edge;
       surface-container-low + elevation; header with title + close affordance; actions region.
     - _Requirements: 10.1, 10.4, 13.1_
-  - [ ] 6.2 Close affordance and Escape dismiss (modal)
+  - [x] 6.2 Close affordance and Escape dismiss (modal)
     - **Preconditions:** Modal side sheet open.
     - **Steps:**
       1. Click the header ✕. 2. Reopen and press Escape. 3. Reopen and click "Apply".
     - **Expected:** ✕ and Escape close with a dismissal; "Apply" emits a confirm result ("applied").
     - _Requirements: 10.5, 10.6_
-  - [ ] 6.3 Side-sheet content scrolls within the sheet
+  - [!] 6.3 Side-sheet content scrolls within the sheet
     - **Preconditions:** Modal side sheet with overflowing content.
     - **Steps:**
       1. Scroll inside the sheet body.
     - **Expected:** The content region scrolls within the sheet; the header/actions stay in place.
     - _Requirements: 10.6_
-  - [ ] 6.4 Standard side sheet coexists with the page
+    - **FAILED:** The side sheet provides **no built-in scrollable content region** (unlike the bottom
+      sheet's `.gui-bottom-sheet-body{overflow-y:auto}`). The inner surface is `overflow:hidden`, header
+      and actions are `flex:0 0 auto`, and the projected content slot is `overflow:visible`. Injecting
+      tall content grows the content to 2400px, overflows the surface by ~1556px, and **pushes the
+      actions region off-screen** (clipped) instead of scrolling. Fix: wrap projected content in a
+      `flex:1 1 auto; overflow-y:auto` region in the side-sheet surface/container, mirroring the bottom
+      sheet.
+  - [x] 6.4 Standard side sheet coexists with the page
     - **Preconditions:** Demo open; click "Toggle standard side sheet".
     - **Steps:**
       1. With it open, interact with the page beside it. 2. Confirm there is no scrim.
@@ -294,40 +327,42 @@ says so.
     - **Expected:** No scrim; the page beside it stays interactive; closes via the close affordance/toggle.
     - _Requirements: 10.3_
 
-- [ ] 7. Shared modal overlay behavior (APG Dialog)
-  - [ ] 7.1 Scrim dims and blocks the content behind every modal surface
+- [x] 7. Shared modal overlay behavior (APG Dialog)
+  - [x] 7.1 Scrim dims and blocks the content behind every modal surface
     - **Preconditions:** Demo open.
     - **Steps:**
       1. Open in turn: basic dialog, full-screen dialog, modal bottom sheet, modal side sheet.
       2. For each, try to click a button on the page behind the scrim.
     - **Expected:** Each shows a scrim at ~32% scrim color; clicks on the page behind are blocked.
     - _Requirements: 12.1_
-  - [ ] 7.2 Focus moves in and is trapped
+  - [x] 7.2 Focus moves in and is trapped
     - **Preconditions:** Any modal surface.
     - **Steps:**
       1. Open it. 2. Press Tab repeatedly past the last focusable element; Shift+Tab past the first.
     - **Expected:** Focus moves into the surface on open and cycles **within** it — Tab never lands on
       page content behind the scrim.
     - _Requirements: 12.2, 14.1, 14.3_
-  - [ ] 7.3 Focus restores to the opener on close
+  - [x] 7.3 Focus restores to the opener on close
     - **Preconditions:** Focus a known opener button, then open a modal from it.
     - **Steps:**
       1. Open, then close via Escape / scrim / an action.
     - **Expected:** After close, focus returns to the exact opener element.
     - _Requirements: 12.3_
-  - [ ] 7.4 Escape and scrim-click dismiss
+  - [x] 7.4 Escape and scrim-click dismiss
     - **Preconditions:** Any dismissible modal surface.
     - **Steps:**
       1. Press Escape. 2. Reopen and click the scrim outside the surface.
     - **Expected:** Both close the surface and emit a dismissal result.
     - _Requirements: 12.4, 12.5_
-  - [ ] 7.5 Non-dismissible surface ignores Escape and scrim-click
+  - [s] 7.5 Non-dismissible surface ignores Escape and scrim-click
     - **Preconditions:** Open a dialog with `disableClose: true` (adjust the demo config).
     - **Steps:**
       1. Press Escape. 2. Click the scrim.
     - **Expected:** The surface stays open in both cases; it closes only via an explicit action control.
     - _Requirements: 12.4, 12.5_
-  - [ ] 7.6 Scroll lock while open, restored on close
+    - **SKIPPED:** No demo opens a surface with `disableClose: true`. `normalizeModalConfig` maps it to
+      CDK's `disableClose` (unit-tested). Needs a demo button to dogfood in-browser.
+  - [x] 7.6 Scroll lock while open, restored on close
     - **Preconditions:** A page tall enough to scroll behind the modal.
     - **Steps:**
       1. Note the page scroll position. 2. Open a modal and try to scroll the page (wheel/trackpad).
@@ -335,23 +370,26 @@ says so.
     - **Expected:** The page behind cannot scroll while the modal is open; normal scrolling resumes
       (at the prior position) after close.
     - _Requirements: 12.6_
-  - [ ] 7.7 Dialog semantics + accessible name
+  - [x] 7.7 Dialog semantics + accessible name
     - **Preconditions:** Screen reader on.
     - **Steps:**
       1. Open each modal surface and listen to how it is announced.
     - **Expected:** Announced as a modal dialog (role=dialog, aria-modal=true) with an accessible name
       from its headline/title (or aria-label).
     - _Requirements: 12.7, 14.1_
-  - [ ] 7.8 Stacked modals: Escape + focus target the top-most
+  - [s] 7.8 Stacked modals: Escape + focus target the top-most
     - **Preconditions:** Open one modal, then open a second from within it (e.g. a dialog that opens a sheet).
     - **Steps:**
       1. Press Escape once. 2. Observe which surface closes and where focus lands. 3. Press Escape again.
     - **Expected:** Escape closes only the top-most surface; focus trapping applies to the top-most; on
       close focus returns to the surface beneath; closing unwinds in reverse order.
     - _Requirements: 12.8_
+    - **SKIPPED:** No demo surface opens a second modal from within it, and page triggers are blocked by
+      the scrim while a modal is open, so a stack can't be built in the playground. CDK overlay stacking
+      handles top-most Escape/focus. Needs a nested-modal demo to dogfood.
 
-- [ ] 8. Carousel — layouts and sizing
-  - [ ] 8.1 Multi-browse sizes items into large/medium/small with a peek
+- [!] 8. Carousel — layouts and sizing
+  - [x] 8.1 Multi-browse sizes items into large/medium/small with a peek
     - **Preconditions:** Demo open at "Carousel"; "multi-browse" selected.
     - **Steps:**
       1. Inspect the rendered item widths across the row.
@@ -359,41 +397,51 @@ says so.
     - **Expected:** A large focal item, then medium/small keylines (non-focal capped at two), with the
       smallest item peeking at the trailing edge; sizes morph as you scroll; small items stay within 40–56dp.
     - _Requirements: 11.1, 11.2, 11.3_
-  - [ ] 8.2 Uncontained uses uniform items with a cut-off trailing item
+  - [!] 8.2 Uncontained uses uniform items with a cut-off trailing item
     - **Preconditions:** "uncontained" selected.
     - **Steps:**
       1. Inspect item widths; confirm the last visible item is partially cut off.
     - **Expected:** Uniform item widths; the trailing item is resized/cut at the edge; scrolls past the edge.
     - _Requirements: 11.2_
-  - [ ] 8.3 Hero shows one large focal item plus a peek
+    - **FAILED:** Uncontained items render **non-uniform** — measured `[181, 81, 76, 76, 76, 76, 76, 76]`
+      (focal large, the rest shrunk). The engine's `arrange('uncontained')` correctly returns uniform
+      `large` items, but `maskForOffset` applies the multi-browse distance-morph (`width = large −
+      distance·(large − smallest)`) to **every** layout, so only the focal item stays large. M3
+      uncontained should be uniform with no morph. Fix: skip `maskForOffset` (use static `large`) for
+      the `uncontained` and `full-screen` layouts.
+  - [x] 8.3 Hero shows one large focal item plus a peek
     - **Preconditions:** "hero" selected.
     - **Steps:**
       1. Inspect the layout.
     - **Expected:** One large focal item fills most of the width with a small peek of the next item.
     - _Requirements: 11.2, 11.3_
-  - [ ] 8.4 Full-screen: one item fills the viewport; vertical on compact
+  - [x] 8.4 Full-screen: one item fills the viewport; vertical on compact
     - **Preconditions:** "full-screen" selected.
     - **Steps:**
       1. On a wide viewport, confirm one item fills the carousel width and scrolls horizontally.
       2. Narrow the window below 600px and confirm orientation.
     - **Expected:** One item fills the viewport; on a compact window the carousel scrolls **vertically**.
     - _Requirements: 11.1, 11.6_
-  - [ ] 8.5 Items clip to the 28dp corner shape
+  - [x] 8.5 Items clip to the 28dp corner shape
     - **Preconditions:** Any layout.
     - **Steps:**
       1. Inspect a carousel item's corner radius and content clipping.
     - **Expected:** Each item clips its content to the extra-large (28dp) corner shape.
     - _Requirements: 11.4, 13.1_
-  - [ ] 8.6 Resize re-fits without disallowed partial items
+  - [s] 8.6 Resize re-fits without disallowed partial items
     - **Preconditions:** Multi-browse selected.
     - **Steps:**
       1. Slowly drag the window/viewport width from wide to narrow and back.
     - **Expected:** Items re-fit continuously per the layout; no partially-cut items appear in positions
       the layout disallows; no layout jump/flicker beyond the resize.
     - _Requirements: 11.5_
+    - **SKIPPED:** The demo's carousel container is fixed at ~480px, so narrowing the viewport (tested
+      1280→360px) never changes the track width and the `ResizeObserver` re-fit can't be exercised
+      in-browser. The re-fit/`measure()` path is covered by `carousel.spec.ts`. Needs a fluid-width demo
+      container to dogfood.
 
-- [ ] 9. Tokens, theming, and motion
-  - [ ] 9.1 Light/dark switch updates every component via tokens
+- [x] 9. Tokens, theming, and motion
+  - [x] 9.1 Light/dark switch updates every component via tokens
     - **Preconditions:** Demo open with all containment sections visible.
     - **Steps:**
       1. Toggle the OS (or app) theme between light and dark.
@@ -401,7 +449,7 @@ says so.
     - **Expected:** Cards, dividers, lists, dialog/sheet surfaces, and carousel items all recolor purely
       from `--md-sys-*` tokens — no element keeps a stale/hard-coded color.
     - _Requirements: 13.1, 13.2, 13.3_
-  - [ ] 9.2 Transitions use M3 motion; reduced-motion removes them
+  - [x] 9.2 Transitions use M3 motion; reduced-motion removes them
     - **Preconditions:** Reduced motion **off**, then **on** (OS Accessibility setting).
     - **Steps:**
       1. With motion on, open a dialog, a bottom sheet, a side sheet — watch the enter animation; scroll the carousel.
@@ -411,22 +459,30 @@ says so.
       scroll **state** still work; items render at their arranged sizes.
     - _Requirements: 15.1, 15.2, 15.3_
 
-- [ ] 10. Accessibility sweep (keyboard + screen reader)
-  - [ ] 10.1 Full keyboard-only operation
+- [!] 10. Accessibility sweep (keyboard + screen reader)
+  - [x] 10.1 Full keyboard-only operation
     - **Preconditions:** Mouse unplugged / not used; demo open.
     - **Steps:**
       1. Using only the keyboard, operate: clickable card, listbox selection, open/close every dialog and
          sheet, switch carousel layouts.
     - **Expected:** Every interactive containment surface is reachable and operable by keyboard alone.
     - _Requirements: 14.3_
-  - [ ] 10.2 Visible focus indicator everywhere
+  - [!] 10.2 Visible focus indicator everywhere
     - **Preconditions:** Keyboard navigation.
     - **Steps:**
       1. Tab through every focusable containment surface and watch the focus ring.
     - **Expected:** A visible focus indicator appears on each focusable surface, meeting WCAG 2.2 AA
       focus-appearance / non-text-contrast.
     - _Requirements: 14.4_
-  - [ ] 10.3 Screen-reader semantics
+    - **FAILED:** **Listbox options have no visible focus indicator.** A keyboard-focused option matches
+      `:focus-visible` but renders nothing: host `outline-style:none` (list-item.css:39 sets `outline:
+      none`), no `gui-state-layer`, no `gui-focus-ring` class (`GuiListItem` doesn't apply
+      `GuiFocusRingDirective`), no `::before/::after` ring, and no background change for the *focused*
+      (vs selected) row. Arrowing through the listbox gives a sighted keyboard user no sign of which
+      option is focused. The clickable **card** correctly shows the 3dp ring (it uses
+      `GuiFocusRingDirective`). Fix: give interactive/selectable list items the M3 focus indicator
+      (state-layer focus tint and/or the `gui-focus-ring`).
+  - [x] 10.3 Screen-reader semantics
     - **Preconditions:** Screen reader on.
     - **Steps:**
       1. Navigate cards (plain vs actionable), the listbox, dividers, and each modal surface.
@@ -435,8 +491,8 @@ says so.
       by color alone.
     - _Requirements: 14.1, 14.2, 14.5_
 
-- [ ] 11. Packaging, SSR, and zoneless
-  - [ ] 11.1 Each family imports from its own entry point
+- [x] 11. Packaging, SSR, and zoneless
+  - [x] 11.1 Each family imports from its own entry point
     - **Preconditions:** Source/editor available.
     - **Steps:**
       1. Confirm the demo imports from `@ngguide/ui/{card,divider,list,dialog,bottom-sheet,side-sheet,carousel}`.
@@ -444,13 +500,13 @@ says so.
     - **Expected:** Each family resolves as its own secondary entry point and the library builds with all
       seven entry points emitted.
     - _Requirements: 16.1_
-  - [ ] 11.2 Imperative open returns a handle/result
+  - [x] 11.2 Imperative open returns a handle/result
     - **Preconditions:** Demo open.
     - **Steps:**
       1. Trigger the imperative full-screen dialog and the modal sheets (service `open()` calls).
     - **Expected:** Each `open()` returns a ref whose `closed` emits the result; closing programmatically works.
     - _Requirements: 16.2_
-  - [ ] 11.3 SSR renders without errors and hydrates without layout shift
+  - [x] 11.3 SSR renders without errors and hydrates without layout shift
     - **Preconditions:** `NX_NO_CLOUD=true pnpm exec nx build web` (prerenders one route).
     - **Steps:**
       1. Inspect the prerendered HTML for the containment sections (cards, list, carousel items).
@@ -458,9 +514,39 @@ says so.
     - **Expected:** Server HTML renders the static surfaces (carousel items at the large fallback width);
       no console errors; no visible layout shift on hydration; the app runs zoneless (no zone.js).
     - _Requirements: 16.3, 16.4_
+    - **PASSED (with note):** Prerendered HTML renders the containment surfaces (26 `gui-card`, 18
+      `gui-divider`, 64 `gui-list-item`, 26 `gui-carousel-item`), carousel items fall back to the CSS
+      `--gui-carousel-large` width, and there are **no** `zone.js` references (zoneless). Console has **no
+      hydration errors** (no NG0xxx / mismatch) and **no containment-component errors**. The only console
+      error (×20) is a pre-existing, out-of-scope `ChipSetComponent` issue: `createRovingFocus` enables
+      type-ahead but chips don't implement `getLabel` → `ListKeyManager … must implement the getLabel
+      method`. Worth a separate fix (and relevant to the list type-ahead note in 3.6).
 
 ## Summary
-- Total: 52 tests
-- Passed: 0
-- Failed: 0
-- Skipped: 0
+- Total: 56 tests
+- Passed: 44
+- Failed: 5
+- Skipped: 7
+
+### Run notes
+Dogfooded in a real headless Chromium via `agent-browser` against the dev server
+(`nx serve web`, port 4300), driving real clicks/keyboard/pointer-drag gestures and reading
+computed styles, ARIA, and CDP media emulation (`prefers-color-scheme`, `prefers-reduced-motion`).
+Screen-reader cases (1.7, 2.2, 3.7, 7.7, 10.3) were verified by their **ARIA semantics** as a proxy
+— true VoiceOver/NVDA narration still warrants a manual pass.
+
+**Failures (5):**
+- **3.2** — list supporting text has no line-clamp; long text grows the row instead of truncating.
+- **5.5** — standard bottom sheet stays visible after a drag-dismiss (CdkDrag `setFreeDragPosition`
+  inline transform overrides the CSS `translateY(100%)` close state).
+- **6.3** — side sheet has no built-in scroll region; overflowing content clips and pushes the actions
+  region off-screen.
+- **8.2** — uncontained carousel renders non-uniform (morphed) items because `maskForOffset` is applied
+  to every layout.
+- **10.2** — listbox options have no visible keyboard focus indicator.
+
+**Skipped (7):** 1.6, 3.8, 4.6, 5.6, 7.5, 7.8 (need a demo prop/button to exercise a config the
+playground doesn't expose), 8.6 (demo carousel container is fixed-width). All are covered by unit tests.
+
+**Also noted:** listbox type-ahead doesn't move focus (3.6 — optional per APG); a pre-existing
+`ChipSetComponent` console error (out of containment scope, see 11.3).

--- a/.specs/containment/test-plan.md
+++ b/.specs/containment/test-plan.md
@@ -114,7 +114,7 @@ says so.
       not reachable by Tab.
     - _Requirements: 3.3, 3.4, 14.5_
 
-- [!] 3. List — densities, leading/trailing, action vs listbox
+- [x] 3. List — densities, leading/trailing, action vs listbox
   - [x] 3.1 One/two/three-line densities at the correct heights
     - **Preconditions:** Demo open at the "List" section (action list).
     - **Steps:**
@@ -122,16 +122,16 @@ says so.
     - **Expected:** Heights are 56 / 72 / 88dp respectively; headline uses the body-large typescale,
       supporting text uses body-medium, trailing supporting text uses label-small.
     - _Requirements: 4.1, 4.2, 4.3, 13.1_
-  - [!] 3.2 Long supporting text truncates within the reserved lines
+  - [x] 3.2 Long supporting text truncates within the reserved lines
     - **Preconditions:** Action list; the 3-line row with a long description.
     - **Steps:**
       1. Narrow the container and observe the supporting text.
     - **Expected:** Supporting text truncates within the row's reserved lines; nothing overflows the row.
     - _Requirements: 4.4_
-    - **FAILED:** The supporting text has no `-webkit-line-clamp`/ellipsis (computed `overflow:visible`,
-      `line-clamp:none`). With the demo's short copy it happens to fit in 2 lines, but injecting longer
-      text grows the 3-line row from 88px to 168px (6 lines) instead of truncating — the row just
-      expands. Fix: clamp supporting text to its reserved line count in `list-item.css`.
+    - **FIXED & re-tested:** `list-item.css` now clamps the supporting text with `-webkit-line-clamp`
+      (1 line for 2-line rows, 2 for 3-line) plus `overflow:hidden`/ellipsis, and the headline is single
+      line with ellipsis. Re-test: injecting long text now keeps the 3-line row at **88px** (`scrollHeight
+      88`, no overflow, `line-clamp:2`) instead of growing to 168px. (Originally: no clamp, row grew.)
   - [x] 3.3 Leading and trailing elements positioned per M3
     - **Preconditions:** Action list with leading icons and trailing supporting text; dividers between rows.
     - **Steps:**
@@ -165,10 +165,11 @@ says so.
       Enter/Space/click toggle selection; selected rows render the secondary-container treatment and
       expose `aria-selected=true`; multi-select keeps multiple selected.
     - _Requirements: 6.3, 6.6, 14.2, 14.3, 14.5_
-    - **PASSED (with note):** Single tab stop ✓, arrows wrap (Date→Apple) ✓, Home/End ✓, Enter/Space/click
-      toggle selection ✓, `aria-selected=true` + secondary-container (`#4a4458`) ✓, multi-select keeps
-      [Apple,Banana,Cherry] ✓. **Type-ahead does NOT move focus** (no jump on `c`/`d`/`b`) — optional in
-      the APG listbox pattern and not mandated by Req 6.6, so recorded as pass; worth wiring up later.
+    - **PASSED:** Single tab stop ✓, arrows wrap (Date→Apple) ✓, Home/End ✓, Enter/Space/click toggle
+      selection ✓, `aria-selected=true` + secondary-container (`#4a4458`) ✓, multi-select keeps
+      [Apple,Banana,Cherry] ✓. **Type-ahead works** (`c`→Cherry, `d`→Date with a faithful keydown) — the
+      original "type-ahead broken" note was an `agent-browser press` artifact (its CDP key events race
+      with the RxJS-debounced type-ahead / focus wasn't on the option); real keyboards move focus.
   - [x] 3.7 Selected state is not conveyed by color alone
     - **Preconditions:** Listbox with a selected option; screen reader on.
     - **Steps:**
@@ -237,7 +238,7 @@ says so.
     - **Expected:** The inline `<ng-template>` content opens as the dialog without any imperative code.
     - _Requirements: 7.2_
 
-- [!] 5. Bottom sheet — modal, drag, standard
+- [x] 5. Bottom sheet — modal, drag, standard
   - [x] 5.1 Modal bottom sheet anatomy
     - **Preconditions:** Demo open at "Bottom sheet"; click "Modal sheet".
     - **Steps:**
@@ -266,7 +267,7 @@ says so.
       1. Scroll inside the sheet.
     - **Expected:** Content scrolls within the sheet, not past the screen edge.
     - _Requirements: 9.5_
-  - [!] 5.5 Standard bottom sheet coexists with the page
+  - [x] 5.5 Standard bottom sheet coexists with the page
     - **Preconditions:** Demo open; click "Toggle standard sheet".
     - **Steps:**
       1. With the standard sheet open, click/scroll/select text on the page behind it.
@@ -275,14 +276,11 @@ says so.
     - **Expected:** No scrim; the page behind stays fully interactive and scrollable; dragging down
       dismisses (sets open=false); the toggle button opens/closes it.
     - _Requirements: 9.2, 9.4_
-    - **FAILED:** No scrim ✓, host `pointer-events:none` (page interactive) ✓, toggle open/close slides
-      the surface off-screen ✓, and drag-down sets `open=false` ✓ — BUT after any drag the dismissed
-      sheet **stays visible on screen** instead of sliding away. `onDragEnded` calls
-      `event.source.setFreeDragPosition({x:0,y:0})` (bottom-sheet.ts:69), which writes an inline
-      `transform: translate3d(0,0,0)` that overrides the CSS closed state
-      `.gui-bottom-sheet-surface{transform:translateY(100%)}`. The clean (no-drag) toggle path hides
-      correctly; the bug is drag-specific. Fix: clear the inline drag transform on close (e.g. reset to
-      `''`/null) so the CSS slide-out applies, or animate the dismiss via the open state.
+    - **FIXED & re-tested:** `onDragEnded` now calls `event.source.reset()` (instead of
+      `setFreeDragPosition({0,0})`), which clears the inline drag transform so the CSS open/closed state
+      (`translateY(0)` / `translateY(100%)`) drives the position. Re-test: a past-threshold drag now sets
+      `open=false`, clears the inline transform, and the surface slides to `top 900` (off-screen); a
+      short drag springs back with the transform cleared. (Originally: dismissed sheet stayed visible.)
   - [s] 5.6 Drag handle can be hidden
     - **Preconditions:** Open a modal sheet with `showDragHandle: false`.
     - **Steps:**
@@ -292,7 +290,7 @@ says so.
     - **SKIPPED:** No demo opens a modal sheet with `showDragHandle: false`. The `@if (showDragHandle())`
       gate is covered by the bottom-sheet specs. Needs a demo button to dogfood in-browser.
 
-- [!] 6. Side sheet — modal and standard
+- [x] 6. Side sheet — modal and standard
   - [x] 6.1 Modal side sheet anatomy
     - **Preconditions:** Demo open at "Side sheet"; click "Modal side sheet".
     - **Steps:**
@@ -306,19 +304,17 @@ says so.
       1. Click the header ✕. 2. Reopen and press Escape. 3. Reopen and click "Apply".
     - **Expected:** ✕ and Escape close with a dismissal; "Apply" emits a confirm result ("applied").
     - _Requirements: 10.5, 10.6_
-  - [!] 6.3 Side-sheet content scrolls within the sheet
+  - [x] 6.3 Side-sheet content scrolls within the sheet
     - **Preconditions:** Modal side sheet with overflowing content.
     - **Steps:**
       1. Scroll inside the sheet body.
     - **Expected:** The content region scrolls within the sheet; the header/actions stay in place.
     - _Requirements: 10.6_
-    - **FAILED:** The side sheet provides **no built-in scrollable content region** (unlike the bottom
-      sheet's `.gui-bottom-sheet-body{overflow-y:auto}`). The inner surface is `overflow:hidden`, header
-      and actions are `flex:0 0 auto`, and the projected content slot is `overflow:visible`. Injecting
-      tall content grows the content to 2400px, overflows the surface by ~1556px, and **pushes the
-      actions region off-screen** (clipped) instead of scrolling. Fix: wrap projected content in a
-      `flex:1 1 auto; overflow-y:auto` region in the side-sheet surface/container, mirroring the bottom
-      sheet.
+    - **FIXED & re-tested:** Added a `GuiSideSheetContent` component
+      (`flex:1 1 auto; min-height:0; overflow-y:auto`) — the side-sheet analogue of `gui-dialog-content`
+      — and wrapped the demo's content in it. Re-test: tall content now scrolls **within** the content
+      region (`overflow-y:auto`, scrollable), the content stays inside the surface, and the header +
+      actions remain visible/pinned after scrolling. (Originally: content clipped and pushed actions off.)
   - [x] 6.4 Standard side sheet coexists with the page
     - **Preconditions:** Demo open; click "Toggle standard side sheet".
     - **Steps:**
@@ -388,7 +384,7 @@ says so.
       the scrim while a modal is open, so a stack can't be built in the playground. CDK overlay stacking
       handles top-most Escape/focus. Needs a nested-modal demo to dogfood.
 
-- [!] 8. Carousel — layouts and sizing
+- [x] 8. Carousel — layouts and sizing
   - [x] 8.1 Multi-browse sizes items into large/medium/small with a peek
     - **Preconditions:** Demo open at "Carousel"; "multi-browse" selected.
     - **Steps:**
@@ -397,18 +393,16 @@ says so.
     - **Expected:** A large focal item, then medium/small keylines (non-focal capped at two), with the
       smallest item peeking at the trailing edge; sizes morph as you scroll; small items stay within 40–56dp.
     - _Requirements: 11.1, 11.2, 11.3_
-  - [!] 8.2 Uncontained uses uniform items with a cut-off trailing item
+  - [x] 8.2 Uncontained uses uniform items with a cut-off trailing item
     - **Preconditions:** "uncontained" selected.
     - **Steps:**
       1. Inspect item widths; confirm the last visible item is partially cut off.
     - **Expected:** Uniform item widths; the trailing item is resized/cut at the edge; scrolls past the edge.
     - _Requirements: 11.2_
-    - **FAILED:** Uncontained items render **non-uniform** — measured `[181, 81, 76, 76, 76, 76, 76, 76]`
-      (focal large, the rest shrunk). The engine's `arrange('uncontained')` correctly returns uniform
-      `large` items, but `maskForOffset` applies the multi-browse distance-morph (`width = large −
-      distance·(large − smallest)`) to **every** layout, so only the focal item stays large. M3
-      uncontained should be uniform with no morph. Fix: skip `maskForOffset` (use static `large`) for
-      the `uncontained` and `full-screen` layouts.
+    - **FIXED & re-tested:** `applyWidths` now has an `uncontained` branch that assigns every item the
+      static `large` width (no `maskForOffset` morph); the trailing item is clipped by the container's
+      overflow rather than resized. Re-test: uncontained renders `[186, 186, 186, …]` (uniform), while
+      multi-browse/hero still morph (`[180, 62, 56, …]`). (Originally: uncontained was non-uniform.)
   - [x] 8.3 Hero shows one large focal item plus a peek
     - **Preconditions:** "hero" selected.
     - **Steps:**
@@ -459,7 +453,7 @@ says so.
       scroll **state** still work; items render at their arranged sizes.
     - _Requirements: 15.1, 15.2, 15.3_
 
-- [!] 10. Accessibility sweep (keyboard + screen reader)
+- [x] 10. Accessibility sweep (keyboard + screen reader)
   - [x] 10.1 Full keyboard-only operation
     - **Preconditions:** Mouse unplugged / not used; demo open.
     - **Steps:**
@@ -467,21 +461,18 @@ says so.
          sheet, switch carousel layouts.
     - **Expected:** Every interactive containment surface is reachable and operable by keyboard alone.
     - _Requirements: 14.3_
-  - [!] 10.2 Visible focus indicator everywhere
+  - [x] 10.2 Visible focus indicator everywhere
     - **Preconditions:** Keyboard navigation.
     - **Steps:**
       1. Tab through every focusable containment surface and watch the focus ring.
     - **Expected:** A visible focus indicator appears on each focusable surface, meeting WCAG 2.2 AA
       focus-appearance / non-text-contrast.
     - _Requirements: 14.4_
-    - **FAILED:** **Listbox options have no visible focus indicator.** A keyboard-focused option matches
-      `:focus-visible` but renders nothing: host `outline-style:none` (list-item.css:39 sets `outline:
-      none`), no `gui-state-layer`, no `gui-focus-ring` class (`GuiListItem` doesn't apply
-      `GuiFocusRingDirective`), no `::before/::after` ring, and no background change for the *focused*
-      (vs selected) row. Arrowing through the listbox gives a sighted keyboard user no sign of which
-      option is focused. The clickable **card** correctly shows the 3dp ring (it uses
-      `GuiFocusRingDirective`). Fix: give interactive/selectable list items the M3 focus indicator
-      (state-layer focus tint and/or the `gui-focus-ring`).
+    - **FIXED & re-tested:** `GuiListItem` now applies `GuiFocusRingDirective` (keyboard focus → the
+      `.gui-focus-visible` class via CDK FocusMonitor), and `list-item.css` draws the M3 focus indicator
+      on `:host(.gui-focus-visible)` (3dp `currentColor` outline, inset so it isn't clipped; suppressed
+      for disabled options). Re-test: arrowing to an option now shows `outline: solid 3px #e6e0e9`,
+      offset −3px. (Originally: no ring/tint at all on focused options.)
   - [x] 10.3 Screen-reader semantics
     - **Preconditions:** Screen reader on.
     - **Steps:**
@@ -518,14 +509,15 @@ says so.
       `gui-divider`, 64 `gui-list-item`, 26 `gui-carousel-item`), carousel items fall back to the CSS
       `--gui-carousel-large` width, and there are **no** `zone.js` references (zoneless). Console has **no
       hydration errors** (no NG0xxx / mismatch) and **no containment-component errors**. The only console
-      error (×20) is a pre-existing, out-of-scope `ChipSetComponent` issue: `createRovingFocus` enables
-      type-ahead but chips don't implement `getLabel` → `ListKeyManager … must implement the getLabel
-      method`. Worth a separate fix (and relevant to the list type-ahead note in 3.6).
+      error was a pre-existing `ChipSetComponent` issue (`createRovingFocus` enables type-ahead but chips
+      didn't implement `getLabel` → `ListKeyManager … must implement the getLabel method`). **Now fixed:**
+      `GuiChip` implements `getLabel()` (explicit `label` input or visible text). Re-test on a fresh
+      browser session: **0 console errors**.
 
 ## Summary
 - Total: 56 tests
-- Passed: 44
-- Failed: 5
+- Passed: 49
+- Failed: 0
 - Skipped: 7
 
 ### Run notes
@@ -535,18 +527,22 @@ computed styles, ARIA, and CDP media emulation (`prefers-color-scheme`, `prefers
 Screen-reader cases (1.7, 2.2, 3.7, 7.7, 10.3) were verified by their **ARIA semantics** as a proxy
 — true VoiceOver/NVDA narration still warrants a manual pass.
 
-**Failures (5):**
-- **3.2** — list supporting text has no line-clamp; long text grows the row instead of truncating.
-- **5.5** — standard bottom sheet stays visible after a drag-dismiss (CdkDrag `setFreeDragPosition`
-  inline transform overrides the CSS `translateY(100%)` close state).
-- **6.3** — side sheet has no built-in scroll region; overflowing content clips and pushes the actions
-  region off-screen.
-- **8.2** — uncontained carousel renders non-uniform (morphed) items because `maskForOffset` is applied
-  to every layout.
-- **10.2** — listbox options have no visible keyboard focus indicator.
+**All 5 originally-failed cases were fixed and re-verified in the browser:**
+- **3.2** — `list-item.css` clamps supporting text (`-webkit-line-clamp`) + single-line headline; the
+  3-line row stays 88px under long text.
+- **5.5** — `onDragEnded` now `reset()`s the CdkDrag transform, so a drag-dismissed standard sheet slides
+  off-screen (CSS `translateY(100%)`).
+- **6.3** — new `GuiSideSheetContent` (`flex:1; min-height:0; overflow-y:auto`) gives the side sheet a
+  scrollable content region; header/actions stay pinned.
+- **8.2** — carousel `applyWidths` renders uncontained items at a uniform `large` width (no morph);
+  multi-browse/hero still morph.
+- **10.2** — `GuiListItem` applies `GuiFocusRingDirective`; focused options show a 3dp inset ring.
+
+**Fixed beyond the 5 (during this pass):**
+- listbox **type-ahead** in fact works (`c`→Cherry) — the original 3.6 note was an `agent-browser press`
+  artifact, not a product defect.
+- pre-existing **`ChipSetComponent` console error** fixed by adding `getLabel()` to `GuiChip`; a fresh
+  session now logs **0 errors**.
 
 **Skipped (7):** 1.6, 3.8, 4.6, 5.6, 7.5, 7.8 (need a demo prop/button to exercise a config the
 playground doesn't expose), 8.6 (demo carousel container is fixed-width). All are covered by unit tests.
-
-**Also noted:** listbox type-ahead doesn't move focus (3.6 — optional per APG); a pre-existing
-`ChipSetComponent` console error (out of containment scope, see 11.3).

--- a/.specs/containment/test-plan.md
+++ b/.specs/containment/test-plan.md
@@ -1,0 +1,466 @@
+---
+created: 2026-06-03
+updated: 2026-06-03
+---
+
+# Manual Test Plan: Containment Components
+
+## Overview
+
+This plan verifies the seven M3 containment families (card, divider, list, dialog,
+bottom-sheet, side-sheet, carousel) **in a real browser** — the layer the zoneless
+Vitest suite (294 passing unit tests) cannot exercise: computed layout and item
+sizing, pointer drag gestures, focus trap / restore, scroll-lock, scrim behavior,
+live theming, real motion + the OS reduced-motion preference, screen-reader output,
+and SSR/hydration. Every testable acceptance criterion in `requirements.md` is traced
+to at least one case below.
+
+Tests are run against the demo playground (`apps/web`), which has a dedicated section
+per family (Card & Divider, List, Dialog, Bottom sheet, Side sheet, Carousel). Where a
+behavior is only observable with a tool (screen reader, DevTools, OS setting), the step
+says so.
+
+## Prerequisites
+
+- Node + pnpm installed; dependencies installed (`pnpm install`).
+- Dev server running: `NX_NO_CLOUD=true pnpm exec nx serve web`, opened in a Chromium-based
+  browser **and** at least one of Firefox/Safari for a cross-browser pass.
+- Browser DevTools available (to read computed styles / the element tree / emulate
+  prefers-reduced-motion and prefers-color-scheme, and to throttle viewport width).
+- A screen reader for the a11y group: VoiceOver (macOS) or NVDA (Windows).
+- OS controls reachable for: **reduced motion** (Settings → Accessibility), **dark mode**,
+  and (optional) **increased contrast**.
+- A way to narrow the viewport below 600px (DevTools device toolbar or window resize) for
+  the compact-window cases.
+- For SSR: a production build to inspect prerendered HTML — `NX_NO_CLOUD=true pnpm exec nx build web`
+  then open `dist/apps/web` output (the build prerenders one static route).
+
+## Test Scenarios
+
+- [ ] 1. Card — variants, actionability, states
+  - [ ] 1.1 Three variants render with the correct M3 surface
+    - **Preconditions:** Demo open at the "Card & Divider" section.
+    - **Steps:**
+      1. Locate the row of three cards labelled elevated / filled / outlined.
+      2. With DevTools, inspect each card's computed `background-color`, `box-shadow`, and `border`.
+    - **Expected:** Elevated = surface-container-low with a resting shadow (elevation level 1);
+      filled = surface-container-highest with **no** shadow; outlined = surface with **no** shadow
+      and a 1px outline-variant border. All three share the same medium (12dp) corner radius.
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 13.1_
+  - [ ] 1.2 Content clips to the rounded corners
+    - **Preconditions:** Demo open.
+    - **Steps:**
+      1. Inspect a card containing full-bleed content (or temporarily add an image that fills the card).
+    - **Expected:** Content is clipped to the card's rounded corners; nothing spills past the radius.
+    - _Requirements: 1.6, 1.7_
+  - [ ] 1.3 Whole-surface clickable card behaves as one control
+    - **Preconditions:** Demo open; "Last card action" readout visible.
+    - **Steps:**
+      1. Hover the "Clickable card" — observe the state layer.
+      2. Tab to it with the keyboard — observe the focus ring.
+      3. Press Enter, then Space, then click it.
+    - **Expected:** Hover/focus/press show M3 state layers; the card is a single Tab stop with a
+      visible focus indicator; Enter, Space, and click each set the readout to "clickable card".
+    - _Requirements: 2.1, 2.2, 2.4, 13.4, 14.3, 14.4_
+  - [ ] 1.4 Elevated actionable card raises on hover/press
+    - **Preconditions:** Demo open.
+    - **Steps:**
+      1. Inspect the elevated clickable card's `box-shadow` at rest, then while hovering.
+    - **Expected:** The shadow increases on hover (resting level 1 → level 2) per M3.
+    - _Requirements: 2.3_
+  - [ ] 1.5 Primary-action region is independent of card action buttons
+    - **Preconditions:** Demo open; the outlined "Primary-action card" with Share/Save buttons.
+    - **Steps:**
+      1. Click the card body (above the divider). Note the readout.
+      2. Click "Share", then "Save".
+      3. Tab through the card and confirm the focus order.
+    - **Expected:** Body click sets readout to "primary action"; Share/Save set "share"/"save"
+      independently; the primary-action region and each button are separately focusable.
+    - _Requirements: 2.1, 2.4, 14.3_
+  - [ ] 1.6 Disabled card suppresses interaction
+    - **Preconditions:** Temporarily set `disabled` on the clickable card (or use a disabled demo card).
+    - **Steps:**
+      1. Observe the card's opacity. 2. Hover and click it. 3. Try to Tab to it.
+    - **Expected:** Card shows the 0.38 disabled treatment, emits **no** activation event, shows
+      **no** state layer, and is not focusable (skipped in Tab order).
+    - _Requirements: 2.5, 2.6_
+  - [ ] 1.7 Non-actionable card has no control semantics
+    - **Preconditions:** Demo open; the three plain variant cards.
+    - **Steps:**
+      1. With a screen reader on, navigate onto a plain card. 2. Try to Tab to it.
+    - **Expected:** Plain cards are **not** announced as buttons, are not focusable, and show no
+      hover/press state layer.
+    - _Requirements: 2.6_
+
+- [ ] 2. Divider
+  - [ ] 2.1 Thickness, color, and the three insets
+    - **Preconditions:** Demo open; the divider inset examples (none / inset / middle-inset) and the
+      divider inside the primary-action card.
+    - **Steps:**
+      1. Inspect each divider's height and `background-color`.
+      2. Compare the leading/trailing edges of none vs inset vs middle-inset.
+    - **Expected:** 1px line in outline-variant; `inset` is indented 16px on the leading edge only;
+      `middle-inset` is indented 16px on both edges; `none` is full-width.
+    - _Requirements: 3.1, 3.2, 13.1_
+  - [ ] 2.2 Divider is a non-focusable separator
+    - **Preconditions:** Demo open; screen reader on.
+    - **Steps:**
+      1. Navigate to a divider with the screen reader. 2. Try to Tab to it.
+    - **Expected:** Announced as a separator (role=separator), conveys "divider" not content, and is
+      not reachable by Tab.
+    - _Requirements: 3.3, 3.4, 14.5_
+
+- [ ] 3. List — densities, leading/trailing, action vs listbox
+  - [ ] 3.1 One/two/three-line densities at the correct heights
+    - **Preconditions:** Demo open at the "List" section (action list).
+    - **Steps:**
+      1. Inspect the min-height of the 1-, 2-, and 3-line rows.
+    - **Expected:** Heights are 56 / 72 / 88dp respectively; headline uses the body-large typescale,
+      supporting text uses body-medium, trailing supporting text uses label-small.
+    - _Requirements: 4.1, 4.2, 4.3, 13.1_
+  - [ ] 3.2 Long supporting text truncates within the reserved lines
+    - **Preconditions:** Action list; the 3-line row with a long description.
+    - **Steps:**
+      1. Narrow the container and observe the supporting text.
+    - **Expected:** Supporting text truncates within the row's reserved lines; nothing overflows the row.
+    - _Requirements: 4.4_
+  - [ ] 3.3 Leading and trailing elements positioned per M3
+    - **Preconditions:** Action list with leading icons and trailing supporting text; dividers between rows.
+    - **Steps:**
+      1. Confirm leading icons sit at the start with 16dp inset; trailing text at the end.
+      2. Confirm the dividers render between rows (inset variant).
+    - **Expected:** Leading icon ~24dp at the start, 16dp insets, trailing text aligned to the end;
+      dividers separate rows.
+    - _Requirements: 4.5, 5.1, 5.2, 5.3_
+  - [ ] 3.4 Text inset when no leading element
+    - **Preconditions:** A list row with no leading element.
+    - **Steps:**
+      1. Compare the headline start position of a row with a leading icon vs one without.
+    - **Expected:** The row without a leading element applies the M3 text inset (headline starts at the
+      16dp content inset, not under a missing leading slot).
+    - _Requirements: 5.4_
+  - [ ] 3.5 Action list uses natural tab order
+    - **Preconditions:** Action list whose rows host native controls/links.
+    - **Steps:**
+      1. Tab through the list.
+    - **Expected:** Each interactive control is its own Tab stop in document order; the list is `role=list`
+      and rows are `role=listitem`; no roving single-tab-stop behavior.
+    - _Requirements: 6.1, 6.2, 6.6, 14.2_
+  - [ ] 3.6 Listbox: roving focus + selection
+    - **Preconditions:** Demo open; the selectable listbox (multi-select).
+    - **Steps:**
+      1. Tab into the listbox (lands on one option only).
+      2. Arrow Down/Up through options; press Home/End; type a letter (type-ahead).
+      3. Press Enter or Space on options to select; click another.
+      4. With a screen reader, confirm selected state is announced.
+    - **Expected:** Single Tab stop; arrows move focus (wrapping), Home/End jump, type-ahead matches;
+      Enter/Space/click toggle selection; selected rows render the secondary-container treatment and
+      expose `aria-selected=true`; multi-select keeps multiple selected.
+    - _Requirements: 6.3, 6.6, 14.2, 14.3, 14.5_
+  - [ ] 3.7 Selected state is not conveyed by color alone
+    - **Preconditions:** Listbox with a selected option; screen reader on.
+    - **Steps:**
+      1. Select an option and listen to the announcement.
+    - **Expected:** Selection is exposed via `aria-selected` (announced "selected"), not only the
+      container color change.
+    - _Requirements: 6.3, 14.5_
+  - [ ] 3.8 Disabled list option stays discoverable but inert
+    - **Preconditions:** Add a `disabled` option to the listbox.
+    - **Steps:**
+      1. Arrow onto the disabled option. 2. Press Enter/Space and click it.
+    - **Expected:** Option is still reachable by arrow keys (M3 keeps disabled options discoverable),
+      shows the dimmed treatment, exposes `aria-disabled=true`, and does **not** toggle selection.
+    - _Requirements: 6.5, 14.5_
+
+- [ ] 4. Dialog — basic and full-screen
+  - [ ] 4.1 Basic dialog surface and anatomy
+    - **Preconditions:** Demo open at "Dialog"; click "Basic dialog".
+    - **Steps:**
+      1. Inspect the dialog surface color, corner radius, elevation, and max-width.
+      2. Confirm the icon, headline, supporting content, and the two end-aligned text actions.
+    - **Expected:** Centered surface, surface-container-high, 28dp corners, elevation level 3, max
+      width ≈ min(560px, 100%−48px); icon + headline (h2) + content + ≤3 end-aligned text buttons.
+    - _Requirements: 7.1, 7.2, 13.1_
+  - [ ] 4.2 Basic dialog returns a result to the opener
+    - **Preconditions:** Basic dialog open. (Optionally watch the console/readout if wired.)
+    - **Steps:**
+      1. Click "Reset" — note close. 2. Reopen and click "Cancel". 3. Reopen and press Escape.
+    - **Expected:** Each path closes the dialog and the opener receives a distinct result
+      ("reset" vs undefined for Cancel/Escape) — verify via the returned `closed` value.
+    - _Requirements: 7.4, 7.6, 16.2_
+  - [ ] 4.3 Tall dialog content scrolls; headline + actions stay visible
+    - **Preconditions:** Basic dialog with content taller than the viewport (lengthen the demo content).
+    - **Steps:**
+      1. Open it and scroll the body.
+    - **Expected:** Only the content region scrolls; the headline and action row remain visible/pinned.
+    - _Requirements: 7.5_
+  - [ ] 4.4 Full-screen dialog fills the window with a top app bar
+    - **Preconditions:** Demo open; click "Full-screen dialog".
+    - **Steps:**
+      1. Confirm the surface fills the window edge-to-edge with a top bar (close ✕ + title + Save).
+      2. Scroll the body if it overflows.
+    - **Expected:** Edge-to-edge surface, no corner radius; top app bar with close/back, title, and a
+      confirming action; the body scrolls independently of the fixed top bar.
+    - _Requirements: 8.1, 8.5_
+  - [ ] 4.5 Full-screen close vs confirm results
+    - **Preconditions:** Full-screen dialog open.
+    - **Steps:**
+      1. Click ✕ (or press Escape) — note result. 2. Reopen and click "Save".
+    - **Expected:** Close/back/Escape emit a dismissal; "Save" emits a confirm result ("saved") to the opener.
+    - _Requirements: 8.2, 8.3_
+  - [ ] 4.6 `fullScreen: 'compact'` auto-selection
+    - **Preconditions:** A dialog opened with `fullScreen: 'compact'` (adjust the demo config or add a button).
+    - **Steps:**
+      1. Open it on a wide viewport. 2. Narrow the window below 600px and reopen.
+    - **Expected:** Basic (centered) on the wide viewport; full-screen on the compact viewport.
+    - _Requirements: 8.1_
+  - [ ] 4.7 Declarative trigger opens the inline template
+    - **Preconditions:** Demo open; "Basic dialog" uses `[guiDialogTrigger]`.
+    - **Steps:**
+      1. Click the trigger button.
+    - **Expected:** The inline `<ng-template>` content opens as the dialog without any imperative code.
+    - _Requirements: 7.2_
+
+- [ ] 5. Bottom sheet — modal, drag, standard
+  - [ ] 5.1 Modal bottom sheet anatomy
+    - **Preconditions:** Demo open at "Bottom sheet"; click "Modal sheet".
+    - **Steps:**
+      1. Inspect the surface color, top corner shape, elevation, and the drag handle.
+    - **Expected:** Surface slides up from the bottom; surface-container-low, 28dp top corners,
+      elevation level 1; a 32×4dp drag handle in on-surface-variant; initial height capped ~50%.
+    - _Requirements: 9.1, 13.1_
+  - [ ] 5.2 Drag past threshold dismisses; short drag springs back
+    - **Preconditions:** Modal sheet open.
+    - **Steps:**
+      1. Drag the handle down a small amount (< ~96px) and release.
+      2. Drag the handle down a large amount (> ~96px) and release.
+      3. During a drag, watch the scrim opacity.
+    - **Expected:** Short drag settles back to the open position; long drag dismisses the sheet (closing
+      with a `'swipe'` result); the scrim fades proportionally to the downward drag distance.
+    - _Requirements: 9.3, 9.4, 9.6_
+  - [ ] 5.3 No text selection / page scroll during drag
+    - **Preconditions:** Modal sheet open over page content.
+    - **Steps:**
+      1. Drag the handle and observe the page behind and any text under the pointer.
+    - **Expected:** No page text gets selected and the page behind does not scroll during the drag.
+    - _Requirements: 9.7_
+  - [ ] 5.4 Sheet content scrolls within the sheet
+    - **Preconditions:** Modal sheet with content taller than its ~50% height.
+    - **Steps:**
+      1. Scroll inside the sheet.
+    - **Expected:** Content scrolls within the sheet, not past the screen edge.
+    - _Requirements: 9.5_
+  - [ ] 5.5 Standard bottom sheet coexists with the page
+    - **Preconditions:** Demo open; click "Toggle standard sheet".
+    - **Steps:**
+      1. With the standard sheet open, click/scroll/select text on the page behind it.
+      2. Confirm there is no scrim.
+      3. Drag the handle down to dismiss; toggle it closed via the button.
+    - **Expected:** No scrim; the page behind stays fully interactive and scrollable; dragging down
+      dismisses (sets open=false); the toggle button opens/closes it.
+    - _Requirements: 9.2, 9.4_
+  - [ ] 5.6 Drag handle can be hidden
+    - **Preconditions:** Open a modal sheet with `showDragHandle: false`.
+    - **Steps:**
+      1. Confirm no handle is rendered.
+    - **Expected:** No drag handle; the sheet still opens/closes via scrim/Escape/controls.
+    - _Requirements: 9.3_
+
+- [ ] 6. Side sheet — modal and standard
+  - [ ] 6.1 Modal side sheet anatomy
+    - **Preconditions:** Demo open at "Side sheet"; click "Modal side sheet".
+    - **Steps:**
+      1. Inspect the surface — edge, width, corner shape, elevation, header (title + close), actions.
+    - **Expected:** Slides in from the end edge; 256–400dp wide; 16dp corners on the inner edge;
+      surface-container-low + elevation; header with title + close affordance; actions region.
+    - _Requirements: 10.1, 10.4, 13.1_
+  - [ ] 6.2 Close affordance and Escape dismiss (modal)
+    - **Preconditions:** Modal side sheet open.
+    - **Steps:**
+      1. Click the header ✕. 2. Reopen and press Escape. 3. Reopen and click "Apply".
+    - **Expected:** ✕ and Escape close with a dismissal; "Apply" emits a confirm result ("applied").
+    - _Requirements: 10.5, 10.6_
+  - [ ] 6.3 Side-sheet content scrolls within the sheet
+    - **Preconditions:** Modal side sheet with overflowing content.
+    - **Steps:**
+      1. Scroll inside the sheet body.
+    - **Expected:** The content region scrolls within the sheet; the header/actions stay in place.
+    - _Requirements: 10.6_
+  - [ ] 6.4 Standard side sheet coexists with the page
+    - **Preconditions:** Demo open; click "Toggle standard side sheet".
+    - **Steps:**
+      1. With it open, interact with the page beside it. 2. Confirm there is no scrim.
+      3. Close via the header ✕ / toggle button.
+    - **Expected:** No scrim; the page beside it stays interactive; closes via the close affordance/toggle.
+    - _Requirements: 10.3_
+
+- [ ] 7. Shared modal overlay behavior (APG Dialog)
+  - [ ] 7.1 Scrim dims and blocks the content behind every modal surface
+    - **Preconditions:** Demo open.
+    - **Steps:**
+      1. Open in turn: basic dialog, full-screen dialog, modal bottom sheet, modal side sheet.
+      2. For each, try to click a button on the page behind the scrim.
+    - **Expected:** Each shows a scrim at ~32% scrim color; clicks on the page behind are blocked.
+    - _Requirements: 12.1_
+  - [ ] 7.2 Focus moves in and is trapped
+    - **Preconditions:** Any modal surface.
+    - **Steps:**
+      1. Open it. 2. Press Tab repeatedly past the last focusable element; Shift+Tab past the first.
+    - **Expected:** Focus moves into the surface on open and cycles **within** it — Tab never lands on
+      page content behind the scrim.
+    - _Requirements: 12.2, 14.1, 14.3_
+  - [ ] 7.3 Focus restores to the opener on close
+    - **Preconditions:** Focus a known opener button, then open a modal from it.
+    - **Steps:**
+      1. Open, then close via Escape / scrim / an action.
+    - **Expected:** After close, focus returns to the exact opener element.
+    - _Requirements: 12.3_
+  - [ ] 7.4 Escape and scrim-click dismiss
+    - **Preconditions:** Any dismissible modal surface.
+    - **Steps:**
+      1. Press Escape. 2. Reopen and click the scrim outside the surface.
+    - **Expected:** Both close the surface and emit a dismissal result.
+    - _Requirements: 12.4, 12.5_
+  - [ ] 7.5 Non-dismissible surface ignores Escape and scrim-click
+    - **Preconditions:** Open a dialog with `disableClose: true` (adjust the demo config).
+    - **Steps:**
+      1. Press Escape. 2. Click the scrim.
+    - **Expected:** The surface stays open in both cases; it closes only via an explicit action control.
+    - _Requirements: 12.4, 12.5_
+  - [ ] 7.6 Scroll lock while open, restored on close
+    - **Preconditions:** A page tall enough to scroll behind the modal.
+    - **Steps:**
+      1. Note the page scroll position. 2. Open a modal and try to scroll the page (wheel/trackpad).
+      3. Close it and scroll again.
+    - **Expected:** The page behind cannot scroll while the modal is open; normal scrolling resumes
+      (at the prior position) after close.
+    - _Requirements: 12.6_
+  - [ ] 7.7 Dialog semantics + accessible name
+    - **Preconditions:** Screen reader on.
+    - **Steps:**
+      1. Open each modal surface and listen to how it is announced.
+    - **Expected:** Announced as a modal dialog (role=dialog, aria-modal=true) with an accessible name
+      from its headline/title (or aria-label).
+    - _Requirements: 12.7, 14.1_
+  - [ ] 7.8 Stacked modals: Escape + focus target the top-most
+    - **Preconditions:** Open one modal, then open a second from within it (e.g. a dialog that opens a sheet).
+    - **Steps:**
+      1. Press Escape once. 2. Observe which surface closes and where focus lands. 3. Press Escape again.
+    - **Expected:** Escape closes only the top-most surface; focus trapping applies to the top-most; on
+      close focus returns to the surface beneath; closing unwinds in reverse order.
+    - _Requirements: 12.8_
+
+- [ ] 8. Carousel — layouts and sizing
+  - [ ] 8.1 Multi-browse sizes items into large/medium/small with a peek
+    - **Preconditions:** Demo open at "Carousel"; "multi-browse" selected.
+    - **Steps:**
+      1. Inspect the rendered item widths across the row.
+      2. Scroll the carousel and watch the items morph between sizes.
+    - **Expected:** A large focal item, then medium/small keylines (non-focal capped at two), with the
+      smallest item peeking at the trailing edge; sizes morph as you scroll; small items stay within 40–56dp.
+    - _Requirements: 11.1, 11.2, 11.3_
+  - [ ] 8.2 Uncontained uses uniform items with a cut-off trailing item
+    - **Preconditions:** "uncontained" selected.
+    - **Steps:**
+      1. Inspect item widths; confirm the last visible item is partially cut off.
+    - **Expected:** Uniform item widths; the trailing item is resized/cut at the edge; scrolls past the edge.
+    - _Requirements: 11.2_
+  - [ ] 8.3 Hero shows one large focal item plus a peek
+    - **Preconditions:** "hero" selected.
+    - **Steps:**
+      1. Inspect the layout.
+    - **Expected:** One large focal item fills most of the width with a small peek of the next item.
+    - _Requirements: 11.2, 11.3_
+  - [ ] 8.4 Full-screen: one item fills the viewport; vertical on compact
+    - **Preconditions:** "full-screen" selected.
+    - **Steps:**
+      1. On a wide viewport, confirm one item fills the carousel width and scrolls horizontally.
+      2. Narrow the window below 600px and confirm orientation.
+    - **Expected:** One item fills the viewport; on a compact window the carousel scrolls **vertically**.
+    - _Requirements: 11.1, 11.6_
+  - [ ] 8.5 Items clip to the 28dp corner shape
+    - **Preconditions:** Any layout.
+    - **Steps:**
+      1. Inspect a carousel item's corner radius and content clipping.
+    - **Expected:** Each item clips its content to the extra-large (28dp) corner shape.
+    - _Requirements: 11.4, 13.1_
+  - [ ] 8.6 Resize re-fits without disallowed partial items
+    - **Preconditions:** Multi-browse selected.
+    - **Steps:**
+      1. Slowly drag the window/viewport width from wide to narrow and back.
+    - **Expected:** Items re-fit continuously per the layout; no partially-cut items appear in positions
+      the layout disallows; no layout jump/flicker beyond the resize.
+    - _Requirements: 11.5_
+
+- [ ] 9. Tokens, theming, and motion
+  - [ ] 9.1 Light/dark switch updates every component via tokens
+    - **Preconditions:** Demo open with all containment sections visible.
+    - **Steps:**
+      1. Toggle the OS (or app) theme between light and dark.
+      2. Optionally switch contrast level.
+    - **Expected:** Cards, dividers, lists, dialog/sheet surfaces, and carousel items all recolor purely
+      from `--md-sys-*` tokens — no element keeps a stale/hard-coded color.
+    - _Requirements: 13.1, 13.2, 13.3_
+  - [ ] 9.2 Transitions use M3 motion; reduced-motion removes them
+    - **Preconditions:** Reduced motion **off**, then **on** (OS Accessibility setting).
+    - **Steps:**
+      1. With motion on, open a dialog, a bottom sheet, a side sheet — watch the enter animation; scroll the carousel.
+      2. Enable reduced motion and repeat.
+    - **Expected:** With motion on, surfaces animate in with M3 easing/duration and the carousel morphs on
+      scroll. With reduced motion on, enter/scroll animations are removed/minimized but open/close and
+      scroll **state** still work; items render at their arranged sizes.
+    - _Requirements: 15.1, 15.2, 15.3_
+
+- [ ] 10. Accessibility sweep (keyboard + screen reader)
+  - [ ] 10.1 Full keyboard-only operation
+    - **Preconditions:** Mouse unplugged / not used; demo open.
+    - **Steps:**
+      1. Using only the keyboard, operate: clickable card, listbox selection, open/close every dialog and
+         sheet, switch carousel layouts.
+    - **Expected:** Every interactive containment surface is reachable and operable by keyboard alone.
+    - _Requirements: 14.3_
+  - [ ] 10.2 Visible focus indicator everywhere
+    - **Preconditions:** Keyboard navigation.
+    - **Steps:**
+      1. Tab through every focusable containment surface and watch the focus ring.
+    - **Expected:** A visible focus indicator appears on each focusable surface, meeting WCAG 2.2 AA
+      focus-appearance / non-text-contrast.
+    - _Requirements: 14.4_
+  - [ ] 10.3 Screen-reader semantics
+    - **Preconditions:** Screen reader on.
+    - **Steps:**
+      1. Navigate cards (plain vs actionable), the listbox, dividers, and each modal surface.
+    - **Expected:** Actionable cards = buttons; plain cards = no control role; listbox/options with
+      selected state; dividers = separators; modals = dialog (modal) with a name; nothing conveys state
+      by color alone.
+    - _Requirements: 14.1, 14.2, 14.5_
+
+- [ ] 11. Packaging, SSR, and zoneless
+  - [ ] 11.1 Each family imports from its own entry point
+    - **Preconditions:** Source/editor available.
+    - **Steps:**
+      1. Confirm the demo imports from `@ngguide/ui/{card,divider,list,dialog,bottom-sheet,side-sheet,carousel}`.
+      2. Build the library: `NX_NO_CLOUD=true pnpm exec nx build ui`.
+    - **Expected:** Each family resolves as its own secondary entry point and the library builds with all
+      seven entry points emitted.
+    - _Requirements: 16.1_
+  - [ ] 11.2 Imperative open returns a handle/result
+    - **Preconditions:** Demo open.
+    - **Steps:**
+      1. Trigger the imperative full-screen dialog and the modal sheets (service `open()` calls).
+    - **Expected:** Each `open()` returns a ref whose `closed` emits the result; closing programmatically works.
+    - _Requirements: 16.2_
+  - [ ] 11.3 SSR renders without errors and hydrates without layout shift
+    - **Preconditions:** `NX_NO_CLOUD=true pnpm exec nx build web` (prerenders one route).
+    - **Steps:**
+      1. Inspect the prerendered HTML for the containment sections (cards, list, carousel items).
+      2. Serve the build and load it; watch for hydration errors in the console and visible reflow.
+    - **Expected:** Server HTML renders the static surfaces (carousel items at the large fallback width);
+      no console errors; no visible layout shift on hydration; the app runs zoneless (no zone.js).
+    - _Requirements: 16.3, 16.4_
+
+## Summary
+- Total: 52 tests
+- Passed: 0
+- Failed: 0
+- Skipped: 0

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1000,6 +1000,48 @@
       </div>
     </div>
 
+    <!-- Containment — List -->
+    <div class="flex flex-col gap-4 mt-8">
+      <h2 class="text-lg font-medium">List</h2>
+
+      <!-- (a) Action list: 1/2/3 lines, leading icon / trailing text -->
+      <gui-card variant="outlined" class="w-96">
+        <gui-list mode="action">
+          <gui-list-item [lines]="1">
+            <gui-icon guiListItemLeading>★</gui-icon>
+            Single-line item
+            <span guiListItemTrailing>now</span>
+          </gui-list-item>
+          <gui-divider inset="inset" />
+          <gui-list-item [lines]="2">
+            <gui-icon guiListItemLeading>☆</gui-icon>
+            Two-line item
+            <span guiListItemSupporting>With supporting text</span>
+            <span guiListItemTrailing>5m</span>
+          </gui-list-item>
+          <gui-divider inset="inset" />
+          <gui-list-item [lines]="3">
+            <gui-icon guiListItemLeading>✶</gui-icon>
+            Three-line item
+            <span guiListItemSupporting
+              >A longer supporting description spanning the available width of the
+              row.</span
+            >
+            <span guiListItemTrailing>1h</span>
+          </gui-list-item>
+        </gui-list>
+      </gui-card>
+
+      <!-- (b) Selectable listbox (arrow keys + Enter/Space/click) -->
+      <gui-card variant="outlined" class="w-96">
+        <gui-list mode="listbox" [multiselectable]="true">
+          @for (fruit of fruits; track fruit) {
+            <gui-list-item selectable>{{ fruit }}</gui-list-item>
+          }
+        </gui-list>
+      </gui-card>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -927,6 +927,79 @@
       <div class="ml-4 text-sm text-gray-600">Plain (hover/focus), rich</div>
     </div>
 
+    <!-- Containment — Card + Divider -->
+    <div class="flex flex-col gap-4 mt-8">
+      <h2 class="text-lg font-medium">Card &amp; Divider</h2>
+
+      <!-- (a) Three card variants -->
+      <div class="flex flex-row gap-4 items-stretch">
+        @for (variant of cardVariants; track variant) {
+          <gui-card [variant]="variant" class="p-4 w-48 gap-1">
+            <span class="font-medium capitalize">{{ variant }}</span>
+            <span class="text-sm text-gray-600">M3 {{ variant }} card</span>
+          </gui-card>
+        }
+      </div>
+
+      <!-- (b) Whole-surface clickable card -->
+      <gui-card
+        variant="elevated"
+        guiCardClickable
+        class="p-4 w-72 gap-1"
+        (cardActivate)="lastCardAction.set('clickable card')"
+      >
+        <span class="font-medium">Clickable card</span>
+        <span class="text-sm text-gray-600"
+          >Whole surface is one button (Enter / Space / click)</span
+        >
+      </gui-card>
+
+      <!-- (c) Primary-action region + independent action buttons -->
+      <gui-card variant="outlined" class="w-72">
+        <div
+          guiCardPrimaryAction
+          class="p-4 flex flex-col gap-1"
+          (primaryAction)="lastCardAction.set('primary action')"
+        >
+          <span class="font-medium">Primary-action card</span>
+          <span class="text-sm text-gray-600">Tap the body to open</span>
+        </div>
+        <gui-divider />
+        <div class="p-2 flex flex-row gap-2 justify-end">
+          <button
+            gui-button
+            variant="text"
+            type="button"
+            (click)="lastCardAction.set('share')"
+          >
+            Share
+          </button>
+          <button
+            gui-button
+            variant="text"
+            type="button"
+            (click)="lastCardAction.set('save')"
+          >
+            Save
+          </button>
+        </div>
+      </gui-card>
+
+      <div class="text-sm text-gray-600">
+        Last card action: {{ lastCardAction() }}
+      </div>
+
+      <!-- (d) Divider insets -->
+      <div class="flex flex-col gap-2 w-72">
+        <span class="text-sm">none</span>
+        <gui-divider inset="none" />
+        <span class="text-sm">inset</span>
+        <gui-divider inset="inset" />
+        <span class="text-sm">middle-inset</span>
+        <gui-divider inset="middle-inset" />
+      </div>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1221,13 +1221,13 @@
             <gui-icon>✕</gui-icon>
           </button>
         </gui-side-sheet-header>
-        <div class="px-4 flex-1">
+        <gui-side-sheet-content>
           <gui-list mode="listbox" [multiselectable]="true">
             <gui-list-item selectable>Unread</gui-list-item>
             <gui-list-item selectable>Starred</gui-list-item>
             <gui-list-item selectable>Attachments</gui-list-item>
           </gui-list>
-        </div>
+        </gui-side-sheet-content>
         <gui-side-sheet-actions>
           <button gui-button variant="text" type="button" (click)="ref.close()">
             Cancel
@@ -1258,10 +1258,10 @@
             <gui-icon>✕</gui-icon>
           </button>
         </gui-side-sheet-header>
-        <div class="px-4 flex-1 text-sm text-gray-600">
+        <gui-side-sheet-content class="text-sm text-gray-600">
           A standard side sheet has no scrim — the page behind stays
           interactive.
-        </div>
+        </gui-side-sheet-content>
       </gui-side-sheet>
     </div>
 

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1042,6 +1042,84 @@
       </gui-card>
     </div>
 
+    <!-- Containment — Dialog -->
+    <div class="flex flex-col gap-4 mt-8">
+      <h2 class="text-lg font-medium">Dialog</h2>
+
+      <div class="flex flex-row gap-2 items-center">
+        <!-- (a) Basic dialog via declarative trigger -->
+        <button
+          gui-button
+          variant="filled"
+          type="button"
+          [guiDialogTrigger]="basicDialog"
+          [guiDialogConfig]="{ ariaLabelledBy: 'reset-headline' }"
+        >
+          Basic dialog
+        </button>
+
+        <!-- (b) Full-screen dialog via imperative open() -->
+        <button
+          gui-button
+          variant="outlined"
+          type="button"
+          (click)="dialog.open(fullScreenDialog, { fullScreen: 'always', ariaLabelledBy: 'edit-title' })"
+        >
+          Full-screen dialog
+        </button>
+      </div>
+
+      <ng-template #basicDialog let-ref="dialogRef">
+        <gui-dialog-icon>⚠️</gui-dialog-icon>
+        <gui-dialog-headline id="reset-headline">Reset settings?</gui-dialog-headline>
+        <gui-dialog-content>
+          This will restore all settings to their default values. You can't undo
+          this action.
+        </gui-dialog-content>
+        <gui-dialog-actions>
+          <button gui-button variant="text" type="button" (click)="ref.close()">
+            Cancel
+          </button>
+          <button
+            gui-button
+            variant="text"
+            type="button"
+            (click)="ref.close('reset')"
+          >
+            Reset
+          </button>
+        </gui-dialog-actions>
+      </ng-template>
+
+      <ng-template #fullScreenDialog let-ref="dialogRef">
+        <gui-dialog-fullscreen-header>
+          <button
+            gui-icon-button
+            variant="standard"
+            guiDialogClose
+            aria-label="Close"
+            type="button"
+            (click)="ref.close()"
+          >
+            <gui-icon>✕</gui-icon>
+          </button>
+          <span id="edit-title">Edit profile</span>
+          <button
+            gui-button
+            variant="text"
+            guiDialogConfirm
+            type="button"
+            (click)="ref.close('saved')"
+          >
+            Save
+          </button>
+        </gui-dialog-fullscreen-header>
+        <gui-dialog-content>
+          <p class="py-4">Full-screen dialogs fill the window on compact layouts.</p>
+        </gui-dialog-content>
+      </ng-template>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1265,6 +1265,40 @@
       </gui-side-sheet>
     </div>
 
+    <!-- Containment — Carousel -->
+    <div class="flex flex-col gap-4 mt-8" style="max-width: 480px">
+      <h2 class="text-lg font-medium">Carousel</h2>
+
+      <div class="flex flex-row gap-2 items-center flex-wrap">
+        @for (l of carouselLayouts; track l) {
+          <button
+            gui-button
+            size="sm"
+            [variant]="carouselLayout() === l ? 'filled' : 'outlined'"
+            type="button"
+            (click)="carouselLayout.set(l)"
+          >
+            {{ l }}
+          </button>
+        }
+      </div>
+
+      <gui-carousel [layout]="carouselLayout()">
+        @for (n of carouselItems; track n) {
+          <gui-carousel-item>
+            <div
+              class="h-40 flex items-center justify-center text-2xl font-medium text-white"
+              [style.background]="
+                'oklch(60% 0.15 ' + n * 40 + 'deg)'
+              "
+            >
+              {{ n }}
+            </div>
+          </gui-carousel-item>
+        }
+      </gui-carousel>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1184,6 +1184,87 @@
       </gui-bottom-sheet>
     </div>
 
+    <!-- Containment — Side sheet -->
+    <div class="flex flex-col gap-4 mt-8">
+      <h2 class="text-lg font-medium">Side sheet</h2>
+
+      <div class="flex flex-row gap-2 items-center">
+        <button
+          gui-button
+          variant="filled"
+          type="button"
+          (click)="sideSheet.open(modalSideSheet, { ariaLabel: 'Filters' })"
+        >
+          Modal side sheet
+        </button>
+        <button
+          gui-button
+          variant="outlined"
+          type="button"
+          (click)="standardSideSheetOpen.set(!standardSideSheetOpen())"
+        >
+          Toggle standard side sheet
+        </button>
+      </div>
+
+      <ng-template #modalSideSheet let-ref="dialogRef">
+        <gui-side-sheet-header>
+          Filters
+          <button
+            gui-icon-button
+            variant="standard"
+            guiSideSheetClose
+            aria-label="Close"
+            type="button"
+            (click)="ref.close()"
+          >
+            <gui-icon>✕</gui-icon>
+          </button>
+        </gui-side-sheet-header>
+        <div class="px-4 flex-1">
+          <gui-list mode="listbox" [multiselectable]="true">
+            <gui-list-item selectable>Unread</gui-list-item>
+            <gui-list-item selectable>Starred</gui-list-item>
+            <gui-list-item selectable>Attachments</gui-list-item>
+          </gui-list>
+        </div>
+        <gui-side-sheet-actions>
+          <button gui-button variant="text" type="button" (click)="ref.close()">
+            Cancel
+          </button>
+          <button
+            gui-button
+            variant="filled"
+            type="button"
+            (click)="ref.close('applied')"
+          >
+            Apply
+          </button>
+        </gui-side-sheet-actions>
+      </ng-template>
+
+      <!-- Standard side sheet coexists with the page (no scrim) -->
+      <gui-side-sheet [(open)]="standardSideSheetOpen">
+        <gui-side-sheet-header>
+          Details
+          <button
+            gui-icon-button
+            variant="standard"
+            guiSideSheetClose
+            aria-label="Close"
+            type="button"
+            (click)="standardSideSheetOpen.set(false)"
+          >
+            <gui-icon>✕</gui-icon>
+          </button>
+        </gui-side-sheet-header>
+        <div class="px-4 flex-1 text-sm text-gray-600">
+          A standard side sheet has no scrim — the page behind stays
+          interactive.
+        </div>
+      </gui-side-sheet>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1120,6 +1120,70 @@
       </ng-template>
     </div>
 
+    <!-- Containment — Bottom sheet -->
+    <div class="flex flex-col gap-4 mt-8">
+      <h2 class="text-lg font-medium">Bottom sheet</h2>
+
+      <div class="flex flex-row gap-2 items-center">
+        <button
+          gui-button
+          variant="filled"
+          type="button"
+          (click)="bottomSheet.open(modalSheet, { ariaLabel: 'Share' })"
+        >
+          Modal sheet (drag to dismiss)
+        </button>
+        <button
+          gui-button
+          variant="outlined"
+          type="button"
+          (click)="standardSheetOpen.set(!standardSheetOpen())"
+        >
+          Toggle standard sheet
+        </button>
+      </div>
+
+      <ng-template #modalSheet let-ref="dialogRef">
+        <div class="p-4 flex flex-col gap-2">
+          <span class="font-medium">Share</span>
+          <gui-list mode="action">
+            <gui-list-item>Copy link</gui-list-item>
+            <gui-list-item>Email</gui-list-item>
+            <gui-list-item>Message</gui-list-item>
+          </gui-list>
+          <button
+            gui-button
+            variant="text"
+            type="button"
+            class="self-end"
+            (click)="ref.close()"
+          >
+            Close
+          </button>
+        </div>
+      </ng-template>
+
+      <!-- Standard sheet coexists with the page (no scrim) -->
+      <gui-bottom-sheet [(open)]="standardSheetOpen">
+        <div class="p-4 flex flex-col gap-2">
+          <span class="font-medium">Standard sheet</span>
+          <span class="text-sm text-gray-600"
+            >This sheet has no scrim — the page stays interactive. Drag the
+            handle down to dismiss.</span
+          >
+          <button
+            gui-button
+            variant="text"
+            type="button"
+            class="self-end"
+            (click)="standardSheetOpen.set(false)"
+          >
+            Close
+          </button>
+        </div>
+      </gui-bottom-sheet>
+    </div>
+
     <app-interaction-demo />
   </div>
 </div>

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -78,6 +78,7 @@ import { GuiBottomSheet, GuiBottomSheetSurface } from '@ngguide/ui/bottom-sheet'
 import {
   GuiSideSheet,
   GuiSideSheetActions,
+  GuiSideSheetContent,
   GuiSideSheetHeader,
   GuiSideSheetSurface,
 } from '@ngguide/ui/side-sheet';
@@ -143,6 +144,7 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiBottomSheetSurface,
     GuiSideSheetSurface,
     GuiSideSheetHeader,
+    GuiSideSheetContent,
     GuiSideSheetActions,
     GuiCarousel,
     GuiCarouselItem,

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -65,6 +65,15 @@ import {
 } from '@ngguide/ui/card';
 import { GuiDivider } from '@ngguide/ui/divider';
 import { GuiList, GuiListItem } from '@ngguide/ui/list';
+import {
+  GuiDialog,
+  GuiDialogActions,
+  GuiDialogContent,
+  GuiDialogFullscreenHeader,
+  GuiDialogHeadline,
+  GuiDialogIcon,
+  GuiDialogTrigger,
+} from '@ngguide/ui/dialog';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -113,6 +122,12 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiDivider,
     GuiList,
     GuiListItem,
+    GuiDialogTrigger,
+    GuiDialogIcon,
+    GuiDialogHeadline,
+    GuiDialogContent,
+    GuiDialogActions,
+    GuiDialogFullscreenHeader,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,
@@ -123,6 +138,8 @@ import { InteractionDemoComponent } from './interaction-demo.component';
 })
 export class AppComponent {
   private readonly theme = inject(M3ThemeService);
+  /** Dialog service used by the containment demo (imperative full-screen open). */
+  protected readonly dialog = inject(GuiDialog);
 
   /** Demo brand seeds to exercise runtime re-theming (Req 7.3). */
   readonly brandSeeds = ['#6750A4', '#00629D', '#B3261E'];

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -74,6 +74,7 @@ import {
   GuiDialogIcon,
   GuiDialogTrigger,
 } from '@ngguide/ui/dialog';
+import { GuiBottomSheet, GuiBottomSheetSurface } from '@ngguide/ui/bottom-sheet';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -128,6 +129,7 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiDialogContent,
     GuiDialogActions,
     GuiDialogFullscreenHeader,
+    GuiBottomSheetSurface,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,
@@ -140,6 +142,10 @@ export class AppComponent {
   private readonly theme = inject(M3ThemeService);
   /** Dialog service used by the containment demo (imperative full-screen open). */
   protected readonly dialog = inject(GuiDialog);
+  /** Bottom-sheet service used by the containment demo (modal open). */
+  protected readonly bottomSheet = inject(GuiBottomSheet);
+  /** Standard (non-modal) bottom-sheet open state. */
+  readonly standardSheetOpen = signal(false);
 
   /** Demo brand seeds to exercise runtime re-theming (Req 7.3). */
   readonly brandSeeds = ['#6750A4', '#00629D', '#B3261E'];

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -75,6 +75,12 @@ import {
   GuiDialogTrigger,
 } from '@ngguide/ui/dialog';
 import { GuiBottomSheet, GuiBottomSheetSurface } from '@ngguide/ui/bottom-sheet';
+import {
+  GuiSideSheet,
+  GuiSideSheetActions,
+  GuiSideSheetHeader,
+  GuiSideSheetSurface,
+} from '@ngguide/ui/side-sheet';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -130,6 +136,9 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiDialogActions,
     GuiDialogFullscreenHeader,
     GuiBottomSheetSurface,
+    GuiSideSheetSurface,
+    GuiSideSheetHeader,
+    GuiSideSheetActions,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,
@@ -146,6 +155,10 @@ export class AppComponent {
   protected readonly bottomSheet = inject(GuiBottomSheet);
   /** Standard (non-modal) bottom-sheet open state. */
   readonly standardSheetOpen = signal(false);
+  /** Side-sheet service used by the containment demo (modal open). */
+  protected readonly sideSheet = inject(GuiSideSheet);
+  /** Standard (non-modal) side-sheet open state. */
+  readonly standardSideSheetOpen = signal(false);
 
   /** Demo brand seeds to exercise runtime re-theming (Req 7.3). */
   readonly brandSeeds = ['#6750A4', '#00629D', '#B3261E'];

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -64,6 +64,7 @@ import {
   GuiCardPrimaryAction,
 } from '@ngguide/ui/card';
 import { GuiDivider } from '@ngguide/ui/divider';
+import { GuiList, GuiListItem } from '@ngguide/ui/list';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -110,6 +111,8 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiCardClickable,
     GuiCardPrimaryAction,
     GuiDivider,
+    GuiList,
+    GuiListItem,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,
@@ -127,6 +130,7 @@ export class AppComponent {
   /** Containment demo: last card interaction, for visible feedback. */
   readonly lastCardAction = signal('none');
   readonly cardVariants = ['elevated', 'filled', 'outlined'] as const;
+  readonly fruits = ['Apple', 'Banana', 'Cherry', 'Date'];
 
   /** Re-theme the running app from a brand seed color. */
   applyBrand(seed: string): void {

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -58,6 +58,12 @@ import {
   GuiRichTooltipTrigger,
   GuiTooltip,
 } from '@ngguide/ui/tooltip';
+import {
+  GuiCard,
+  GuiCardClickable,
+  GuiCardPrimaryAction,
+} from '@ngguide/ui/card';
+import { GuiDivider } from '@ngguide/ui/divider';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -100,6 +106,10 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiTooltip,
     GuiRichTooltip,
     GuiRichTooltipTrigger,
+    GuiCard,
+    GuiCardClickable,
+    GuiCardPrimaryAction,
+    GuiDivider,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,
@@ -113,6 +123,10 @@ export class AppComponent {
 
   /** Demo brand seeds to exercise runtime re-theming (Req 7.3). */
   readonly brandSeeds = ['#6750A4', '#00629D', '#B3261E'];
+
+  /** Containment demo: last card interaction, for visible feedback. */
+  readonly lastCardAction = signal('none');
+  readonly cardVariants = ['elevated', 'filled', 'outlined'] as const;
 
   /** Re-theme the running app from a brand seed color. */
   applyBrand(seed: string): void {

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -81,6 +81,11 @@ import {
   GuiSideSheetHeader,
   GuiSideSheetSurface,
 } from '@ngguide/ui/side-sheet';
+import {
+  GuiCarousel,
+  GuiCarouselItem,
+  GuiCarouselLayout,
+} from '@ngguide/ui/carousel';
 import { InteractionDemoComponent } from './interaction-demo.component';
 
 @Component({
@@ -139,6 +144,8 @@ import { InteractionDemoComponent } from './interaction-demo.component';
     GuiSideSheetSurface,
     GuiSideSheetHeader,
     GuiSideSheetActions,
+    GuiCarousel,
+    GuiCarouselItem,
     ReactiveFormsModule,
     FormsModule,
     InteractionDemoComponent,
@@ -159,6 +166,15 @@ export class AppComponent {
   protected readonly sideSheet = inject(GuiSideSheet);
   /** Standard (non-modal) side-sheet open state. */
   readonly standardSideSheetOpen = signal(false);
+  /** Carousel demo layout switcher. */
+  readonly carouselLayouts = [
+    'multi-browse',
+    'uncontained',
+    'hero',
+    'full-screen',
+  ] as const satisfies readonly GuiCarouselLayout[];
+  readonly carouselLayout = signal<GuiCarouselLayout>('multi-browse');
+  readonly carouselItems = [1, 2, 3, 4, 5, 6, 7, 8];
 
   /** Demo brand seeds to exercise runtime re-theming (Req 7.3). */
   readonly brandSeeds = ['#6750A4', '#00629D', '#B3261E'];

--- a/libs/ui/bottom-sheet/ng-package.json
+++ b/libs/ui/bottom-sheet/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/bottom-sheet/src/bottom-sheet-config.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet-config.ts
@@ -1,0 +1,15 @@
+import { GuiModalConfigBase } from '@ngguide/ui/overlay';
+
+export interface GuiBottomSheetConfig<D = unknown>
+  extends GuiModalConfigBase<D> {
+  /** Show the M3 drag handle (32×4dp) at the top of the sheet. Default `true`. */
+  showDragHandle?: boolean;
+  /** Raise the bottom offset to clear a docked FAB. Default `false`. */
+  aboveFab?: boolean;
+  /** Downward drag distance (px) past which the sheet dismisses. Default 96. */
+  dismissThreshold?: number;
+  /** Max width on larger screens (full-width on compact). Default `640px`. */
+  maxWidth?: string;
+}
+
+export { GUI_DIALOG_DATA, type GuiDialogRef } from '@ngguide/ui/overlay';

--- a/libs/ui/bottom-sheet/src/bottom-sheet-container.css
+++ b/libs/ui/bottom-sheet/src/bottom-sheet-container.css
@@ -1,0 +1,59 @@
+/* M3 modal bottom sheet. The host fills the bottom-anchored overlay pane; the
+   inner surface carries the chrome and is the draggable element. */
+
+:host {
+  display: block;
+  width: 100%;
+  outline: none;
+}
+
+.gui-bottom-sheet-surface {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: 100%;
+  /* Initial height capped at ~50% of the viewport with internal scroll. */
+  max-height: 50dvh;
+  background-color: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  border-start-start-radius: var(--md-sys-shape-corner-extra-large);
+  border-start-end-radius: var(--md-sys-shape-corner-extra-large);
+  box-shadow: var(--md-sys-elevation-level1);
+  animation: gui-bottom-sheet-enter var(--md-sys-motion-duration-medium4)
+    var(--md-sys-motion-easing-emphasized-decelerate);
+}
+
+@keyframes gui-bottom-sheet-enter {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+:host(.gui-no-motion) .gui-bottom-sheet-surface {
+  animation: none;
+}
+
+/* --- Drag handle: 32×4dp, on-surface-variant, centered (Req 9.1) --- */
+.gui-bottom-sheet-handle {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 32px;
+  height: 4px;
+  margin: 16px 0;
+  border-radius: var(--md-sys-shape-corner-full);
+  background-color: var(--md-sys-color-on-surface-variant);
+  cursor: grab;
+  touch-action: none;
+}
+.gui-bottom-sheet-handle:active {
+  cursor: grabbing;
+}
+
+/* --- Body scrolls independently below the handle --- */
+.gui-bottom-sheet-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}

--- a/libs/ui/bottom-sheet/src/bottom-sheet-container.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet-container.ts
@@ -1,0 +1,104 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CdkDialogContainer, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import { OverlayRef } from '@angular/cdk/overlay';
+import { CdkPortalOutlet } from '@angular/cdk/portal';
+import {
+  CdkDrag,
+  CdkDragEnd,
+  CdkDragHandle,
+  CdkDragMove,
+} from '@angular/cdk/drag-drop';
+import { GuiReducedMotion } from '@ngguide/ui/interaction';
+
+/** Config shape the service passes through; CDK preserves the extra fields. */
+export interface GuiBottomSheetContainerConfig extends DialogConfig {
+  guiShowDragHandle?: boolean;
+  guiDismissThreshold?: number;
+}
+
+/**
+ * M3 modal bottom-sheet surface. Extends CDK's {@link CdkDialogContainer}
+ * (focus trap, restore, `aria-modal`) and adds the M3 chrome —
+ * `surface-container-low`, `corner-extra-large` top corners (28dp),
+ * `elevation-level1` — plus the drag handle and drag-to-dismiss gesture
+ * (Req 9.1, 9.3). Dragging the handle past `dismissThreshold` closes the sheet
+ * with `'swipe'`; a shorter drag springs back (Req 9.4). The scrim fades with
+ * the drag distance. The slide-up enter animation is disabled under reduced
+ * motion (Req 15.2).
+ */
+@Component({
+  selector: 'gui-bottom-sheet-container',
+  changeDetection: ChangeDetectionStrategy.Default,
+  imports: [CdkPortalOutlet, CdkDrag, CdkDragHandle],
+  template: `
+    <div
+      class="gui-bottom-sheet-surface"
+      cdkDrag
+      cdkDragLockAxis="y"
+      (cdkDragMoved)="onDragMoved($event)"
+      (cdkDragEnded)="onDragEnded($event)"
+    >
+      @if (showDragHandle) {
+        <div class="gui-bottom-sheet-handle" cdkDragHandle aria-hidden="true"></div>
+      }
+      <div class="gui-bottom-sheet-body">
+        <ng-template cdkPortalOutlet />
+      </div>
+    </div>
+  `,
+  styleUrl: './bottom-sheet-container.css',
+  host: {
+    class: 'gui-bottom-sheet-container',
+    tabindex: '-1',
+    '[attr.id]': '_config.id || null',
+    '[attr.role]': '_config.role',
+    '[attr.aria-modal]': '_config.ariaModal',
+    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledByQueue[0]',
+    '[attr.aria-label]': '_config.ariaLabel',
+    '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
+    '[class.gui-no-motion]': 'reducedMotion.prefersReducedMotion()',
+  },
+})
+export class GuiBottomSheetContainer extends CdkDialogContainer {
+  protected readonly reducedMotion = inject(GuiReducedMotion);
+  private readonly dialogRef = inject<DialogRef>(DialogRef);
+  private readonly overlayRef = inject(OverlayRef);
+
+  protected get showDragHandle(): boolean {
+    return (
+      (this._config as GuiBottomSheetContainerConfig).guiShowDragHandle ?? true
+    );
+  }
+
+  private get dismissThreshold(): number {
+    return (
+      (this._config as GuiBottomSheetContainerConfig).guiDismissThreshold ?? 96
+    );
+  }
+
+  /** Fade the scrim proportionally to the downward drag distance (Req 9.3). */
+  protected onDragMoved(event: CdkDragMove): void {
+    const surface = event.source.element.nativeElement;
+    const distance = Math.max(0, event.distance.y);
+    const ratio = surface.offsetHeight
+      ? Math.min(1, distance / surface.offsetHeight)
+      : 0;
+    const backdrop = this.overlayRef.backdropElement;
+    if (backdrop) {
+      backdrop.style.opacity = `${1 - ratio}`;
+    }
+  }
+
+  /** Dismiss past the threshold; otherwise spring back to rest (Req 9.4). */
+  protected onDragEnded(event: CdkDragEnd): void {
+    if (event.distance.y > this.dismissThreshold) {
+      this.dialogRef.close('swipe');
+      return;
+    }
+    event.source.setFreeDragPosition({ x: 0, y: 0 });
+    const backdrop = this.overlayRef.backdropElement;
+    if (backdrop) {
+      backdrop.style.opacity = '';
+    }
+  }
+}

--- a/libs/ui/bottom-sheet/src/bottom-sheet.css
+++ b/libs/ui/bottom-sheet/src/bottom-sheet.css
@@ -1,0 +1,61 @@
+/* M3 standard (non-modal) bottom sheet. Fixed to the bottom edge; coexists with
+   page content (no scrim). Slides in/out on `open`. */
+
+:host {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 6;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.gui-bottom-sheet-surface {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 640px;
+  max-height: 50dvh;
+  pointer-events: auto;
+  background-color: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  border-start-start-radius: var(--md-sys-shape-corner-extra-large);
+  border-start-end-radius: var(--md-sys-shape-corner-extra-large);
+  box-shadow: var(--md-sys-elevation-level1);
+  transform: translateY(100%);
+  transition: transform var(--md-sys-motion-duration-medium4)
+    var(--md-sys-motion-easing-emphasized);
+}
+
+/* --- Open: slide into view (Req 9.2) --- */
+:host([data-open]) .gui-bottom-sheet-surface {
+  transform: translateY(0);
+}
+
+/* --- Reduced motion: no slide (Req 15.2) --- */
+:host(.gui-no-motion) .gui-bottom-sheet-surface {
+  transition: none;
+}
+
+/* --- Drag handle: 32×4dp, on-surface-variant, centered (Req 9.1) --- */
+.gui-bottom-sheet-handle {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 32px;
+  height: 4px;
+  margin: 16px 0;
+  border-radius: var(--md-sys-shape-corner-full);
+  background-color: var(--md-sys-color-on-surface-variant);
+  cursor: grab;
+  touch-action: none;
+}
+.gui-bottom-sheet-handle:active {
+  cursor: grabbing;
+}
+
+.gui-bottom-sheet-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}

--- a/libs/ui/bottom-sheet/src/bottom-sheet.service.spec.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet.service.spec.ts
@@ -1,0 +1,54 @@
+import { ApplicationRef, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiBottomSheet } from './bottom-sheet.service';
+
+@Component({ template: `<button type="button">action</button>` })
+class SheetContent {}
+
+function flush(): void {
+  TestBed.inject(ApplicationRef).tick();
+}
+
+describe('GuiBottomSheet (modal)', () => {
+  it('opens a bottom-anchored modal with scrim, role and handle (Req 9.1, 12.1)', () => {
+    const ref = TestBed.inject(GuiBottomSheet).open(SheetContent, {
+      ariaLabel: 'Sheet',
+    });
+    flush();
+    const container = document.querySelector('.gui-bottom-sheet-container');
+    expect(container?.getAttribute('role')).toBe('dialog');
+    expect(container?.getAttribute('aria-modal')).toBe('true');
+    expect(document.querySelector('.cdk-overlay-backdrop.gui-scrim')).not.toBeNull();
+    expect(document.querySelector('.gui-bottom-sheet-handle')).not.toBeNull();
+    ref.close();
+    flush();
+  });
+
+  it('hides the drag handle when showDragHandle is false (Req 9.1)', () => {
+    const ref = TestBed.inject(GuiBottomSheet).open(SheetContent, {
+      ariaLabel: 'Sheet',
+      showDragHandle: false,
+    });
+    flush();
+    expect(document.querySelector('.gui-bottom-sheet-handle')).toBeNull();
+    ref.close();
+    flush();
+  });
+
+  it('close(result) emits on closed (Req 16.2)', () => {
+    const ref = TestBed.inject(GuiBottomSheet).open<string>(SheetContent);
+    let result: string | undefined;
+    ref.closed.subscribe((r) => (result = r));
+    flush();
+    ref.close('done');
+    flush();
+    expect(result).toBe('done');
+    expect(document.querySelector('.gui-bottom-sheet-container')).toBeNull();
+  });
+
+  it('throws when opened without content', () => {
+    expect(() =>
+      TestBed.inject(GuiBottomSheet).open(null as never),
+    ).toThrowError(/component type or a TemplateRef/);
+  });
+});

--- a/libs/ui/bottom-sheet/src/bottom-sheet.service.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, TemplateRef, inject } from '@angular/core';
+import { ComponentType, Overlay } from '@angular/cdk/overlay';
+import { Dialog, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import {
+  GuiBreakpoint,
+  GuiDialogRef,
+  asArray,
+  normalizeModalConfig,
+  wrapDialogRef,
+} from '@ngguide/ui/overlay';
+import { GuiBottomSheetConfig } from './bottom-sheet-config';
+import { GuiBottomSheetContainer } from './bottom-sheet-container';
+
+/**
+ * Opens M3 **modal** bottom sheets over the headless CDK `Dialog` service: a
+ * bottom-anchored surface with a scrim, focus trap, focus restore and a
+ * drag-to-dismiss handle (Req 9.1, 12). Returns a {@link GuiDialogRef} whose
+ * `closed` emits the result (`'swipe'` when dismissed by drag). For a
+ * non-modal sheet that coexists with the page, use the standard
+ * `<gui-bottom-sheet variant="standard">` surface instead (Req 9.2).
+ */
+@Injectable({ providedIn: 'root' })
+export class GuiBottomSheet {
+  private readonly cdkDialog = inject(Dialog);
+  private readonly overlay = inject(Overlay);
+  private readonly breakpoint = inject(GuiBreakpoint);
+
+  open<R = unknown, D = unknown, C = unknown>(
+    content: ComponentType<C> | TemplateRef<C>,
+    config?: GuiBottomSheetConfig<D>,
+  ): GuiDialogRef<R> {
+    if (content == null) {
+      throw new Error(
+        'GuiBottomSheet.open() requires a component type or a TemplateRef.',
+      );
+    }
+
+    const maxWidth = this.breakpoint.isCompact()
+      ? '100%'
+      : config?.maxWidth ?? '640px';
+
+    const cdkConfig: DialogConfig<D, DialogRef<R, C>> & {
+      guiShowDragHandle?: boolean;
+      guiDismissThreshold?: number;
+    } = {
+      ...normalizeModalConfig<D>(config),
+      container: GuiBottomSheetContainer,
+      positionStrategy: this.overlay
+        .position()
+        .global()
+        .centerHorizontally()
+        .bottom('0'),
+      width: '100%',
+      maxWidth,
+      panelClass: ['gui-bottom-sheet-pane', ...asArray(config?.panelClass)],
+      guiShowDragHandle: config?.showDragHandle ?? true,
+      guiDismissThreshold: config?.dismissThreshold ?? 96,
+    };
+
+    const ref = this.cdkDialog.open<R, D, C>(content, cdkConfig);
+    return wrapDialogRef(ref);
+  }
+}

--- a/libs/ui/bottom-sheet/src/bottom-sheet.spec.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet.spec.ts
@@ -1,0 +1,69 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { CdkDragEnd } from '@angular/cdk/drag-drop';
+import { GuiBottomSheetSurface } from './bottom-sheet';
+
+@Component({
+  imports: [GuiBottomSheetSurface],
+  template: `
+    <gui-bottom-sheet [(open)]="open">
+      <p class="sheet-body">Standard sheet</p>
+    </gui-bottom-sheet>
+  `,
+})
+class StandardHost {
+  readonly open = signal(true);
+}
+
+/** Build a minimal CdkDragEnd with the given downward distance. */
+function dragEnd(distanceY: number): CdkDragEnd {
+  const reset = (): void => undefined;
+  return {
+    distance: { x: 0, y: distanceY },
+    source: { setFreeDragPosition: reset },
+  } as unknown as CdkDragEnd;
+}
+
+describe('GuiBottomSheetSurface (standard)', () => {
+  it('renders inline with no scrim, leaving the page interactive (Req 9.2)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.detectChanges();
+    expect(document.querySelector('.cdk-overlay-backdrop')).toBeNull();
+    const host = fixture.nativeElement.querySelector('gui-bottom-sheet');
+    expect(host.hasAttribute('data-open')).toBe(true);
+    expect(host.querySelector('.sheet-body')?.textContent).toContain(
+      'Standard sheet',
+    );
+  });
+
+  it('reflects the open model onto data-open + aria-hidden (Req 9.2)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.componentInstance.open.set(false);
+    fixture.detectChanges();
+    const host = fixture.nativeElement.querySelector('gui-bottom-sheet');
+    expect(host.hasAttribute('data-open')).toBe(false);
+    expect(host.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('dismisses when dragged past the threshold (Req 9.4)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.detectChanges();
+    const surface = fixture.debugElement.children[0]
+      .componentInstance as GuiBottomSheetSurface;
+    (surface as unknown as { onDragEnded(e: CdkDragEnd): void }).onDragEnded(
+      dragEnd(120),
+    );
+    expect(fixture.componentInstance.open()).toBe(false);
+  });
+
+  it('springs back when dragged below the threshold (Req 9.4)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.detectChanges();
+    const surface = fixture.debugElement.children[0]
+      .componentInstance as GuiBottomSheetSurface;
+    (surface as unknown as { onDragEnded(e: CdkDragEnd): void }).onDragEnded(
+      dragEnd(20),
+    );
+    expect(fixture.componentInstance.open()).toBe(true);
+  });
+});

--- a/libs/ui/bottom-sheet/src/bottom-sheet.spec.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet.spec.ts
@@ -16,11 +16,10 @@ class StandardHost {
 }
 
 /** Build a minimal CdkDragEnd with the given downward distance. */
-function dragEnd(distanceY: number): CdkDragEnd {
-  const reset = (): void => undefined;
+function dragEnd(distanceY: number, reset: () => void = () => undefined): CdkDragEnd {
   return {
     distance: { x: 0, y: distanceY },
-    source: { setFreeDragPosition: reset },
+    source: { reset },
   } as unknown as CdkDragEnd;
 }
 
@@ -65,5 +64,26 @@ describe('GuiBottomSheetSurface (standard)', () => {
       dragEnd(20),
     );
     expect(fixture.componentInstance.open()).toBe(true);
+  });
+
+  it('clears the inline drag transform on drag end so CSS drives position (Req 9.4)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.detectChanges();
+    const surface = fixture.debugElement.children[0]
+      .componentInstance as GuiBottomSheetSurface;
+    const onEnd = (surface as unknown as { onDragEnded(e: CdkDragEnd): void })
+      .onDragEnded;
+    // Both a dismissing drag and a spring-back must reset() the drag ref —
+    // otherwise CdkDrag's inline translate3d(0,0,0) would override the CSS
+    // closed/open transform and the sheet would not slide.
+    let dismissReset = 0;
+    onEnd.call(surface, dragEnd(120, () => (dismissReset += 1)));
+    expect(dismissReset).toBe(1);
+
+    fixture.componentInstance.open.set(true);
+    fixture.detectChanges();
+    let springReset = 0;
+    onEnd.call(surface, dragEnd(20, () => (springReset += 1)));
+    expect(springReset).toBe(1);
   });
 });

--- a/libs/ui/bottom-sheet/src/bottom-sheet.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet.ts
@@ -1,0 +1,71 @@
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  model,
+  numberAttribute,
+} from '@angular/core';
+import {
+  CdkDrag,
+  CdkDragEnd,
+  CdkDragHandle,
+} from '@angular/cdk/drag-drop';
+import { GuiReducedMotion } from '@ngguide/ui/interaction';
+
+/**
+ * M3 **standard** (non-modal) bottom sheet (Req 9.2). Rendered inline as a
+ * fixed-position surface that coexists with the page — **no scrim and no focus
+ * trap** — so content behind it stays interactive and scrollable. Toggle it
+ * with the two-way `open` model. Dragging the handle down past
+ * `dismissThreshold` closes it (sets `open` to `false`); a shorter drag springs
+ * back (Req 9.3, 9.4). For a focus-trapping modal sheet, use the
+ * {@link GuiBottomSheet} service instead.
+ */
+@Component({
+  selector: 'gui-bottom-sheet',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CdkDrag, CdkDragHandle],
+  template: `
+    <div
+      class="gui-bottom-sheet-surface"
+      cdkDrag
+      cdkDragLockAxis="y"
+      (cdkDragEnded)="onDragEnded($event)"
+    >
+      @if (showDragHandle()) {
+        <div class="gui-bottom-sheet-handle" cdkDragHandle aria-hidden="true"></div>
+      }
+      <div class="gui-bottom-sheet-body"><ng-content /></div>
+    </div>
+  `,
+  styleUrl: './bottom-sheet.css',
+  host: {
+    class: 'gui-bottom-sheet-host',
+    '[attr.data-variant]': 'variant()',
+    '[attr.data-open]': 'open() ? "" : null',
+    '[attr.aria-hidden]': 'open() ? null : "true"',
+    '[class.gui-no-motion]': 'reducedMotion.prefersReducedMotion()',
+  },
+})
+export class GuiBottomSheetSurface {
+  protected readonly reducedMotion = inject(GuiReducedMotion);
+
+  /** Surface mode. The inline component is `standard`; modal sheets use the service. */
+  readonly variant = input<'modal' | 'standard'>('standard');
+  /** Two-way open state (Req 9.2). */
+  readonly open = model(false);
+  /** Show the drag handle. Default `true`. */
+  readonly showDragHandle = input(true, { transform: booleanAttribute });
+  /** Downward drag (px) past which the sheet closes. Default 96. */
+  readonly dismissThreshold = input(96, { transform: numberAttribute });
+
+  protected onDragEnded(event: CdkDragEnd): void {
+    if (event.distance.y > this.dismissThreshold()) {
+      this.open.set(false);
+    }
+    // Always reset the transform; visibility is driven by `open` + CSS.
+    event.source.setFreeDragPosition({ x: 0, y: 0 });
+  }
+}

--- a/libs/ui/bottom-sheet/src/bottom-sheet.ts
+++ b/libs/ui/bottom-sheet/src/bottom-sheet.ts
@@ -65,7 +65,11 @@ export class GuiBottomSheetSurface {
     if (event.distance.y > this.dismissThreshold()) {
       this.open.set(false);
     }
-    // Always reset the transform; visibility is driven by `open` + CSS.
-    event.source.setFreeDragPosition({ x: 0, y: 0 });
+    // Clear the inline drag transform entirely so the CSS open/closed state
+    // (`translateY(0)` vs `translateY(100%)`) drives the surface position and
+    // animates. `setFreeDragPosition({0,0})` would leave an inline
+    // `translate3d(0,0,0)` that overrides the closed `translateY(100%)`, so a
+    // dismissed sheet would snap back into view instead of sliding away.
+    event.source.reset();
   }
 }

--- a/libs/ui/bottom-sheet/src/index.ts
+++ b/libs/ui/bottom-sheet/src/index.ts
@@ -1,0 +1,4 @@
+export * from './bottom-sheet-config';
+export * from './bottom-sheet.service';
+export * from './bottom-sheet';
+export { GuiBottomSheetContainer } from './bottom-sheet-container';

--- a/libs/ui/card/ng-package.json
+++ b/libs/ui/card/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/card/src/card.css
+++ b/libs/ui/card/src/card.css
@@ -1,0 +1,58 @@
+/* M3 card container. Per-variant container color, elevation, shape and border
+   only — hover/focus/pressed state layers, ripple and focus ring come from the
+   interaction foundation (GuiStateLayer/GuiRipple/GuiFocusRing) on the
+   actionable directives, never re-implemented here. */
+
+:host {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  /* Corner: medium (12dp). Content is clipped to the rounded corners. */
+  border-radius: var(--md-sys-shape-corner-medium);
+  overflow: hidden;
+  color: var(--md-sys-color-on-surface);
+  transition:
+    box-shadow var(--md-sys-motion-duration-short4)
+      var(--md-sys-motion-easing-standard),
+    background-color var(--md-sys-motion-duration-short4)
+      var(--md-sys-motion-easing-standard);
+}
+
+/* --- Elevated: surface-container-low + elevation level 1 (Req 1.2) --- */
+:host([data-variant='elevated']) {
+  background-color: var(--md-sys-color-surface-container-low);
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+/* --- Filled: surface-container-highest, no resting elevation (Req 1.2) --- */
+:host([data-variant='filled']) {
+  background-color: var(--md-sys-color-surface-container-highest);
+  box-shadow: var(--md-sys-elevation-level0);
+}
+
+/* --- Outlined: surface + 1dp outline-variant border, no elevation (Req 1.2) --- */
+:host([data-variant='outlined']) {
+  background-color: var(--md-sys-color-surface);
+  box-shadow: var(--md-sys-elevation-level0);
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+/* --- Hover elevation for whole-surface actionable cards (Req 2.5) --- */
+:host([data-variant='elevated'].gui-card-clickable:hover) {
+  box-shadow: var(--md-sys-elevation-level2);
+}
+:host([data-variant='filled'].gui-card-clickable:hover) {
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+/* --- Disabled: 0.38 opacity, no pointer interaction (Req 2.6) --- */
+:host([data-disabled]) {
+  opacity: 0.38;
+  pointer-events: none;
+}
+
+/* When the whole surface is the control, it must show the affordance. */
+:host(.gui-card-clickable) {
+  cursor: pointer;
+}

--- a/libs/ui/card/src/card.spec.ts
+++ b/libs/ui/card/src/card.spec.ts
@@ -1,0 +1,107 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import {
+  GuiCard,
+  GuiCardClickable,
+  GuiCardPrimaryAction,
+  GuiCardVariant,
+} from './card';
+
+@Component({
+  imports: [GuiCard],
+  template: `<gui-card [variant]="variant()" [disabled]="disabled()"
+    >content</gui-card
+  >`,
+})
+class CardHost {
+  readonly variant = signal<GuiCardVariant>('elevated');
+  readonly disabled = signal(false);
+}
+
+@Component({
+  imports: [GuiCardClickable],
+  template: `<div
+    guiCardClickable
+    [disabled]="disabled()"
+    (cardActivate)="count = count + 1"
+  ></div>`,
+})
+class ClickableHost {
+  readonly disabled = signal(false);
+  count = 0;
+}
+
+@Component({
+  imports: [GuiCardPrimaryAction],
+  template: `<div guiCardPrimaryAction (primaryAction)="count = count + 1"></div>`,
+})
+class PrimaryActionHost {
+  count = 0;
+}
+
+describe('GuiCard', () => {
+  it('reflects variant onto data-variant (Req 1.2)', () => {
+    const fixture = TestBed.createComponent(CardHost);
+    fixture.componentInstance.variant.set('outlined');
+    fixture.detectChanges();
+    const card = fixture.nativeElement.querySelector('gui-card');
+    expect(card.getAttribute('data-variant')).toBe('outlined');
+  });
+
+  it('sets data-disabled only when disabled (Req 2.6)', () => {
+    const fixture = TestBed.createComponent(CardHost);
+    fixture.componentInstance.disabled.set(true);
+    fixture.detectChanges();
+    const card = fixture.nativeElement.querySelector('gui-card');
+    expect(card.hasAttribute('data-disabled')).toBe(true);
+  });
+});
+
+describe('GuiCardClickable', () => {
+  it('exposes role=button and tabindex=0 (Req 2.1)', () => {
+    const fixture = TestBed.createComponent(ClickableHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.directive(GuiCardClickable))
+      .nativeElement as HTMLElement;
+    expect(el.getAttribute('role')).toBe('button');
+    expect(el.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('emits cardActivate on click and Enter (Req 2.1)', () => {
+    const fixture = TestBed.createComponent(ClickableHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.directive(GuiCardClickable))
+      .nativeElement as HTMLElement;
+
+    el.dispatchEvent(new MouseEvent('click'));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(fixture.componentInstance.count).toBe(2);
+  });
+
+  it('suppresses activation + exposes aria-disabled when disabled (Req 2.6)', () => {
+    const fixture = TestBed.createComponent(ClickableHost);
+    fixture.componentInstance.disabled.set(true);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.directive(GuiCardClickable))
+      .nativeElement as HTMLElement;
+
+    expect(el.getAttribute('aria-disabled')).toBe('true');
+    expect(el.hasAttribute('tabindex')).toBe(false);
+    el.dispatchEvent(new MouseEvent('click'));
+    expect(fixture.componentInstance.count).toBe(0);
+  });
+});
+
+describe('GuiCardPrimaryAction', () => {
+  it('emits primaryAction independently of the surface (Req 2.2)', () => {
+    const fixture = TestBed.createComponent(PrimaryActionHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.directive(GuiCardPrimaryAction))
+      .nativeElement as HTMLElement;
+
+    el.dispatchEvent(new MouseEvent('click'));
+    expect(fixture.componentInstance.count).toBe(1);
+    expect(el.getAttribute('role')).toBe('button');
+  });
+});

--- a/libs/ui/card/src/card.ts
+++ b/libs/ui/card/src/card.ts
@@ -1,0 +1,134 @@
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import {
+  GuiFocusRingDirective,
+  GuiRippleDirective,
+  GuiStateLayerDirective,
+} from '@ngguide/ui/interaction';
+
+export type GuiCardVariant = 'elevated' | 'filled' | 'outlined';
+
+/**
+ * M3 card container — a contained surface grouping related content and actions.
+ * Comes in three variants (Req 1.2): `elevated` (surface-container-low +
+ * elevation level 1), `filled` (surface-container-highest, no elevation),
+ * `outlined` (surface + 1dp outline-variant border). Corner is `medium`
+ * (12dp). Content is projected; the card itself is non-interactive — pair it
+ * with {@link GuiCardClickable} (whole-surface) or {@link GuiCardPrimaryAction}
+ * (a sub-region) for actionable cards (Req 2).
+ */
+@Component({
+  selector: 'gui-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  styleUrl: './card.css',
+  host: {
+    class: 'gui-card',
+    '[attr.data-variant]': 'variant()',
+    '[attr.data-disabled]': 'disabled() ? "" : null',
+  },
+})
+export class GuiCard {
+  /** Visual variant (Req 1.2). */
+  readonly variant = input<GuiCardVariant>('elevated');
+  /** Dim the card to 0.38 opacity and suppress interaction (Req 2.6). */
+  readonly disabled = input(false, { transform: booleanAttribute });
+}
+
+/**
+ * Whole-surface actionable card (Req 2.1, M3 actionable card "Variant A").
+ * Apply to a `gui-card` (or an `<a gui-card>`) to make the entire surface a
+ * single control. Adds the interaction foundation (state layer / ripple /
+ * focus ring), keyboard activation (Enter/Space), and `role="button"` when the
+ * host is not an anchor. Do NOT use on a card that contains its own buttons or
+ * links — nest those interactions with {@link GuiCardPrimaryAction} instead
+ * (Req 2.3).
+ */
+@Directive({
+  selector: '[guiCardClickable]',
+  hostDirectives: [
+    GuiStateLayerDirective,
+    GuiRippleDirective,
+    GuiFocusRingDirective,
+  ],
+  host: {
+    class: 'gui-card-clickable',
+    '[attr.tabindex]': 'disabled() ? null : 0',
+    '[attr.role]': 'isAnchor ? null : "button"',
+    '[attr.aria-disabled]': 'disabled() ? "true" : null',
+    '(click)': 'activate($event)',
+    '(keydown.enter)': 'activate($event)',
+    '(keydown.space)': 'activate($event)',
+  },
+})
+export class GuiCardClickable {
+  /** Mirror the card's disabled state so activation + state layers are suppressed (Req 2.6). */
+  readonly disabled = input(false, { transform: booleanAttribute });
+  /** Emitted when the card is activated by click or keyboard (Req 2.1). */
+  readonly cardActivate = output<Event>();
+
+  protected readonly isAnchor =
+    inject<ElementRef<HTMLElement>>(ElementRef).nativeElement.tagName === 'A';
+
+  protected activate(event: Event): void {
+    if (this.disabled()) {
+      event.preventDefault();
+      return;
+    }
+    if (event.type === 'keydown') {
+      // Prevent the page scrolling on Space / activating twice.
+      event.preventDefault();
+    }
+    this.cardActivate.emit(event);
+  }
+}
+
+/**
+ * Primary-action region of a card (Req 2.2, M3 actionable card "Variant B").
+ * Use when a card has both a main tap target AND its own action buttons: wrap
+ * the headline/media in this region; place the buttons OUTSIDE it so they
+ * remain independently focusable (Req 2.4). Carries the interaction foundation
+ * and keyboard activation, exposing `role="button"`.
+ */
+@Directive({
+  selector: '[guiCardPrimaryAction]',
+  hostDirectives: [
+    GuiStateLayerDirective,
+    GuiRippleDirective,
+    GuiFocusRingDirective,
+  ],
+  host: {
+    class: 'gui-card-primary-action',
+    '[attr.tabindex]': 'disabled() ? null : 0',
+    role: 'button',
+    '[attr.aria-disabled]': 'disabled() ? "true" : null',
+    '(click)': 'activate($event)',
+    '(keydown.enter)': 'activate($event)',
+    '(keydown.space)': 'activate($event)',
+  },
+})
+export class GuiCardPrimaryAction {
+  /** Suppress activation + state layers when disabled (Req 2.6). */
+  readonly disabled = input(false, { transform: booleanAttribute });
+  /** Emitted when the primary-action region is activated (Req 2.2). */
+  readonly primaryAction = output<Event>();
+
+  protected activate(event: Event): void {
+    if (this.disabled()) {
+      event.preventDefault();
+      return;
+    }
+    if (event.type === 'keydown') {
+      event.preventDefault();
+    }
+    this.primaryAction.emit(event);
+  }
+}

--- a/libs/ui/card/src/index.ts
+++ b/libs/ui/card/src/index.ts
@@ -1,0 +1,1 @@
+export * from './card';

--- a/libs/ui/carousel/ng-package.json
+++ b/libs/ui/carousel/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/carousel/src/carousel-item.css
+++ b/libs/ui/carousel/src/carousel-item.css
@@ -1,0 +1,11 @@
+/* M3 carousel item: extra-large (28dp) corners, clipped content, snap target.
+   Falls back to the carousel's large width (inherited custom prop) when the
+   engine has not assigned an explicit width (SSR / first frame). */
+:host {
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  width: var(--gui-carousel-large, 186px);
+  overflow: hidden;
+  border-radius: var(--md-sys-shape-corner-extra-large);
+  scroll-snap-align: start;
+}

--- a/libs/ui/carousel/src/carousel-item.ts
+++ b/libs/ui/carousel/src/carousel-item.ts
@@ -1,0 +1,25 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  signal,
+} from '@angular/core';
+
+/**
+ * A single M3 carousel item. Its width is assigned by the parent
+ * {@link GuiCarousel}'s keyline engine; when unset (SSR / full-screen) it falls
+ * back to the inherited large width from CSS. Corner is `extra-large` (28dp).
+ */
+@Component({
+  selector: 'gui-carousel-item',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  styleUrl: './carousel-item.css',
+  host: {
+    class: 'gui-carousel-item',
+    '[style.width.px]': 'width()',
+  },
+})
+export class GuiCarouselItem {
+  /** Width in px assigned by the engine, or `null` to use the CSS default. */
+  readonly width = signal<number | null>(null);
+}

--- a/libs/ui/carousel/src/carousel-keylines.spec.ts
+++ b/libs/ui/carousel/src/carousel-keylines.spec.ts
@@ -1,0 +1,87 @@
+import {
+  MAX_SMALL_ITEM,
+  MIN_SMALL_ITEM,
+  arrange,
+  maskForOffset,
+} from './carousel-keylines';
+
+const OPTS = { preferredLargeWidth: 186, itemSpacing: 8, itemCount: 8 };
+
+describe('arrange', () => {
+  it('returns a degenerate arrangement for zero width or no items', () => {
+    expect(arrange('multi-browse', 0, OPTS).largeCount).toBe(0);
+    expect(
+      arrange('multi-browse', 360, { ...OPTS, itemCount: 0 }).largeCount,
+    ).toBe(0);
+  });
+
+  describe('multi-browse', () => {
+    it('keeps small within [40, 56] and medium at the midpoint (Req 11.2)', () => {
+      const a = arrange('multi-browse', 412, OPTS);
+      expect(a.small).toBeGreaterThanOrEqual(MIN_SMALL_ITEM);
+      expect(a.small).toBeLessThanOrEqual(MAX_SMALL_ITEM);
+      expect(a.medium).toBeCloseTo((a.large + a.small) / 2, 5);
+      expect(a.largeCount).toBe(1);
+    });
+
+    it('caps non-focal keylines at two (Req 11.2)', () => {
+      const a = arrange('multi-browse', 1200, OPTS);
+      expect(a.mediumCount + a.smallCount).toBeLessThanOrEqual(2);
+    });
+
+    it('drops small items when the focal width is below 80px (Req 11.2)', () => {
+      const a = arrange('multi-browse', 60, {
+        ...OPTS,
+        preferredLargeWidth: 60,
+      });
+      expect(a.smallCount).toBe(0);
+      expect(a.mediumCount).toBe(0);
+    });
+  });
+
+  describe('full-screen', () => {
+    it('lays out a single item filling the viewport (Req 11.1)', () => {
+      const a = arrange('full-screen', 360, OPTS);
+      expect(a.large).toBe(360);
+      expect(a.largeCount).toBe(1);
+      expect(a.smallCount).toBe(0);
+    });
+  });
+
+  describe('hero', () => {
+    it('shows one large focal item and a small peek (Req 11.1)', () => {
+      const a = arrange('hero', 360, OPTS);
+      expect(a.largeCount).toBe(1);
+      expect(a.smallCount).toBe(1);
+      expect(a.large + a.small + OPTS.itemSpacing).toBeCloseTo(360, 5);
+    });
+  });
+
+  describe('uncontained', () => {
+    it('fits whole items and resizes the cut-off trailing item (Req 11.3)', () => {
+      const a = arrange('uncontained', 420, OPTS);
+      expect(a.large).toBe(186);
+      expect(a.largeCount).toBeGreaterThanOrEqual(1);
+      // A partial item peeks when there is leftover room and more items.
+      expect(a.smallCount).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+describe('maskForOffset', () => {
+  it('renders the focal item at large and distant items toward small', () => {
+    const a = arrange('multi-browse', 412, OPTS);
+    const focal = maskForOffset(a, 0, 0);
+    const distant = maskForOffset(a, 0, 5);
+    expect(focal.width).toBeCloseTo(a.large, 5);
+    expect(distant.width).toBeLessThan(a.large);
+    expect(focal.clipInset).toBe(0);
+  });
+
+  it('is safe on an empty arrangement', () => {
+    expect(maskForOffset(arrange('multi-browse', 0, OPTS), 0, 0)).toEqual({
+      width: 0,
+      clipInset: 0,
+    });
+  });
+});

--- a/libs/ui/carousel/src/carousel-keylines.ts
+++ b/libs/ui/carousel/src/carousel-keylines.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure M3 carousel keyline sizing engine. No `Date.now`/`Math.random`, no DOM —
+ * deterministic and SSR-safe (Req 16.4). The runtime ({@link GuiCarousel})
+ * feeds it the measured viewport width and applies the resulting item widths.
+ *
+ * Verified M3 sizing rules (Compose `CarouselDefaults`): the focal item renders
+ * at the preferred large width; the smallest visible items are
+ * `small = clamp(large / 3, 40, 56)`; a medium item bridges them at
+ * `medium = (large + small) / 2`.
+ */
+export type GuiCarouselLayout =
+  | 'multi-browse'
+  | 'uncontained'
+  | 'hero'
+  | 'full-screen';
+
+/** dp — smallest a small carousel item may shrink to (verified). */
+export const MIN_SMALL_ITEM = 40;
+/** dp — largest a small carousel item may grow to (verified). */
+export const MAX_SMALL_ITEM = 56;
+
+/**
+ * Below this focal width the multi-browse layout has no room for small items
+ * and drops them, showing only the focal (and a medium if it fits).
+ */
+const SMALL_DROP_THRESHOLD = 80;
+
+export interface KeylineArrangement {
+  /** Focal item width (px). */
+  large: number;
+  /** Medium item width (px); 0 when the layout has no medium keyline. */
+  medium: number;
+  /** Small item width (px); 0 when no small items are shown. */
+  small: number;
+  largeCount: number;
+  mediumCount: number;
+  smallCount: number;
+}
+
+const EMPTY: KeylineArrangement = {
+  large: 0,
+  medium: 0,
+  small: 0,
+  largeCount: 0,
+  mediumCount: 0,
+  smallCount: 0,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** small = clamp(large / 3, 40, 56) — verified M3 rule. */
+function smallFor(large: number): number {
+  return clamp(large / 3, MIN_SMALL_ITEM, MAX_SMALL_ITEM);
+}
+
+export interface ArrangeOptions {
+  preferredLargeWidth: number;
+  itemSpacing: number;
+  itemCount: number;
+}
+
+/**
+ * Compute the keyline arrangement that fits `viewportWidth` for a layout.
+ * Returns a degenerate (all-zero) arrangement when there is nothing to lay out.
+ */
+export function arrange(
+  layout: GuiCarouselLayout,
+  viewportWidth: number,
+  opts: ArrangeOptions,
+): KeylineArrangement {
+  const { preferredLargeWidth, itemSpacing, itemCount } = opts;
+  if (viewportWidth <= 0 || itemCount <= 0) {
+    return { ...EMPTY };
+  }
+
+  switch (layout) {
+    case 'full-screen':
+      // One item fills the viewport (Req 11.1).
+      return {
+        ...EMPTY,
+        large: viewportWidth,
+        largeCount: 1,
+      };
+
+    case 'hero': {
+      // One large focal item plus a small peek of the next (Req 11.1).
+      const small = Math.min(smallFor(preferredLargeWidth), viewportWidth);
+      const canPeek =
+        itemCount > 1 && viewportWidth - small - itemSpacing > small;
+      const large = canPeek
+        ? viewportWidth - small - itemSpacing
+        : viewportWidth;
+      return {
+        ...EMPTY,
+        large: Math.max(0, large),
+        small: canPeek ? small : 0,
+        largeCount: 1,
+        smallCount: canPeek ? 1 : 0,
+      };
+    }
+
+    case 'uncontained': {
+      // Repeat the preferred width; the last visible item is cut off (resized).
+      const large = Math.min(preferredLargeWidth, viewportWidth);
+      const step = large + itemSpacing;
+      const fullCount = Math.max(
+        1,
+        Math.floor((viewportWidth + itemSpacing) / step),
+      );
+      const used = fullCount * large + (fullCount - 1) * itemSpacing;
+      const leftover = viewportWidth - used - itemSpacing;
+      const showCut = leftover > MIN_SMALL_ITEM && fullCount < itemCount;
+      return {
+        ...EMPTY,
+        large,
+        small: showCut ? leftover : 0,
+        largeCount: Math.min(fullCount, itemCount),
+        smallCount: showCut ? 1 : 0,
+      };
+    }
+
+    case 'multi-browse':
+    default: {
+      // One large focal item, then a medium, then small items — non-focal
+      // keylines capped at 2 total; smalls dropped when the focal item is
+      // narrower than 80px (Req 11.2).
+      const large = Math.min(preferredLargeWidth, viewportWidth);
+      const small = smallFor(large);
+      const medium = (large + small) / 2;
+      let remaining = viewportWidth - large - itemSpacing;
+      let mediumCount = 0;
+      let smallCount = 0;
+
+      if (large >= SMALL_DROP_THRESHOLD) {
+        if (remaining >= medium) {
+          mediumCount = 1;
+          remaining -= medium + itemSpacing;
+        }
+        while (smallCount + mediumCount < 2 && remaining >= small) {
+          smallCount += 1;
+          remaining -= small + itemSpacing;
+        }
+      }
+
+      // Never lay out more slots than there are items.
+      const nonFocalBudget = Math.max(0, itemCount - 1);
+      mediumCount = Math.min(mediumCount, nonFocalBudget);
+      smallCount = Math.min(smallCount, nonFocalBudget - mediumCount);
+
+      return {
+        large,
+        medium: mediumCount > 0 ? medium : 0,
+        small: smallCount > 0 ? small : 0,
+        largeCount: 1,
+        mediumCount,
+        smallCount,
+      };
+    }
+  }
+}
+
+/**
+ * Interpolated width and clip inset for the item at `index`, given the current
+ * `scrollOffset` (px). Items at the focal keyline render at `large`; items
+ * further away taper toward `small`, producing the M3 size-morph as the user
+ * scrolls. Pure and deterministic.
+ */
+export function maskForOffset(
+  arrangement: KeylineArrangement,
+  scrollOffset: number,
+  index: number,
+): { width: number; clipInset: number } {
+  const { large } = arrangement;
+  const smallest = arrangement.small || arrangement.medium || large;
+  if (large <= 0) {
+    return { width: 0, clipInset: 0 };
+  }
+  const focalIndex = scrollOffset / large;
+  const distance = Math.min(1, Math.abs(index - focalIndex));
+  const width = large - distance * (large - smallest);
+  const clipInset = (large - width) / 2;
+  return { width, clipInset };
+}

--- a/libs/ui/carousel/src/carousel.css
+++ b/libs/ui/carousel/src/carousel.css
@@ -1,0 +1,41 @@
+/* M3 carousel: native scroll + scroll-snap for momentum and snapping. The
+   engine sizes the items; this file only lays out the track. */
+
+:host {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+}
+
+.gui-carousel-track {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding: 8px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+.gui-carousel-track::-webkit-scrollbar {
+  display: none;
+}
+
+/* --- Full-screen on compact: vertical orientation (Req 11.6) --- */
+:host([data-orientation='vertical']) .gui-carousel-track {
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  height: 100dvh;
+}
+:host([data-orientation='vertical']) ::ng-deep .gui-carousel-item {
+  width: 100% !important;
+  height: 100dvh;
+}
+
+/* --- Full-screen horizontal: each item fills the viewport width --- */
+:host([data-layout='full-screen'][data-orientation='horizontal'])
+  ::ng-deep
+  .gui-carousel-item {
+  width: 100% !important;
+}

--- a/libs/ui/carousel/src/carousel.spec.ts
+++ b/libs/ui/carousel/src/carousel.spec.ts
@@ -55,6 +55,24 @@ describe('GuiCarousel', () => {
     expect(parseFloat(items[5].style.width)).toBeLessThan(186);
   });
 
+  it('sizes uncontained items uniformly (no per-scroll morph) (Req 11.2)', () => {
+    const fixture = TestBed.createComponent(CarouselHost);
+    fixture.componentInstance.layout.set('uncontained');
+    fixture.detectChanges();
+    flush();
+    const carousel = fixture.debugElement.children[0]
+      .componentInstance as GuiCarousel;
+    (carousel as unknown as { measure(w: number): void }).measure(412);
+    fixture.detectChanges();
+    const widths = Array.from(
+      fixture.nativeElement.querySelectorAll('gui-carousel-item'),
+    ).map((el) => (el as HTMLElement).style.width);
+    // Every item is the same (large) width — the trailing item is cut by the
+    // container's overflow, not resized down per keyline.
+    expect(new Set(widths).size).toBe(1);
+    expect(parseFloat(widths[0])).toBeGreaterThan(56);
+  });
+
   it('renders full-screen items without an engine width (CSS fills them)', () => {
     const fixture = TestBed.createComponent(CarouselHost);
     fixture.componentInstance.layout.set('full-screen');

--- a/libs/ui/carousel/src/carousel.spec.ts
+++ b/libs/ui/carousel/src/carousel.spec.ts
@@ -1,0 +1,103 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { GuiCarousel } from './carousel';
+import { GuiCarouselItem } from './carousel-item';
+import { GuiCarouselLayout } from './carousel-keylines';
+
+@Component({
+  imports: [GuiCarousel, GuiCarouselItem],
+  template: `
+    <gui-carousel [layout]="layout()" [preferredLargeWidth]="186">
+      @for (n of items; track n) {
+        <gui-carousel-item>{{ n }}</gui-carousel-item>
+      }
+    </gui-carousel>
+  `,
+})
+class CarouselHost {
+  readonly layout = signal<GuiCarouselLayout>('multi-browse');
+  readonly items = [1, 2, 3, 4, 5, 6];
+}
+
+function flush(): void {
+  TestBed.inject(ApplicationRef).tick();
+}
+
+describe('GuiCarousel', () => {
+  it('exposes the carousel role and reflects the layout (Req 11.1, 14)', () => {
+    const fixture = TestBed.createComponent(CarouselHost);
+    fixture.componentInstance.layout.set('hero');
+    fixture.detectChanges();
+    flush();
+    const carousel = fixture.nativeElement.querySelector('gui-carousel');
+    expect(carousel.getAttribute('role')).toBe('group');
+    expect(carousel.getAttribute('aria-roledescription')).toBe('carousel');
+    expect(carousel.getAttribute('data-layout')).toBe('hero');
+  });
+
+  it('assigns item widths from the engine after layout (Req 11.2)', () => {
+    const fixture = TestBed.createComponent(CarouselHost);
+    fixture.detectChanges();
+    flush();
+    const carousel = fixture.debugElement.children[0]
+      .componentInstance as GuiCarousel;
+    // jsdom does not compute layout, so drive a viewport width explicitly.
+    (carousel as unknown as { measure(w: number): void }).measure(412);
+    fixture.detectChanges();
+
+    const items = Array.from(
+      fixture.nativeElement.querySelectorAll('gui-carousel-item'),
+    ) as HTMLElement[];
+    // Focal item renders at the large width (186px).
+    expect(items[0].style.width).toBe('186px');
+    // A distant item is narrower than the focal one.
+    expect(parseFloat(items[5].style.width)).toBeLessThan(186);
+  });
+
+  it('renders full-screen items without an engine width (CSS fills them)', () => {
+    const fixture = TestBed.createComponent(CarouselHost);
+    fixture.componentInstance.layout.set('full-screen');
+    fixture.detectChanges();
+    flush();
+    const carousel = fixture.debugElement.children[0]
+      .componentInstance as GuiCarousel;
+    (carousel as unknown as { measure(w: number): void }).measure(360);
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector(
+      'gui-carousel-item',
+    ) as HTMLElement;
+    expect(item.style.width).toBe('');
+  });
+
+  describe('reduced motion', () => {
+    it('assigns static arranged sizes (no per-scroll morph) (Req 15)', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: MediaMatcher,
+            useValue: {
+              matchMedia: (q: string) => ({
+                matches: q.includes('prefers-reduced-motion'),
+              }),
+            },
+          },
+        ],
+      });
+      const fixture = TestBed.createComponent(CarouselHost);
+      fixture.detectChanges();
+      flush();
+      const carousel = fixture.debugElement.children[0]
+        .componentInstance as GuiCarousel;
+      (carousel as unknown as { measure(w: number): void }).measure(412);
+      fixture.detectChanges();
+      const items = Array.from(
+        fixture.nativeElement.querySelectorAll('gui-carousel-item'),
+      ) as HTMLElement[];
+      // Focal item is large; a trailing item collapses to the small keyline.
+      expect(items[0].style.width).toBe('186px');
+      expect(parseFloat(items[5].style.width)).toBeLessThanOrEqual(56);
+    });
+  });
+});

--- a/libs/ui/carousel/src/carousel.ts
+++ b/libs/ui/carousel/src/carousel.ts
@@ -118,6 +118,17 @@ export class GuiCarousel {
       return;
     }
 
+    // Uncontained lays out items of a *uniform* width; native scroll + the
+    // container's overflow clip the trailing item. There is no per-scroll
+    // keyline morph here (that is the multi-browse/hero behavior) — every item
+    // renders at the large width (Req 11.2).
+    if (this.effectiveLayout() === 'uncontained') {
+      for (const item of items) {
+        item.width.set(arr.large);
+      }
+      return;
+    }
+
     const reduced = this.reducedMotion.prefersReducedMotion();
     const scrollOffset = reduced ? 0 : this.track().nativeElement.scrollLeft;
 

--- a/libs/ui/carousel/src/carousel.ts
+++ b/libs/ui/carousel/src/carousel.ts
@@ -1,0 +1,139 @@
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  contentChildren,
+  effect,
+  ElementRef,
+  inject,
+  input,
+  numberAttribute,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { GuiBreakpoint } from '@ngguide/ui/overlay';
+import { GuiReducedMotion } from '@ngguide/ui/interaction';
+import {
+  GuiCarouselLayout,
+  arrange,
+  maskForOffset,
+} from './carousel-keylines';
+import { GuiCarouselItem } from './carousel-item';
+
+/**
+ * M3 carousel — a horizontally (or, full-screen on compact, vertically)
+ * scrolling row of items sized by the keyline engine (Req 11). Native scroll +
+ * `scroll-snap` provide momentum and snapping; a `ResizeObserver` tracks the
+ * viewport and a scroll listener morphs item widths between keylines. Under
+ * reduced motion the per-scroll morph is disabled — items render at their
+ * arranged sizes (Req 11.6, 15). On the server / first frame items fall back to
+ * the large width via CSS, so there is no layout shift on hydration.
+ */
+@Component({
+  selector: 'gui-carousel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="gui-carousel-track" #track><ng-content /></div>`,
+  styleUrl: './carousel.css',
+  host: {
+    class: 'gui-carousel',
+    role: 'group',
+    'aria-roledescription': 'carousel',
+    '[attr.data-layout]': 'effectiveLayout()',
+    '[attr.data-orientation]': 'vertical() ? "vertical" : "horizontal"',
+    '[style.--gui-carousel-large.px]': 'preferredLargeWidth()',
+  },
+})
+export class GuiCarousel {
+  private readonly breakpoint = inject(GuiBreakpoint);
+  private readonly reducedMotion = inject(GuiReducedMotion);
+
+  readonly layout = input<GuiCarouselLayout>('multi-browse');
+  readonly preferredLargeWidth = input(186, { transform: numberAttribute });
+  readonly itemSpacing = input(8, { transform: numberAttribute });
+
+  private readonly track =
+    viewChild.required<ElementRef<HTMLElement>>('track');
+  private readonly items = contentChildren(GuiCarouselItem);
+
+  /** Last measured viewport width (px); 0 until the first measurement / on SSR. */
+  private readonly viewportWidth = signal(0);
+
+  /**
+   * The full-screen layout switches to a vertical orientation in the compact
+   * window class (Req 11.6); other layouts stay horizontal.
+   */
+  readonly vertical = computed(
+    () => this.layout() === 'full-screen' && this.breakpoint.isCompact(),
+  );
+  readonly effectiveLayout = computed(() => this.layout());
+
+  /** Keyline arrangement derived purely from the inputs + measured width. */
+  private readonly arrangement = computed(() =>
+    arrange(this.effectiveLayout(), this.viewportWidth(), {
+      preferredLargeWidth: this.preferredLargeWidth(),
+      itemSpacing: this.itemSpacing(),
+      itemCount: this.items().length,
+    }),
+  );
+
+  constructor() {
+    afterNextRender(() => {
+      const el = this.track().nativeElement;
+      if (typeof ResizeObserver !== 'undefined') {
+        const observer = new ResizeObserver((entries) => {
+          this.viewportWidth.set(
+            entries[0]?.contentRect.width ?? el.clientWidth,
+          );
+        });
+        observer.observe(el);
+      }
+      el.addEventListener('scroll', () => this.applyWidths(), { passive: true });
+      this.viewportWidth.set(el.clientWidth);
+    });
+
+    // Re-apply item widths whenever the arrangement or motion preference change.
+    effect(() => {
+      this.arrangement();
+      this.reducedMotion.prefersReducedMotion();
+      this.applyWidths();
+    });
+  }
+
+  /** Test/IMPERATIVE hook: set the measured viewport width. */
+  protected measure(viewportWidth: number): void {
+    this.viewportWidth.set(viewportWidth);
+  }
+
+  /** Assign each item its width from the current arrangement. */
+  private applyWidths(): void {
+    const arr = this.arrangement();
+    const items = this.items();
+
+    // Full-screen items fill the viewport — let CSS drive (width stays null).
+    if (this.effectiveLayout() === 'full-screen' || arr.large <= 0) {
+      for (const item of items) {
+        item.width.set(null);
+      }
+      return;
+    }
+
+    const reduced = this.reducedMotion.prefersReducedMotion();
+    const scrollOffset = reduced ? 0 : this.track().nativeElement.scrollLeft;
+
+    items.forEach((item, index) => {
+      if (reduced) {
+        // Static arranged sizes — focal large, then medium, then small.
+        let width = arr.small || arr.large;
+        if (index < arr.largeCount) {
+          width = arr.large;
+        } else if (index < arr.largeCount + arr.mediumCount) {
+          width = arr.medium || arr.large;
+        }
+        item.width.set(width);
+      } else {
+        item.width.set(maskForOffset(arr, scrollOffset, index).width);
+      }
+    });
+  }
+}

--- a/libs/ui/carousel/src/index.ts
+++ b/libs/ui/carousel/src/index.ts
@@ -1,0 +1,3 @@
+export * from './carousel-keylines';
+export * from './carousel';
+export * from './carousel-item';

--- a/libs/ui/chip/src/chip.spec.ts
+++ b/libs/ui/chip/src/chip.spec.ts
@@ -1,5 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { ChipComponent, GuiChipType } from './chip';
 import { ChipSetComponent, GuiChipSelect } from './chip-set';
 
@@ -91,5 +92,12 @@ describe('ChipComponent', () => {
     fixture.detectChanges();
 
     expect(chips[0].hasAttribute('data-elevated')).toBe(true);
+  });
+
+  it('implements getLabel so roving type-ahead does not throw (FocusableOption)', () => {
+    const instances = fixture.debugElement
+      .queryAll(By.directive(ChipComponent))
+      .map((d) => d.componentInstance as ChipComponent);
+    expect(instances.map((c) => c.getLabel())).toEqual(['A', 'B']);
   });
 });

--- a/libs/ui/chip/src/chip.ts
+++ b/libs/ui/chip/src/chip.ts
@@ -96,9 +96,26 @@ export class ChipComponent {
 
   private readonly primary =
     viewChild.required<ElementRef<HTMLButtonElement>>('primary');
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
 
   focus(): void {
     this.primary().nativeElement.focus();
+  }
+
+  /**
+   * {@link FocusableOption} type-ahead label. `createRovingFocus` enables
+   * type-ahead, whose {@link FocusKeyManager} requires every option to provide a
+   * `getLabel()`; without it the manager throws on build. Returns the explicit
+   * `label` input or, failing that, the chip's visible text.
+   */
+  getLabel(): string {
+    return (
+      this.label() ||
+      this.host.nativeElement
+        .querySelector('.gui-chip-label')
+        ?.textContent?.trim() ||
+      ''
+    );
   }
 
   protected onPrimary(): void {

--- a/libs/ui/dialog/ng-package.json
+++ b/libs/ui/dialog/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/dialog/src/dialog-config.ts
+++ b/libs/ui/dialog/src/dialog-config.ts
@@ -1,0 +1,22 @@
+import { GuiModalConfigBase } from '@ngguide/ui/overlay';
+
+/**
+ * Full-screen behavior for a dialog (Req 8):
+ * - `never` (default) — always a centered basic dialog.
+ * - `compact` — full-screen only in the compact window class (`< 600dp`).
+ * - `always` — always full-screen.
+ */
+export type GuiDialogFullScreen = 'never' | 'compact' | 'always';
+
+export interface GuiDialogConfig<D = unknown> extends GuiModalConfigBase<D> {
+  /** When the dialog should occupy the full screen (Req 8.1). Default `never`. */
+  fullScreen?: GuiDialogFullScreen;
+  /**
+   * Maximum width of the basic dialog. Default `min(560px, calc(100% - 48px))`
+   * (M3 basic dialog max 560dp with a 24dp margin each side). Ignored in
+   * full-screen mode.
+   */
+  maxWidth?: string;
+}
+
+export { GUI_DIALOG_DATA, type GuiDialogRef } from '@ngguide/ui/overlay';

--- a/libs/ui/dialog/src/dialog-container.css
+++ b/libs/ui/dialog/src/dialog-container.css
@@ -1,0 +1,55 @@
+/* M3 dialog surface chrome. The container host IS the surface. */
+
+:host {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  outline: none;
+  min-width: 280px;
+  max-height: inherit;
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  border-radius: var(--md-sys-shape-corner-extra-large);
+  box-shadow: var(--md-sys-elevation-level3);
+  overflow: hidden;
+  animation: gui-dialog-enter var(--md-sys-motion-duration-medium4)
+    var(--md-sys-motion-easing-emphasized-decelerate);
+}
+
+@keyframes gui-dialog-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* --- Full-screen: edge-to-edge surface, no radius (Req 8.1) --- */
+:host([data-fullscreen]) {
+  width: 100vw;
+  height: 100dvh;
+  max-height: 100dvh;
+  border-radius: 0;
+  box-shadow: none;
+  background-color: var(--md-sys-color-surface);
+  animation-name: gui-dialog-enter-fullscreen;
+}
+
+@keyframes gui-dialog-enter-fullscreen {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* --- Reduced motion: no enter animation (Req 15.2) --- */
+:host(.gui-no-motion) {
+  animation: none;
+}

--- a/libs/ui/dialog/src/dialog-container.ts
+++ b/libs/ui/dialog/src/dialog-container.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CdkDialogContainer, DialogConfig } from '@angular/cdk/dialog';
+import { CdkPortalOutlet } from '@angular/cdk/portal';
+import { GuiReducedMotion } from '@ngguide/ui/interaction';
+
+/** Config shape the service passes through; CDK preserves the extra flag. */
+export interface GuiDialogContainerConfig extends DialogConfig {
+  guiFullScreen?: boolean;
+}
+
+/**
+ * M3 dialog surface. Extends CDK's {@link CdkDialogContainer} (which provides
+ * the focus trap, focus restore, autofocus and `aria-modal` wiring) and wraps
+ * the projected content in the M3 chrome: `surface-container-high`,
+ * `corner-extra-large` (28dp), `elevation-level3`, centered (Req 7.1, 13).
+ * In full-screen mode (`data-fullscreen`) it fills the window with an edge-to-
+ * edge surface and no corner radius (Req 8). The enter animation
+ * (emphasized-decelerate) is disabled under reduced motion (Req 15.1, 15.2).
+ */
+@Component({
+  selector: 'gui-dialog-container',
+  changeDetection: ChangeDetectionStrategy.Default,
+  imports: [CdkPortalOutlet],
+  template: `<ng-template cdkPortalOutlet />`,
+  styleUrl: './dialog-container.css',
+  host: {
+    class: 'gui-dialog-container',
+    tabindex: '-1',
+    '[attr.id]': '_config.id || null',
+    '[attr.role]': '_config.role',
+    '[attr.aria-modal]': '_config.ariaModal',
+    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledByQueue[0]',
+    '[attr.aria-label]': '_config.ariaLabel',
+    '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
+    '[attr.data-fullscreen]': 'fullScreen ? "" : null',
+    '[class.gui-no-motion]': 'reducedMotion.prefersReducedMotion()',
+  },
+})
+export class GuiDialogContainer extends CdkDialogContainer {
+  protected readonly reducedMotion = inject(GuiReducedMotion);
+
+  protected get fullScreen(): boolean {
+    return !!(this._config as GuiDialogContainerConfig).guiFullScreen;
+  }
+}

--- a/libs/ui/dialog/src/dialog.service.spec.ts
+++ b/libs/ui/dialog/src/dialog.service.spec.ts
@@ -1,0 +1,115 @@
+import { ApplicationRef, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { GuiDialog } from './dialog.service';
+import { GuiDialogHeadline } from './dialog';
+
+@Component({
+  imports: [GuiDialogHeadline],
+  template: `<gui-dialog-headline>Title</gui-dialog-headline>
+    <button type="button">ok</button>`,
+})
+class DialogContent {}
+
+function flush(): void {
+  TestBed.inject(ApplicationRef).tick();
+}
+
+describe('GuiDialog', () => {
+  it('opens a modal with role=dialog + aria-modal (Req 12.1, 14.1)', () => {
+    const ref = TestBed.inject(GuiDialog).open(DialogContent, {
+      ariaLabel: 'Test',
+    });
+    flush();
+    const surface = document.querySelector('.gui-dialog-container');
+    expect(surface?.getAttribute('role')).toBe('dialog');
+    expect(surface?.getAttribute('aria-modal')).toBe('true');
+    ref.close();
+    flush();
+    expect(document.querySelector('.gui-dialog-container')).toBeNull();
+  });
+
+  it('close(result) emits the result on closed (Req 16.2)', () => {
+    const ref = TestBed.inject(GuiDialog).open<string>(DialogContent);
+    let result: string | undefined;
+    ref.closed.subscribe((r) => (result = r));
+    flush();
+    ref.close('done');
+    flush();
+    expect(result).toBe('done');
+  });
+
+  it('restores focus to the opener on close (Req 12.7)', async () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const ref = TestBed.inject(GuiDialog).open(DialogContent, {
+      ariaLabel: 'x',
+    });
+    flush();
+    ref.close();
+    flush();
+    // CDK restores focus asynchronously after teardown.
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  it('throws when opened without content', () => {
+    expect(() =>
+      TestBed.inject(GuiDialog).open(null as never),
+    ).toThrowError(/component type or a TemplateRef/);
+  });
+
+  describe('fullScreen', () => {
+    class FakeMql {
+      constructor(public matches: boolean) {}
+      addEventListener(): void {}
+    }
+
+    function configureCompact(matches: boolean): void {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: MediaMatcher,
+            useValue: { matchMedia: () => new FakeMql(matches) },
+          },
+        ],
+      });
+    }
+
+    it('compact mode goes full-screen only on a compact viewport (Req 8.1)', () => {
+      configureCompact(true);
+      const ref = TestBed.inject(GuiDialog).open(DialogContent, {
+        fullScreen: 'compact',
+        ariaLabel: 'x',
+      });
+      flush();
+      expect(
+        document
+          .querySelector('.gui-dialog-container')
+          ?.hasAttribute('data-fullscreen'),
+      ).toBe(true);
+      ref.close();
+      flush();
+    });
+
+    it('compact mode stays basic on a wide viewport (Req 8.1)', () => {
+      configureCompact(false);
+      const ref = TestBed.inject(GuiDialog).open(DialogContent, {
+        fullScreen: 'compact',
+        ariaLabel: 'x',
+      });
+      flush();
+      expect(
+        document
+          .querySelector('.gui-dialog-container')
+          ?.hasAttribute('data-fullscreen'),
+      ).toBe(false);
+      ref.close();
+      flush();
+    });
+  });
+});

--- a/libs/ui/dialog/src/dialog.service.spec.ts
+++ b/libs/ui/dialog/src/dialog.service.spec.ts
@@ -63,9 +63,10 @@ describe('GuiDialog', () => {
   });
 
   describe('fullScreen', () => {
+    // GuiBreakpoint calls addEventListener via optional chaining, so the mock
+    // can omit it entirely.
     class FakeMql {
       constructor(public matches: boolean) {}
-      addEventListener(): void {}
     }
 
     function configureCompact(matches: boolean): void {

--- a/libs/ui/dialog/src/dialog.service.ts
+++ b/libs/ui/dialog/src/dialog.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, TemplateRef, inject } from '@angular/core';
+import { ComponentType } from '@angular/cdk/overlay';
+import { Dialog, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import {
+  GuiBreakpoint,
+  GuiDialogRef,
+  asArray,
+  normalizeModalConfig,
+  wrapDialogRef,
+} from '@ngguide/ui/overlay';
+import { GuiDialogConfig, GuiDialogFullScreen } from './dialog-config';
+import { GuiDialogContainer } from './dialog-container';
+
+const DEFAULT_MAX_WIDTH = 'min(560px, calc(100% - 48px))';
+
+/**
+ * Opens M3 dialogs imperatively over the headless CDK `Dialog` service
+ * (Req 16.2). Returns a {@link GuiDialogRef} whose `closed` observable emits the
+ * close result. Accepts either a component type or an inline `TemplateRef`
+ * (the CDK `Dialog.open` template overload). Full-screen selection (Req 8) is
+ * resolved against {@link GuiBreakpoint}.
+ */
+@Injectable({ providedIn: 'root' })
+export class GuiDialog {
+  private readonly cdkDialog = inject(Dialog);
+  private readonly breakpoint = inject(GuiBreakpoint);
+
+  open<R = unknown, D = unknown, C = unknown>(
+    content: ComponentType<C> | TemplateRef<C>,
+    config?: GuiDialogConfig<D>,
+  ): GuiDialogRef<R> {
+    if (content == null) {
+      throw new Error(
+        'GuiDialog.open() requires a component type or a TemplateRef.',
+      );
+    }
+
+    const fullScreen = this.resolveFullScreen(config?.fullScreen);
+    const cdkConfig: DialogConfig<D, DialogRef<R, C>> & {
+      guiFullScreen?: boolean;
+    } = {
+      ...normalizeModalConfig<D>(config),
+      container: GuiDialogContainer,
+      guiFullScreen: fullScreen,
+      panelClass: [
+        fullScreen ? 'gui-dialog-fullscreen-pane' : 'gui-dialog-pane',
+        ...asArray(config?.panelClass),
+      ],
+      maxWidth: fullScreen ? '100vw' : config?.maxWidth ?? DEFAULT_MAX_WIDTH,
+    };
+
+    const ref = this.cdkDialog.open<R, D, C>(content, cdkConfig);
+    return wrapDialogRef(ref);
+  }
+
+  private resolveFullScreen(mode: GuiDialogFullScreen = 'never'): boolean {
+    return mode === 'always' || (mode === 'compact' && this.breakpoint.isCompact());
+  }
+}

--- a/libs/ui/dialog/src/dialog.spec.ts
+++ b/libs/ui/dialog/src/dialog.spec.ts
@@ -85,9 +85,10 @@ describe('GuiDialogContainer', () => {
           {
             provide: MediaMatcher,
             useValue: {
+              // addEventListener is invoked via optional chaining, so it can
+              // be omitted from the mock.
               matchMedia: (q: string) => ({
                 matches: q.includes('prefers-reduced-motion'),
-                addEventListener: () => {},
               }),
             },
           },

--- a/libs/ui/dialog/src/dialog.spec.ts
+++ b/libs/ui/dialog/src/dialog.spec.ts
@@ -1,0 +1,106 @@
+import { ApplicationRef, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { GuiDialog } from './dialog.service';
+import {
+  GuiDialogActions,
+  GuiDialogContent,
+  GuiDialogFullscreenHeader,
+  GuiDialogHeadline,
+  GuiDialogIcon,
+} from './dialog';
+
+@Component({
+  imports: [
+    GuiDialogIcon,
+    GuiDialogHeadline,
+    GuiDialogContent,
+    GuiDialogActions,
+  ],
+  template: `
+    <gui-dialog-icon>!</gui-dialog-icon>
+    <gui-dialog-headline>Reset settings?</gui-dialog-headline>
+    <gui-dialog-content>This cannot be undone.</gui-dialog-content>
+    <gui-dialog-actions>
+      <button type="button">Cancel</button>
+      <button type="button">Reset</button>
+    </gui-dialog-actions>
+  `,
+})
+class BasicContent {}
+
+@Component({
+  imports: [GuiDialogFullscreenHeader],
+  template: `
+    <gui-dialog-fullscreen-header>
+      <button guiDialogClose type="button">Close</button>
+      Edit profile
+      <button guiDialogConfirm type="button">Save</button>
+    </gui-dialog-fullscreen-header>
+  `,
+})
+class FullscreenContent {}
+
+function flush(): void {
+  TestBed.inject(ApplicationRef).tick();
+}
+
+describe('GuiDialogContainer', () => {
+  it('renders the M3 anatomy slots (Req 7.1)', () => {
+    const ref = TestBed.inject(GuiDialog).open(BasicContent, {
+      ariaLabel: 'Reset',
+    });
+    flush();
+    const surface = document.querySelector('.gui-dialog-container');
+    expect(surface?.querySelector('gui-dialog-icon')).not.toBeNull();
+    expect(
+      surface?.querySelector('gui-dialog-headline')?.getAttribute('role'),
+    ).toBe('heading');
+    expect(surface?.querySelector('gui-dialog-content')).not.toBeNull();
+    expect(surface?.querySelector('gui-dialog-actions')).not.toBeNull();
+    ref.close();
+    flush();
+  });
+
+  it('marks the surface full-screen and renders the header (Req 8.1, 8.2)', () => {
+    const ref = TestBed.inject(GuiDialog).open(FullscreenContent, {
+      fullScreen: 'always',
+      ariaLabel: 'Edit',
+    });
+    flush();
+    const surface = document.querySelector('.gui-dialog-container');
+    expect(surface?.hasAttribute('data-fullscreen')).toBe(true);
+    expect(
+      surface?.querySelector('gui-dialog-fullscreen-header'),
+    ).not.toBeNull();
+    ref.close();
+    flush();
+  });
+
+  describe('reduced motion', () => {
+    it('disables the enter animation (Req 15.2)', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: MediaMatcher,
+            useValue: {
+              matchMedia: (q: string) => ({
+                matches: q.includes('prefers-reduced-motion'),
+                addEventListener: () => {},
+              }),
+            },
+          },
+        ],
+      });
+      const ref = TestBed.inject(GuiDialog).open(BasicContent, {
+        ariaLabel: 'x',
+      });
+      flush();
+      const surface = document.querySelector('.gui-dialog-container');
+      expect(surface?.classList.contains('gui-no-motion')).toBe(true);
+      ref.close();
+      flush();
+    });
+  });
+});

--- a/libs/ui/dialog/src/dialog.trigger.spec.ts
+++ b/libs/ui/dialog/src/dialog.trigger.spec.ts
@@ -1,0 +1,98 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiDialogTrigger } from './dialog.trigger';
+import { GuiDialogConfig } from './dialog-config';
+
+@Component({
+  imports: [GuiDialogTrigger],
+  template: `
+    <button type="button" [guiDialogTrigger]="tpl" [guiDialogConfig]="config()">
+      Open
+    </button>
+    <ng-template #tpl>
+      <p class="trigger-body">Inline content</p>
+    </ng-template>
+  `,
+})
+class TriggerHost {
+  readonly config = signal<GuiDialogConfig | undefined>({ ariaLabel: 'x' });
+}
+
+function flush(): void {
+  TestBed.inject(ApplicationRef).tick();
+}
+
+const ESCAPE = 27;
+
+/**
+ * CDK's `DialogRef` keys off the (deprecated) `keyCode`, which jsdom's
+ * constructor always leaves at 0 — real browsers populate it.
+ */
+function escape(): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Escape',
+    bubbles: true,
+  });
+  Object.defineProperty(event, 'keyCode', { get: () => ESCAPE });
+  return event;
+}
+
+describe('GuiDialogTrigger', () => {
+  function setup() {
+    const fixture = TestBed.createComponent(TriggerHost);
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector(
+      'button',
+    ) as HTMLButtonElement;
+    return { fixture, button };
+  }
+
+  it('opens the bound template on click (Req 7.2)', () => {
+    const { button } = setup();
+    button.dispatchEvent(new MouseEvent('click'));
+    flush();
+    expect(document.querySelector('.trigger-body')?.textContent).toContain(
+      'Inline content',
+    );
+  });
+
+  it('closes on Escape (Req 12.4)', () => {
+    const { button } = setup();
+    button.dispatchEvent(new MouseEvent('click'));
+    flush();
+    const container = document.querySelector('.gui-dialog-container');
+    expect(container).not.toBeNull();
+
+    container?.dispatchEvent(escape());
+    flush();
+    expect(document.querySelector('.gui-dialog-container')).toBeNull();
+  });
+
+  it('closes on scrim click (Req 12.5)', () => {
+    const { button } = setup();
+    button.dispatchEvent(new MouseEvent('click'));
+    flush();
+    const backdrop = document.querySelector(
+      '.cdk-overlay-backdrop',
+    ) as HTMLElement;
+    backdrop.dispatchEvent(new MouseEvent('click'));
+    flush();
+    expect(document.querySelector('.gui-dialog-container')).toBeNull();
+  });
+
+  it('disableClose suppresses Escape + scrim close (Req 12.4, 12.5)', () => {
+    const { fixture, button } = setup();
+    fixture.componentInstance.config.set({ ariaLabel: 'x', disableClose: true });
+    fixture.detectChanges();
+    button.dispatchEvent(new MouseEvent('click'));
+    flush();
+
+    document.querySelector('.gui-dialog-container')?.dispatchEvent(escape());
+    const backdrop = document.querySelector(
+      '.cdk-overlay-backdrop',
+    ) as HTMLElement;
+    backdrop.dispatchEvent(new MouseEvent('click'));
+    flush();
+    expect(document.querySelector('.gui-dialog-container')).not.toBeNull();
+  });
+});

--- a/libs/ui/dialog/src/dialog.trigger.ts
+++ b/libs/ui/dialog/src/dialog.trigger.ts
@@ -1,0 +1,34 @@
+import { Directive, TemplateRef, inject, input } from '@angular/core';
+import { GuiDialog } from './dialog.service';
+import { GuiDialogConfig } from './dialog-config';
+
+/**
+ * Declarative dialog opener (Req 7.2). Bind an inline `<ng-template>` to the
+ * `guiDialogTrigger` input; clicking the host opens it as a dialog via
+ * {@link GuiDialog}. Optional config is supplied through `guiDialogConfig`.
+ *
+ * ```html
+ * <button gui-button [guiDialogTrigger]="tpl">Open</button>
+ * <ng-template #tpl> … </ng-template>
+ * ```
+ */
+@Directive({
+  selector: '[guiDialogTrigger]',
+  host: { '(click)': 'open()' },
+})
+export class GuiDialogTrigger {
+  private readonly dialog = inject(GuiDialog);
+
+  /** The template rendered as the dialog content. */
+  readonly template = input.required<TemplateRef<unknown>>({
+    alias: 'guiDialogTrigger',
+  });
+  /** Optional dialog configuration. */
+  readonly config = input<GuiDialogConfig | undefined>(undefined, {
+    alias: 'guiDialogConfig',
+  });
+
+  protected open(): void {
+    this.dialog.open(this.template(), this.config());
+  }
+}

--- a/libs/ui/dialog/src/dialog.trigger.ts
+++ b/libs/ui/dialog/src/dialog.trigger.ts
@@ -24,9 +24,8 @@ export class GuiDialogTrigger {
     alias: 'guiDialogTrigger',
   });
   /** Optional dialog configuration. */
-  readonly config = input<GuiDialogConfig | undefined>(undefined, {
-    alias: 'guiDialogConfig',
-  });
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  readonly config = input<GuiDialogConfig | undefined>(undefined, { alias: 'guiDialogConfig' });
 
   protected open(): void {
     this.dialog.open(this.template(), this.config());

--- a/libs/ui/dialog/src/dialog.ts
+++ b/libs/ui/dialog/src/dialog.ts
@@ -1,0 +1,153 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+/**
+ * M3 dialog anatomy slot components. Compose them inside the content passed to
+ * {@link GuiDialog.open} to lay out the standard basic-dialog regions
+ * (Req 7.1): an optional icon, the headline (`h2`), the supporting content
+ * (scrollable), and the end-aligned action buttons. For full-screen dialogs use
+ * {@link GuiDialogFullscreenHeader} as the top bar (Req 8.2).
+ */
+
+/** Optional leading icon, centered above the headline (24dp, secondary). */
+@Component({
+  selector: 'gui-dialog-icon',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: { class: 'gui-dialog-icon' },
+  styles: [
+    `
+      :host {
+        display: flex;
+        align-self: center;
+        justify-content: center;
+        margin: 24px 24px 16px;
+        font-size: 24px;
+        line-height: 24px;
+        color: var(--md-sys-color-secondary);
+      }
+    `,
+  ],
+})
+export class GuiDialogIcon {}
+
+/** Dialog headline, exposed as a level-2 heading (Req 7.1, 14). */
+@Component({
+  selector: 'gui-dialog-headline',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: { class: 'gui-dialog-headline', role: 'heading', 'aria-level': '2' },
+  styles: [
+    `
+      :host {
+        display: block;
+        padding: 24px 24px 16px;
+        color: var(--md-sys-color-on-surface);
+        font-family: var(--md-sys-typescale-headline-small-font);
+        font-size: var(--md-sys-typescale-headline-small-size);
+        font-weight: var(--md-sys-typescale-headline-small-weight);
+        line-height: var(--md-sys-typescale-headline-small-line-height);
+        letter-spacing: var(--md-sys-typescale-headline-small-tracking);
+      }
+      /* When an icon precedes the headline, M3 centers the headline. */
+      :host-context(gui-dialog-icon + *) {
+        text-align: center;
+      }
+    `,
+  ],
+})
+export class GuiDialogHeadline {}
+
+/** Scrollable supporting content region (body-medium). */
+@Component({
+  selector: 'gui-dialog-content',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: { class: 'gui-dialog-content' },
+  styles: [
+    `
+      :host {
+        display: block;
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding: 0 24px;
+        color: var(--md-sys-color-on-surface-variant);
+        font-family: var(--md-sys-typescale-body-medium-font);
+        font-size: var(--md-sys-typescale-body-medium-size);
+        font-weight: var(--md-sys-typescale-body-medium-weight);
+        line-height: var(--md-sys-typescale-body-medium-line-height);
+        letter-spacing: var(--md-sys-typescale-body-medium-tracking);
+      }
+    `,
+  ],
+})
+export class GuiDialogContent {}
+
+/** End-aligned action buttons region (up to three text buttons, Req 7.1). */
+@Component({
+  selector: 'gui-dialog-actions',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: { class: 'gui-dialog-actions' },
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 8px;
+        padding: 24px;
+      }
+    `,
+  ],
+})
+export class GuiDialogActions {}
+
+/**
+ * Full-screen dialog top bar (Req 8.2): a leading close/back affordance, the
+ * title, and an optional trailing confirm action. Project the close control
+ * into `[guiDialogClose]` and the confirm control into `[guiDialogConfirm]`.
+ */
+@Component({
+  selector: 'gui-dialog-fullscreen-header',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span class="gui-dialog-fs-leading"
+      ><ng-content select="[guiDialogClose]"
+    /></span>
+    <span class="gui-dialog-fs-title"><ng-content /></span>
+    <span class="gui-dialog-fs-confirm"
+      ><ng-content select="[guiDialogConfirm]"
+    /></span>
+  `,
+  host: { class: 'gui-dialog-fullscreen-header' },
+  styles: [
+    `
+      :host {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        height: 56px;
+        padding: 0 16px;
+        flex: 0 0 auto;
+        background-color: var(--md-sys-color-surface);
+        color: var(--md-sys-color-on-surface);
+      }
+      .gui-dialog-fs-title {
+        flex: 1 1 auto;
+        font-family: var(--md-sys-typescale-title-large-font);
+        font-size: var(--md-sys-typescale-title-large-size);
+        font-weight: var(--md-sys-typescale-title-large-weight);
+        line-height: var(--md-sys-typescale-title-large-line-height);
+        letter-spacing: var(--md-sys-typescale-title-large-tracking);
+      }
+      .gui-dialog-fs-leading,
+      .gui-dialog-fs-confirm {
+        display: flex;
+        align-items: center;
+        flex: 0 0 auto;
+      }
+    `,
+  ],
+})
+export class GuiDialogFullscreenHeader {}

--- a/libs/ui/dialog/src/index.ts
+++ b/libs/ui/dialog/src/index.ts
@@ -1,0 +1,5 @@
+export * from './dialog-config';
+export * from './dialog';
+export * from './dialog.service';
+export * from './dialog.trigger';
+export { GuiDialogContainer } from './dialog-container';

--- a/libs/ui/divider/ng-package.json
+++ b/libs/ui/divider/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/divider/src/divider.css
+++ b/libs/ui/divider/src/divider.css
@@ -1,0 +1,35 @@
+/* M3 divider: a 1dp full-bleed rule in outline-variant. The border carries the
+   line so inset is expressed as margin on the leading / both edges. */
+
+:host {
+  display: block;
+  box-sizing: border-box;
+  border: none;
+  background-color: var(--md-sys-color-outline-variant);
+  flex-shrink: 0;
+}
+
+/* --- Horizontal (default): 1dp tall, full width --- */
+:host([data-orientation='horizontal']) {
+  width: auto;
+  height: 1px;
+}
+:host([data-orientation='horizontal'][data-inset='inset']) {
+  margin-inline-start: 16px;
+}
+:host([data-orientation='horizontal'][data-inset='middle-inset']) {
+  margin-inline: 16px;
+}
+
+/* --- Vertical: 1dp wide, full height --- */
+:host([data-orientation='vertical']) {
+  width: 1px;
+  height: auto;
+  align-self: stretch;
+}
+:host([data-orientation='vertical'][data-inset='inset']) {
+  margin-block-start: 16px;
+}
+:host([data-orientation='vertical'][data-inset='middle-inset']) {
+  margin-block: 16px;
+}

--- a/libs/ui/divider/src/divider.spec.ts
+++ b/libs/ui/divider/src/divider.spec.ts
@@ -1,0 +1,45 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiDivider, GuiDividerInset } from './divider';
+
+@Component({
+  imports: [GuiDivider],
+  template: `<gui-divider
+    [inset]="inset()"
+    [orientation]="orientation()"
+  ></gui-divider>`,
+})
+class DividerHost {
+  readonly inset = signal<GuiDividerInset>('none');
+  readonly orientation = signal<'horizontal' | 'vertical'>('horizontal');
+}
+
+describe('GuiDivider', () => {
+  function render(): HTMLElement {
+    const fixture = TestBed.createComponent(DividerHost);
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('gui-divider');
+  }
+
+  it('exposes role=separator and is not focusable (Req 14.5)', () => {
+    const el = render();
+    expect(el.getAttribute('role')).toBe('separator');
+    expect(el.hasAttribute('tabindex')).toBe(false);
+  });
+
+  it('reflects orientation onto aria-orientation (Req 3.3)', () => {
+    const fixture = TestBed.createComponent(DividerHost);
+    fixture.componentInstance.orientation.set('vertical');
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('gui-divider');
+    expect(el.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('reflects inset onto data-inset (Req 3.2)', () => {
+    const fixture = TestBed.createComponent(DividerHost);
+    fixture.componentInstance.inset.set('middle-inset');
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('gui-divider');
+    expect(el.getAttribute('data-inset')).toBe('middle-inset');
+  });
+});

--- a/libs/ui/divider/src/divider.ts
+++ b/libs/ui/divider/src/divider.ts
@@ -1,0 +1,35 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+} from '@angular/core';
+
+export type GuiDividerInset = 'none' | 'inset' | 'middle-inset';
+
+/**
+ * M3 divider — a thin (1dp) `outline-variant` rule separating content within
+ * the same hierarchy (Req 3). Non-interactive and exposed as a `separator` to
+ * assistive tech (Req 14.5). Inset variants (Req 3.2): `inset` indents the
+ * leading edge by 16dp (aligning the rule with text after a leading element),
+ * `middle-inset` indents both edges by 16dp. Set `orientation="vertical"` to
+ * divide side-by-side content (Req 3.3).
+ */
+@Component({
+  selector: 'gui-divider',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '',
+  styleUrl: './divider.css',
+  host: {
+    class: 'gui-divider',
+    role: 'separator',
+    '[attr.aria-orientation]': 'orientation()',
+    '[attr.data-inset]': 'inset()',
+    '[attr.data-orientation]': 'orientation()',
+  },
+})
+export class GuiDivider {
+  /** Inset treatment (Req 3.2). */
+  readonly inset = input<GuiDividerInset>('none');
+  /** Divider direction (Req 3.3). */
+  readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
+}

--- a/libs/ui/divider/src/index.ts
+++ b/libs/ui/divider/src/index.ts
@@ -1,0 +1,1 @@
+export * from './divider';

--- a/libs/ui/list/ng-package.json
+++ b/libs/ui/list/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/list/src/index.ts
+++ b/libs/ui/list/src/index.ts
@@ -1,0 +1,3 @@
+export * from './list';
+export * from './list-item';
+export { type GuiListMode } from './list-context';

--- a/libs/ui/list/src/list-context.ts
+++ b/libs/ui/list/src/list-context.ts
@@ -1,0 +1,24 @@
+import { InjectionToken, Signal } from '@angular/core';
+
+/** Semantics the list operates under (Req 4/5 action vs Req 6 selection). */
+export type GuiListMode = 'action' | 'listbox';
+
+/**
+ * Minimal contract a {@link GuiListItem} needs from its parent list, exposed
+ * through a DI token so the item never imports the list class directly (avoids
+ * a circular module dependency).
+ */
+export interface GuiListContext {
+  readonly mode: Signal<GuiListMode>;
+  readonly multiselectable: Signal<boolean>;
+  /** Toggle selection of an item, honoring single vs multi selection. */
+  select(item: GuiListSelectable): void;
+}
+
+/** The slice of a list item the parent toggles selection on. */
+export interface GuiListSelectable {
+  readonly selected: { (): boolean; set(value: boolean): void };
+  readonly disabled: Signal<boolean>;
+}
+
+export const GUI_LIST = new InjectionToken<GuiListContext>('GUI_LIST');

--- a/libs/ui/list/src/list-item.css
+++ b/libs/ui/list/src/list-item.css
@@ -1,0 +1,95 @@
+/* M3 list item. 16dp leading/trailing insets; height driven by line count
+   (56 / 72 / 88dp). Headline = body-large, supporting = body-medium, trailing
+   supporting text = label-small. Selected rows use the secondary-container. */
+
+:host {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  gap: 16px;
+  padding-inline: 16px;
+  min-height: 56px;
+  color: var(--md-sys-color-on-surface);
+  background-color: transparent;
+}
+
+:host([data-lines='2']) {
+  min-height: 72px;
+}
+:host([data-lines='3']) {
+  min-height: 88px;
+  align-items: flex-start;
+  padding-block: 12px;
+}
+
+/* --- Selected option: secondary-container (Req 6.3) --- */
+:host([data-selected]) {
+  background-color: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+/* --- Disabled option: dimmed but still present (Req 6.6) --- */
+:host([aria-disabled='true']) {
+  opacity: 0.38;
+  pointer-events: none;
+}
+
+:host([tabindex]) {
+  cursor: pointer;
+  outline: none;
+}
+
+/* --- Leading slot: holds a 24dp icon / 40dp avatar / 56dp image --- */
+.gui-list-item-leading {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+.gui-list-item-leading:empty {
+  display: none;
+}
+
+/* --- Body: headline + supporting text stacked --- */
+.gui-list-item-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.gui-list-item-headline {
+  font-family: var(--md-sys-typescale-body-large-font);
+  font-size: var(--md-sys-typescale-body-large-size);
+  font-weight: var(--md-sys-typescale-body-large-weight);
+  line-height: var(--md-sys-typescale-body-large-line-height);
+  letter-spacing: var(--md-sys-typescale-body-large-tracking);
+}
+
+.gui-list-item-supporting {
+  font-family: var(--md-sys-typescale-body-medium-font);
+  font-size: var(--md-sys-typescale-body-medium-size);
+  font-weight: var(--md-sys-typescale-body-medium-weight);
+  line-height: var(--md-sys-typescale-body-medium-line-height);
+  letter-spacing: var(--md-sys-typescale-body-medium-tracking);
+  color: var(--md-sys-color-on-surface-variant);
+}
+.gui-list-item-supporting:empty {
+  display: none;
+}
+
+/* --- Trailing slot: label-small supporting text or a control --- */
+.gui-list-item-trailing {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  font-family: var(--md-sys-typescale-label-small-font);
+  font-size: var(--md-sys-typescale-label-small-size);
+  font-weight: var(--md-sys-typescale-label-small-weight);
+  line-height: var(--md-sys-typescale-label-small-line-height);
+  letter-spacing: var(--md-sys-typescale-label-small-tracking);
+  color: var(--md-sys-color-on-surface-variant);
+}
+.gui-list-item-trailing:empty {
+  display: none;
+}

--- a/libs/ui/list/src/list-item.css
+++ b/libs/ui/list/src/list-item.css
@@ -39,6 +39,20 @@
   outline: none;
 }
 
+/* --- Keyboard focus indicator (Req 14.4). GuiFocusRingDirective adds
+   `.gui-focus-visible` on keyboard focus (covering the roving programmatic
+   focus of listbox options). Inset by the ring thickness so it stays within the
+   full-bleed row instead of being clipped by the list's bounds; uses the host
+   content color so it contrasts on both plain and selected (secondary-
+   container) rows. Disabled options never show the ring. --- */
+:host(.gui-focus-visible) {
+  outline: var(--md-sys-state-focus-indicator-thickness) solid currentColor;
+  outline-offset: calc(-1 * var(--md-sys-state-focus-indicator-thickness));
+}
+:host([aria-disabled='true'].gui-focus-visible) {
+  outline: none;
+}
+
 /* --- Leading slot: holds a 24dp icon / 40dp avatar / 56dp image --- */
 .gui-list-item-leading {
   display: flex;
@@ -64,8 +78,15 @@
   font-weight: var(--md-sys-typescale-body-large-weight);
   line-height: var(--md-sys-typescale-body-large-line-height);
   letter-spacing: var(--md-sys-typescale-body-large-tracking);
+  /* The headline is a single line; it truncates with an ellipsis (Req 4.4). */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
+/* Supporting text is clamped to the row's reserved lines (headline takes one),
+   truncating with an ellipsis instead of growing the row (Req 4.4): 2-line rows
+   reserve one supporting line, 3-line rows reserve two. */
 .gui-list-item-supporting {
   font-family: var(--md-sys-typescale-body-medium-font);
   font-size: var(--md-sys-typescale-body-medium-size);
@@ -73,6 +94,14 @@
   line-height: var(--md-sys-typescale-body-medium-line-height);
   letter-spacing: var(--md-sys-typescale-body-medium-tracking);
   color: var(--md-sys-color-on-surface-variant);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+:host([data-lines='3']) .gui-list-item-supporting {
+  -webkit-line-clamp: 2;
 }
 .gui-list-item-supporting:empty {
   display: none;

--- a/libs/ui/list/src/list-item.spec.ts
+++ b/libs/ui/list/src/list-item.spec.ts
@@ -1,0 +1,57 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiList } from './list';
+import { GuiListItem } from './list-item';
+import { GuiListMode } from './list-context';
+
+@Component({
+  imports: [GuiList, GuiListItem],
+  template: `
+    <gui-list [mode]="mode()">
+      <gui-list-item [lines]="lines()" [disabled]="disabled()">
+        Headline
+        <span guiListItemSupporting>Supporting</span>
+      </gui-list-item>
+    </gui-list>
+  `,
+})
+class ItemHost {
+  readonly mode = signal<GuiListMode>('action');
+  readonly lines = signal<1 | 2 | 3>(1);
+  readonly disabled = signal(false);
+}
+
+describe('GuiListItem', () => {
+  it('reflects line count onto data-lines (Req 4.2)', () => {
+    const fixture = TestBed.createComponent(ItemHost);
+    fixture.componentInstance.lines.set(3);
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('gui-list-item');
+    expect(item.getAttribute('data-lines')).toBe('3');
+  });
+
+  it('action mode exposes role=listitem (Req 5)', () => {
+    const fixture = TestBed.createComponent(ItemHost);
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('gui-list-item');
+    expect(item.getAttribute('role')).toBe('listitem');
+  });
+
+  it('listbox mode exposes role=option + aria-selected (Req 6.1)', () => {
+    const fixture = TestBed.createComponent(ItemHost);
+    fixture.componentInstance.mode.set('listbox');
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('gui-list-item');
+    expect(item.getAttribute('role')).toBe('option');
+    expect(item.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('disabled item exposes aria-disabled (Req 6.6)', () => {
+    const fixture = TestBed.createComponent(ItemHost);
+    fixture.componentInstance.mode.set('listbox');
+    fixture.componentInstance.disabled.set(true);
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('gui-list-item');
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/libs/ui/list/src/list-item.spec.ts
+++ b/libs/ui/list/src/list-item.spec.ts
@@ -54,4 +54,14 @@ describe('GuiListItem', () => {
     const item = fixture.nativeElement.querySelector('gui-list-item');
     expect(item.getAttribute('aria-disabled')).toBe('true');
   });
+
+  it('carries the focus-ring directive for a keyboard focus indicator (Req 14.4)', () => {
+    const fixture = TestBed.createComponent(ItemHost);
+    fixture.componentInstance.mode.set('listbox');
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('gui-list-item');
+    // GuiFocusRingDirective applies `.gui-focus-ring`; it toggles
+    // `.gui-focus-visible` (and thus the outline) on keyboard focus.
+    expect(item.classList.contains('gui-focus-ring')).toBe(true);
+  });
 });

--- a/libs/ui/list/src/list-item.ts
+++ b/libs/ui/list/src/list-item.ts
@@ -1,0 +1,105 @@
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  inject,
+  input,
+  model,
+  signal,
+} from '@angular/core';
+import { GUI_LIST, GuiListMode } from './list-context';
+
+/**
+ * A single M3 list row. Anatomy slots projected by the consumer:
+ * `[guiListItemLeading]` (icon 24 / avatar 40 / image 56dp), the default slot
+ * (headline, `body-large`), `[guiListItemSupporting]` (`body-medium`), and
+ * `[guiListItemTrailing]` (`label-small` text or a control). Height follows the
+ * `lines` count: 56 / 72 / 88dp (Req 4.2).
+ *
+ * Behavior depends on the parent {@link GuiList} mode (Req 6.5):
+ * - `action` — the row hosts its own native control(s); the item carries
+ *   `role="listitem"` (or no role when `interactive`, letting the inner control
+ *   own semantics).
+ * - `listbox` — the item is a selectable `role="option"` with `aria-selected`,
+ *   reached through the list's roving focus.
+ */
+@Component({
+  selector: 'gui-list-item',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span class="gui-list-item-leading"><ng-content select="[guiListItemLeading]" /></span>
+    <span class="gui-list-item-body">
+      <span class="gui-list-item-headline"><ng-content /></span>
+      <span class="gui-list-item-supporting"
+        ><ng-content select="[guiListItemSupporting]"
+      /></span>
+    </span>
+    <span class="gui-list-item-trailing"
+      ><ng-content select="[guiListItemTrailing]"
+    /></span>
+  `,
+  styleUrl: './list-item.css',
+  host: {
+    class: 'gui-list-item',
+    '[attr.data-lines]': 'lines()',
+    '[attr.role]': 'role()',
+    '[attr.aria-selected]': 'isListbox() ? (selected() ? "true" : "false") : null',
+    '[attr.aria-disabled]': 'disabled() ? "true" : null',
+    '[attr.data-selected]': 'selected() ? "" : null',
+    '[attr.tabindex]': 'isListbox() ? (active() ? 0 : -1) : null',
+    '(click)': 'onClick()',
+  },
+})
+export class GuiListItem {
+  /** Visual density: 1, 2 or 3 lines → 56 / 72 / 88dp (Req 4.2). */
+  readonly lines = input<1 | 2 | 3>(1);
+  /** Action mode: the row is itself interactive (suppresses `role=listitem`). */
+  readonly interactive = input(false, { transform: booleanAttribute });
+  /** Listbox mode: the option can be selected (Req 6.1). */
+  readonly selectable = input(false, { transform: booleanAttribute });
+  /** Two-way selection state (Req 6.3). */
+  readonly selected = model(false);
+  /** Disabled options stay focusable but are not activatable (Req 6.6). */
+  readonly disabled = input(false, { transform: booleanAttribute });
+
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly list = inject(GUI_LIST, { optional: true });
+
+  /** Whether this option currently holds the list's single tab stop. */
+  private readonly activeState = signal(false);
+  protected readonly active = this.activeState.asReadonly();
+
+  protected readonly mode = computed<GuiListMode>(
+    () => this.list?.mode() ?? 'action',
+  );
+  protected readonly isListbox = computed(() => this.mode() === 'listbox');
+  protected readonly role = computed(() => {
+    if (this.isListbox()) {
+      return 'option';
+    }
+    return this.interactive() ? null : 'listitem';
+  });
+
+  /** {@link FocusableOption}: move DOM focus to this row (roving focus). */
+  focus(): void {
+    this.host.nativeElement.focus();
+  }
+
+  /** {@link FocusableOption}: type-ahead label is the visible text. */
+  getLabel(): string {
+    return this.host.nativeElement.textContent?.trim() ?? '';
+  }
+
+  /** Called by the list to grant/withdraw the roving tab stop. */
+  setActive(active: boolean): void {
+    this.activeState.set(active);
+  }
+
+  protected onClick(): void {
+    if (this.isListbox()) {
+      this.list?.select(this);
+    }
+  }
+}

--- a/libs/ui/list/src/list-item.ts
+++ b/libs/ui/list/src/list-item.ts
@@ -9,6 +9,7 @@ import {
   model,
   signal,
 } from '@angular/core';
+import { GuiFocusRingDirective } from '@ngguide/ui/interaction';
 import { GUI_LIST, GuiListMode } from './list-context';
 
 /**
@@ -41,6 +42,12 @@ import { GUI_LIST, GuiListMode } from './list-context';
     /></span>
   `,
   styleUrl: './list-item.css',
+  // Keyboard focus indicator (Req 14.4): GuiFocusRingDirective marks keyboard
+  // focus with `.gui-focus-visible` via CDK FocusMonitor, which also covers the
+  // roving programmatic focus of a listbox option. The ring visual lives in
+  // list-item.css. Non-focusable rows (action items with no tabindex) never
+  // receive host focus, so it shows only on selectable/roving options.
+  hostDirectives: [GuiFocusRingDirective],
   host: {
     class: 'gui-list-item',
     '[attr.data-lines]': 'lines()',

--- a/libs/ui/list/src/list.css
+++ b/libs/ui/list/src/list.css
@@ -1,0 +1,16 @@
+/* M3 list container: a vertical stack on the `surface` color. Rows own their
+   own padding / dividers; the list only provides the surface and layout. */
+
+:host {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: 100%;
+  padding-block: 8px;
+  background-color: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+}
+
+:host(:focus-visible) {
+  outline: none;
+}

--- a/libs/ui/list/src/list.spec.ts
+++ b/libs/ui/list/src/list.spec.ts
@@ -1,0 +1,123 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiList } from './list';
+import { GuiListItem } from './list-item';
+
+@Component({
+  imports: [GuiList, GuiListItem],
+  template: `
+    <gui-list mode="listbox" [multiselectable]="multi()">
+      <gui-list-item selectable>Apple</gui-list-item>
+      <gui-list-item selectable>Banana</gui-list-item>
+      <gui-list-item selectable>Cherry</gui-list-item>
+    </gui-list>
+  `,
+})
+class ListboxHost {
+  readonly multi = signal(false);
+}
+
+@Component({
+  imports: [GuiList, GuiListItem],
+  template: `
+    <gui-list mode="action">
+      <gui-list-item><button>One</button></gui-list-item>
+      <gui-list-item><button>Two</button></gui-list-item>
+    </gui-list>
+  `,
+})
+class ActionHost {}
+
+function flush(): void {
+  TestBed.inject(ApplicationRef).tick();
+}
+
+const ENTER = 13;
+const ARROW_DOWN = 40;
+
+/**
+ * Build a keydown event. CDK's `ListKeyManager` keys off the (deprecated)
+ * `keyCode`, which jsdom's constructor always leaves at 0 — real browsers
+ * populate it — so the tests set it explicitly.
+ */
+function keydown(key: string, keyCode: number): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true });
+  Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+  return event;
+}
+
+describe('GuiList (listbox)', () => {
+  function setup(multi = false) {
+    const fixture = TestBed.createComponent(ListboxHost);
+    fixture.componentInstance.multi.set(multi);
+    fixture.detectChanges();
+    flush();
+    const list = fixture.nativeElement.querySelector('gui-list') as HTMLElement;
+    const items = Array.from(
+      fixture.nativeElement.querySelectorAll('gui-list-item'),
+    ) as HTMLElement[];
+    return { fixture, list, items };
+  }
+
+  it('seeds a single roving tab stop on the first option (Req 6.2)', () => {
+    const { items } = setup();
+    expect(items[0].getAttribute('tabindex')).toBe('0');
+    expect(items[1].getAttribute('tabindex')).toBe('-1');
+    expect(items[2].getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('moves the tab stop with ArrowDown (Req 6.2)', () => {
+    const { fixture, list, items } = setup();
+    list.dispatchEvent(keydown('ArrowDown', ARROW_DOWN));
+    fixture.detectChanges();
+    expect(items[0].getAttribute('tabindex')).toBe('-1');
+    expect(items[1].getAttribute('tabindex')).toBe('0');
+  });
+
+  it('toggles aria-selected on Enter; single-select clears the previous (Req 6.3)', () => {
+    const { fixture, list, items } = setup();
+    // Select the first (active) option.
+    list.dispatchEvent(keydown('Enter', ENTER));
+    fixture.detectChanges();
+    expect(items[0].getAttribute('aria-selected')).toBe('true');
+
+    // Move down and select the second; first clears (single select).
+    list.dispatchEvent(keydown('ArrowDown', ARROW_DOWN));
+    list.dispatchEvent(keydown('Enter', ENTER));
+    fixture.detectChanges();
+    expect(items[1].getAttribute('aria-selected')).toBe('true');
+    expect(items[0].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('allows multiple selections when multiselectable (Req 6.3)', () => {
+    const { fixture, list, items } = setup(true);
+    list.dispatchEvent(keydown('Enter', ENTER));
+    list.dispatchEvent(keydown('ArrowDown', ARROW_DOWN));
+    list.dispatchEvent(keydown('Enter', ENTER));
+    fixture.detectChanges();
+    expect(items[0].getAttribute('aria-selected')).toBe('true');
+    expect(items[1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('toggles selection on click (Req 6.3)', () => {
+    const { fixture, items } = setup();
+    items[2].dispatchEvent(new MouseEvent('click'));
+    fixture.detectChanges();
+    expect(items[2].getAttribute('aria-selected')).toBe('true');
+  });
+});
+
+describe('GuiList (action)', () => {
+  it('is a plain list with no roving tab stops (Req 5)', () => {
+    const fixture = TestBed.createComponent(ActionHost);
+    fixture.detectChanges();
+    flush();
+    const list = fixture.nativeElement.querySelector('gui-list') as HTMLElement;
+    const items = Array.from(
+      fixture.nativeElement.querySelectorAll('gui-list-item'),
+    ) as HTMLElement[];
+    expect(list.getAttribute('role')).toBe('list');
+    expect(items[0].getAttribute('role')).toBe('listitem');
+    expect(items[0].hasAttribute('tabindex')).toBe(false);
+  });
+});

--- a/libs/ui/list/src/list.ts
+++ b/libs/ui/list/src/list.ts
@@ -1,0 +1,132 @@
+import {
+  afterNextRender,
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  contentChildren,
+  effect,
+  forwardRef,
+  inject,
+  input,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subscription } from 'rxjs';
+import {
+  FocusKeyManager,
+  FocusableOption,
+  createRovingFocus,
+} from '@ngguide/ui/interaction';
+import { GUI_LIST, GuiListContext, GuiListMode } from './list-context';
+import { GuiListItem } from './list-item';
+
+/**
+ * M3 list container. One component serves two ARIA patterns via the `mode`
+ * input (Req 6.5):
+ * - `action` (default) — a plain `role="list"` whose rows host their own native
+ *   controls; keyboard order is the natural Tab order, no roving focus.
+ * - `listbox` — a `role="listbox"` with roving focus (single Tab stop,
+ *   arrow / Home / End / type-ahead) and selection toggled with Enter / Space
+ *   or click (Req 6.1–6.3). `multiselectable` allows more than one selected
+ *   option and sets `aria-multiselectable`.
+ */
+@Component({
+  selector: 'gui-list',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  styleUrl: './list.css',
+  host: {
+    class: 'gui-list',
+    '[attr.role]': 'mode() === "listbox" ? "listbox" : "list"',
+    '[attr.aria-multiselectable]':
+      'mode() === "listbox" ? (multiselectable() ? "true" : "false") : null',
+    '(keydown)': 'onKeydown($event)',
+  },
+  providers: [{ provide: GUI_LIST, useExisting: forwardRef(() => GuiList) }],
+})
+export class GuiList implements GuiListContext {
+  readonly mode = input<GuiListMode>('action');
+  readonly multiselectable = input(false, { transform: booleanAttribute });
+
+  private readonly items = contentChildren(forwardRef(() => GuiListItem));
+  private readonly destroyRef = inject(DestroyRef);
+  // Typed over the CDK `FocusableOption`: `GuiListItem` cannot be the type
+  // argument directly because its `disabled` signal input collides with
+  // `FocusableOption.disabled?: boolean` (same constraint as the chip set).
+  private manager?: FocusKeyManager<FocusableOption>;
+  private changeSub?: Subscription;
+
+  constructor() {
+    afterNextRender(() => {
+      if (this.mode() === 'listbox') {
+        this.rebuildManager();
+      }
+    });
+
+    // The FocusKeyManager is built over a static snapshot, so rebuild when the
+    // projected items change (listbox mode only).
+    effect(() => {
+      this.items();
+      if (this.manager && this.mode() === 'listbox') {
+        this.rebuildManager();
+      }
+    });
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (this.mode() !== 'listbox') {
+      return;
+    }
+    const key = event.key;
+    if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+      const active = this.manager?.activeItem as GuiListItem | null;
+      if (active) {
+        event.preventDefault();
+        this.select(active);
+      }
+      return;
+    }
+    this.manager?.onKeydown(event);
+  }
+
+  /** Toggle selection of an option, honoring single vs multi (Req 6.3). */
+  select(item: GuiListItem): void {
+    if (item.disabled()) {
+      return;
+    }
+    const next = !item.selected();
+    if (next && !this.multiselectable()) {
+      for (const other of this.items()) {
+        if (other !== item) {
+          other.selected.set(false);
+        }
+      }
+    }
+    item.selected.set(next);
+  }
+
+  private rebuildManager(): void {
+    this.changeSub?.unsubscribe();
+    const items = this.items();
+    this.manager = createRovingFocus(
+      items as readonly FocusableOption[],
+      { orientation: 'vertical' },
+      // Disabled options stay reachable (M3 keeps them discoverable, Req 6.6).
+    ).skipPredicate(() => false);
+
+    // Mirror the manager's active index onto each item so exactly one option
+    // carries the roving tab stop (tabindex=0).
+    const syncActive = (index: number | null) => {
+      items.forEach((item, i) => item.setActive(i === index));
+    };
+    this.changeSub = this.manager.change
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(syncActive);
+
+    // Seed the first option as the initial tab stop without stealing focus.
+    if (items.length > 0) {
+      this.manager.updateActiveItem(0);
+      syncActive(0);
+    }
+  }
+}

--- a/libs/ui/overlay/src/breakpoint.spec.ts
+++ b/libs/ui/overlay/src/breakpoint.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { GuiBreakpoint } from './breakpoint';
+
+/** Controllable MediaQueryList stand-in. */
+class FakeMediaQueryList {
+  matches = false;
+  private handlers: Array<(e: { matches: boolean }) => void> = [];
+
+  addEventListener(
+    _type: string,
+    handler: (e: { matches: boolean }) => void,
+  ): void {
+    this.handlers.push(handler);
+  }
+
+  /** Simulate the viewport crossing the breakpoint at runtime. */
+  emit(matches: boolean): void {
+    this.matches = matches;
+    for (const handler of this.handlers) {
+      handler({ matches });
+    }
+  }
+}
+
+describe('GuiBreakpoint', () => {
+  let mql: FakeMediaQueryList;
+
+  function configure(initialMatches: boolean): GuiBreakpoint {
+    mql = new FakeMediaQueryList();
+    mql.matches = initialMatches;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MediaMatcher, useValue: { matchMedia: () => mql } },
+      ],
+    });
+    return TestBed.inject(GuiBreakpoint);
+  }
+
+  it('reflects the initial MediaQueryList.matches value', () => {
+    expect(configure(true).isCompact()).toBe(true);
+    TestBed.resetTestingModule();
+    expect(configure(false).isCompact()).toBe(false);
+  });
+
+  it('updates the signal when the viewport crosses the breakpoint', () => {
+    const svc = configure(false);
+    expect(svc.isCompact()).toBe(false);
+
+    mql.emit(true);
+    expect(svc.isCompact()).toBe(true);
+
+    mql.emit(false);
+    expect(svc.isCompact()).toBe(false);
+  });
+});

--- a/libs/ui/overlay/src/breakpoint.ts
+++ b/libs/ui/overlay/src/breakpoint.ts
@@ -1,0 +1,31 @@
+import { Injectable, Signal, inject, signal } from '@angular/core';
+import { MediaMatcher } from '@angular/cdk/layout';
+
+/**
+ * Exposes whether the viewport is in M3's **compact** window class
+ * (`< 600dp`) as a reactive signal, so components that must branch on window
+ * size — full-screen-dialog auto-selection (Req 8) and carousel full-screen
+ * orientation (Req 11.6) — share one source of truth (Req 16.3).
+ *
+ * Built on CDK's {@link MediaMatcher}, which is SSR-safe: on the server it
+ * returns a no-op `MediaQueryList` whose `.matches` is `false`, so the initial
+ * (non-compact) layout renders without touching `window.matchMedia`. The
+ * `change` listener keeps the signal live when the viewport crosses the
+ * breakpoint at runtime. Mirrors `GuiReducedMotion`.
+ */
+@Injectable({ providedIn: 'root' })
+export class GuiBreakpoint {
+  private readonly mql = inject(MediaMatcher).matchMedia(
+    '(max-width: 599.98px)',
+  );
+  private readonly compact = signal(this.mql.matches);
+
+  /** `true` when the viewport is in the compact window class (`< 600dp`). */
+  readonly isCompact: Signal<boolean> = this.compact.asReadonly();
+
+  constructor() {
+    this.mql.addEventListener?.('change', (event) =>
+      this.compact.set(event.matches),
+    );
+  }
+}

--- a/libs/ui/overlay/src/index.ts
+++ b/libs/ui/overlay/src/index.ts
@@ -1,1 +1,2 @@
 export * from './picker-overlay';
+export * from './breakpoint';

--- a/libs/ui/overlay/src/index.ts
+++ b/libs/ui/overlay/src/index.ts
@@ -1,2 +1,3 @@
 export * from './picker-overlay';
 export * from './breakpoint';
+export * from './modal';

--- a/libs/ui/overlay/src/modal.spec.ts
+++ b/libs/ui/overlay/src/modal.spec.ts
@@ -1,0 +1,87 @@
+import { Subject } from 'rxjs';
+import { DialogRef } from '@angular/cdk/dialog';
+import {
+  GUI_DIALOG_DATA,
+  asArray,
+  normalizeModalConfig,
+  wrapDialogRef,
+} from './modal';
+import { DIALOG_DATA } from '@angular/cdk/dialog';
+
+describe('normalizeModalConfig', () => {
+  it('applies the M3 modal defaults (Req 12.1–12.3, 12.7, 14.1)', () => {
+    const cfg = normalizeModalConfig();
+    expect(cfg.role).toBe('dialog');
+    expect(cfg.ariaModal).toBe(true);
+    expect(cfg.hasBackdrop).toBe(true);
+    expect(cfg.backdropClass).toBe('gui-scrim');
+    expect(cfg.autoFocus).toBe('first-tabbable');
+    expect(cfg.restoreFocus).toBe(true);
+    expect(cfg.disableClose).toBe(false);
+    // Scroll-lock relies on CDK Dialog's default block scroll strategy
+    // (Req 12.6) — the normalizer does not override scrollStrategy.
+    expect(cfg.scrollStrategy).toBeUndefined();
+  });
+
+  it('propagates caller overrides', () => {
+    const cfg = normalizeModalConfig({
+      role: 'alertdialog',
+      disableClose: true,
+      ariaLabel: 'Delete file?',
+      autoFocus: 'first-heading',
+      restoreFocus: false,
+    });
+    expect(cfg.role).toBe('alertdialog');
+    expect(cfg.disableClose).toBe(true);
+    expect(cfg.ariaLabel).toBe('Delete file?');
+    expect(cfg.autoFocus).toBe('first-heading');
+    expect(cfg.restoreFocus).toBe(false);
+  });
+
+  it('normalizes panelClass to an array', () => {
+    expect(normalizeModalConfig({ panelClass: 'x' }).panelClass).toEqual(['x']);
+    expect(normalizeModalConfig({ panelClass: ['x', 'y'] }).panelClass).toEqual([
+      'x',
+      'y',
+    ]);
+    expect(normalizeModalConfig().panelClass).toEqual([]);
+  });
+});
+
+describe('asArray', () => {
+  it('wraps singletons and passes arrays through', () => {
+    expect(asArray(undefined)).toEqual([]);
+    expect(asArray('a')).toEqual(['a']);
+    expect(asArray(['a', 'b'])).toEqual(['a', 'b']);
+  });
+});
+
+describe('wrapDialogRef', () => {
+  it('forwards close(result) onto the CDK ref and re-exposes closed', () => {
+    const closed = new Subject<string | undefined>();
+    let closedWith: string | undefined;
+    const fake = {
+      closed,
+      backdropClick: new Subject<MouseEvent>(),
+      keydownEvents: new Subject<KeyboardEvent>(),
+      close: (result?: string) => {
+        closedWith = result;
+        closed.next(result);
+      },
+    } as unknown as DialogRef<string, unknown>;
+
+    const ref = wrapDialogRef<string>(fake);
+    let received: string | undefined;
+    ref.closed.subscribe((r) => (received = r));
+
+    ref.close('ok');
+    expect(closedWith).toBe('ok');
+    expect(received).toBe('ok');
+  });
+});
+
+describe('GUI_DIALOG_DATA', () => {
+  it('re-exports the CDK DIALOG_DATA token', () => {
+    expect(GUI_DIALOG_DATA).toBe(DIALOG_DATA);
+  });
+});

--- a/libs/ui/overlay/src/modal.spec.ts
+++ b/libs/ui/overlay/src/modal.spec.ts
@@ -19,8 +19,9 @@ describe('normalizeModalConfig', () => {
     expect(cfg.restoreFocus).toBe(true);
     expect(cfg.disableClose).toBe(false);
     // Scroll-lock relies on CDK Dialog's default block scroll strategy
-    // (Req 12.6) — the normalizer does not override scrollStrategy.
-    expect(cfg.scrollStrategy).toBeUndefined();
+    // (Req 12.6) — the normalizer deliberately does not set scrollStrategy,
+    // so it is absent from the narrowed normalized config type.
+    expect('scrollStrategy' in cfg).toBe(false);
   });
 
   it('propagates caller overrides', () => {

--- a/libs/ui/overlay/src/modal.ts
+++ b/libs/ui/overlay/src/modal.ts
@@ -1,0 +1,109 @@
+import { Injector, TemplateRef } from '@angular/core';
+import { ComponentType } from '@angular/cdk/overlay';
+import { DIALOG_DATA, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import { Observable } from 'rxjs';
+
+/**
+ * Shared modal foundation for the containment overlay surfaces (dialog, modal
+ * bottom sheet, modal side sheet). Each family builds on CDK's headless
+ * `@angular/cdk/dialog` `Dialog` service for APG-complete modal behavior —
+ * `aria-modal`, role, focus trap, focus restore, autofocus, Escape, and
+ * scroll-lock (the CDK `Dialog` default scroll strategy is already
+ * `block()`, satisfying Req 12.6 without an explicit override).
+ */
+
+/** Modal role exposed to assistive tech (Req 14.1). */
+export type GuiDialogRole = 'dialog' | 'alertdialog';
+
+/**
+ * Common configuration accepted by every modal `open()` in the containment
+ * category. Families extend this with their own layout options.
+ */
+export interface GuiModalConfigBase<D = unknown> {
+  /** Data injected via {@link GUI_DIALOG_DATA} into the content component. */
+  data?: D;
+  /** ARIA role; defaults to `'dialog'`. Use `'alertdialog'` for confirmations. */
+  role?: GuiDialogRole;
+  /** Accessible name when no visible headline exists. */
+  ariaLabel?: string;
+  /** Id of the element naming the surface (e.g. the headline). */
+  ariaLabelledBy?: string;
+  /** When `true`, Escape and scrim-click do not close the surface (Req 12.4/12.5). */
+  disableClose?: boolean;
+  /** Extra class(es) applied to the overlay pane. */
+  panelClass?: string | string[];
+  /** Initial focus target; defaults to `'first-tabbable'`. */
+  autoFocus?: 'dialog' | 'first-tabbable' | 'first-heading' | string;
+  /** Restore focus to the opener on close; defaults to `true`. */
+  restoreFocus?: boolean;
+  /** Parent injector for the projected content. */
+  injector?: Injector;
+}
+
+/**
+ * Public handle returned by every modal `open()`. A thin, framework-agnostic
+ * wrapper over CDK's {@link DialogRef} exposing only the members consumers need.
+ */
+export interface GuiDialogRef<R = unknown> {
+  /** Emits the close result once, when the surface has closed. */
+  readonly closed: Observable<R | undefined>;
+  /** Emits when the scrim (backdrop) is clicked. */
+  readonly backdropClick: Observable<MouseEvent>;
+  /** Emits keydown events dispatched while the surface is focused. */
+  readonly keydownEvents: Observable<KeyboardEvent>;
+  /** Close the surface, optionally returning a result to `closed`. */
+  close(result?: R): void;
+}
+
+/** Re-export of CDK's data token so content components inject it from `@ngguide/ui/overlay`. */
+export const GUI_DIALOG_DATA = DIALOG_DATA;
+
+/** What `open()` accepts as content: a component type or an inline template. */
+export type GuiModalContent<C> = ComponentType<C> | TemplateRef<C>;
+
+/** Normalize a value that may be a single class or an array into an array. */
+export function asArray(value: string | string[] | undefined): string[] {
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Map a {@link GuiModalConfigBase} onto a CDK {@link DialogConfig}, applying the
+ * M3 modal defaults: `ariaModal: true`, a backdrop styled by the global
+ * `.gui-scrim` class, `autoFocus: 'first-tabbable'`, and `restoreFocus: true`
+ * (Req 12.1–12.3, 12.7, 14.1). Scroll-lock is left to CDK `Dialog`'s default
+ * block scroll strategy (Req 12.6). Family-specific fields (`container`,
+ * `panelClass`, position strategy) are layered on by each service afterwards.
+ */
+export function normalizeModalConfig<D = unknown>(
+  config?: GuiModalConfigBase<D>,
+): DialogConfig<D> {
+  return {
+    role: config?.role ?? 'dialog',
+    ariaModal: true,
+    ariaLabel: config?.ariaLabel ?? null,
+    ariaLabelledBy: config?.ariaLabelledBy ?? null,
+    disableClose: config?.disableClose ?? false,
+    autoFocus: config?.autoFocus ?? 'first-tabbable',
+    restoreFocus: config?.restoreFocus ?? true,
+    hasBackdrop: true,
+    backdropClass: 'gui-scrim',
+    data: config?.data ?? null,
+    injector: config?.injector,
+    panelClass: asArray(config?.panelClass),
+  };
+}
+
+/** Wrap a CDK {@link DialogRef} in the narrower public {@link GuiDialogRef}. */
+export function wrapDialogRef<R = unknown>(
+  ref: DialogRef<R, unknown>,
+): GuiDialogRef<R> {
+  return {
+    closed: ref.closed,
+    backdropClick: ref.backdropClick,
+    keydownEvents: ref.keydownEvents,
+    close: (result?: R) => ref.close(result),
+  };
+}

--- a/libs/ui/overlay/src/modal.ts
+++ b/libs/ui/overlay/src/modal.ts
@@ -1,6 +1,6 @@
 import { Injector, TemplateRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/overlay';
-import { DIALOG_DATA, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { Observable } from 'rxjs';
 
 /**
@@ -70,8 +70,29 @@ export function asArray(value: string | string[] | undefined): string[] {
 }
 
 /**
- * Map a {@link GuiModalConfigBase} onto a CDK {@link DialogConfig}, applying the
- * M3 modal defaults: `ariaModal: true`, a backdrop styled by the global
+ * The CDK `DialogConfig` fields the normalizer sets. Deliberately narrower than
+ * `DialogConfig` — it omits the result-generic-dependent fields (`providers`,
+ * `templateContext`) so it can be spread into a fully-typed
+ * `DialogConfig<D, DialogRef<R, C>>` without provoking variance errors.
+ */
+export interface GuiNormalizedModalConfig<D = unknown> {
+  role: GuiDialogRole;
+  ariaModal: true;
+  ariaLabel: string | null;
+  ariaLabelledBy: string | null;
+  disableClose: boolean;
+  autoFocus: string;
+  restoreFocus: boolean;
+  hasBackdrop: true;
+  backdropClass: string;
+  data: D | null;
+  injector: Injector | undefined;
+  panelClass: string[];
+}
+
+/**
+ * Map a {@link GuiModalConfigBase} onto the CDK `DialogConfig` fields, applying
+ * the M3 modal defaults: `ariaModal: true`, a backdrop styled by the global
  * `.gui-scrim` class, `autoFocus: 'first-tabbable'`, and `restoreFocus: true`
  * (Req 12.1–12.3, 12.7, 14.1). Scroll-lock is left to CDK `Dialog`'s default
  * block scroll strategy (Req 12.6). Family-specific fields (`container`,
@@ -79,7 +100,7 @@ export function asArray(value: string | string[] | undefined): string[] {
  */
 export function normalizeModalConfig<D = unknown>(
   config?: GuiModalConfigBase<D>,
-): DialogConfig<D> {
+): GuiNormalizedModalConfig<D> {
   return {
     role: config?.role ?? 'dialog',
     ariaModal: true,
@@ -97,8 +118,8 @@ export function normalizeModalConfig<D = unknown>(
 }
 
 /** Wrap a CDK {@link DialogRef} in the narrower public {@link GuiDialogRef}. */
-export function wrapDialogRef<R = unknown>(
-  ref: DialogRef<R, unknown>,
+export function wrapDialogRef<R = unknown, C = unknown>(
+  ref: DialogRef<R, C>,
 ): GuiDialogRef<R> {
   return {
     closed: ref.closed,

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -74,6 +74,7 @@
           "../datetime/src/parse.spec.ts",
           "../overlay/src/picker-overlay.spec.ts",
           "../overlay/src/breakpoint.spec.ts",
+          "../overlay/src/modal.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -79,6 +79,8 @@
           "../divider/src/divider.spec.ts",
           "../list/src/list.spec.ts",
           "../list/src/list-item.spec.ts",
+          "../dialog/src/dialog.service.spec.ts",
+          "../dialog/src/dialog.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -86,6 +86,8 @@
           "../bottom-sheet/src/bottom-sheet.spec.ts",
           "../side-sheet/src/side-sheet.service.spec.ts",
           "../side-sheet/src/side-sheet.spec.ts",
+          "../carousel/src/carousel-keylines.spec.ts",
+          "../carousel/src/carousel.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -73,6 +73,7 @@
           "../datetime/src/intl.spec.ts",
           "../datetime/src/parse.spec.ts",
           "../overlay/src/picker-overlay.spec.ts",
+          "../overlay/src/breakpoint.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -82,6 +82,8 @@
           "../dialog/src/dialog.service.spec.ts",
           "../dialog/src/dialog.spec.ts",
           "../dialog/src/dialog.trigger.spec.ts",
+          "../bottom-sheet/src/bottom-sheet.service.spec.ts",
+          "../bottom-sheet/src/bottom-sheet.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -84,6 +84,8 @@
           "../dialog/src/dialog.trigger.spec.ts",
           "../bottom-sheet/src/bottom-sheet.service.spec.ts",
           "../bottom-sheet/src/bottom-sheet.spec.ts",
+          "../side-sheet/src/side-sheet.service.spec.ts",
+          "../side-sheet/src/side-sheet.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -76,6 +76,7 @@
           "../overlay/src/breakpoint.spec.ts",
           "../overlay/src/modal.spec.ts",
           "../card/src/card.spec.ts",
+          "../divider/src/divider.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -77,6 +77,8 @@
           "../overlay/src/modal.spec.ts",
           "../card/src/card.spec.ts",
           "../divider/src/divider.spec.ts",
+          "../list/src/list.spec.ts",
+          "../list/src/list-item.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -81,6 +81,7 @@
           "../list/src/list-item.spec.ts",
           "../dialog/src/dialog.service.spec.ts",
           "../dialog/src/dialog.spec.ts",
+          "../dialog/src/dialog.trigger.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -75,6 +75,7 @@
           "../overlay/src/picker-overlay.spec.ts",
           "../overlay/src/breakpoint.spec.ts",
           "../overlay/src/modal.spec.ts",
+          "../card/src/card.spec.ts",
           "../progress/src/linear-progress.spec.ts",
           "../progress/src/circular-progress.spec.ts",
           "../loading-indicator/src/loading-indicator.spec.ts",

--- a/libs/ui/side-sheet/ng-package.json
+++ b/libs/ui/side-sheet/ng-package.json
@@ -1,0 +1,3 @@
+{
+  "lib": { "entryFile": "src/index.ts" }
+}

--- a/libs/ui/side-sheet/src/index.ts
+++ b/libs/ui/side-sheet/src/index.ts
@@ -1,0 +1,4 @@
+export * from './side-sheet-config';
+export * from './side-sheet.service';
+export * from './side-sheet';
+export { GuiSideSheetContainer } from './side-sheet-container';

--- a/libs/ui/side-sheet/src/side-sheet-config.ts
+++ b/libs/ui/side-sheet/src/side-sheet-config.ts
@@ -1,0 +1,9 @@
+import { GuiModalConfigBase } from '@ngguide/ui/overlay';
+
+export interface GuiSideSheetConfig<D = unknown>
+  extends GuiModalConfigBase<D> {
+  /** Sheet width (clamped 256–400dp by the surface). Default `400px`. */
+  maxWidth?: string;
+}
+
+export { GUI_DIALOG_DATA, type GuiDialogRef } from '@ngguide/ui/overlay';

--- a/libs/ui/side-sheet/src/side-sheet-container.css
+++ b/libs/ui/side-sheet/src/side-sheet-container.css
@@ -1,0 +1,37 @@
+/* M3 modal side sheet, docked to the inline-end edge, full height. */
+
+:host {
+  display: block;
+  height: 100%;
+  outline: none;
+}
+
+.gui-side-sheet-surface {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: clamp(256px, 25vw, 400px);
+  height: 100%;
+  background-color: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  /* Rounded on the inner (inline-start) edge only. */
+  border-start-start-radius: var(--md-sys-shape-corner-large);
+  border-end-start-radius: var(--md-sys-shape-corner-large);
+  box-shadow: var(--md-sys-elevation-level1);
+  overflow: hidden;
+  animation: gui-side-sheet-enter var(--md-sys-motion-duration-medium4)
+    var(--md-sys-motion-easing-emphasized-decelerate);
+}
+
+@keyframes gui-side-sheet-enter {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+:host(.gui-no-motion) .gui-side-sheet-surface {
+  animation: none;
+}

--- a/libs/ui/side-sheet/src/side-sheet-container.ts
+++ b/libs/ui/side-sheet/src/side-sheet-container.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CdkDialogContainer } from '@angular/cdk/dialog';
+import { CdkPortalOutlet } from '@angular/cdk/portal';
+import { GuiReducedMotion } from '@ngguide/ui/interaction';
+
+/**
+ * M3 modal side-sheet surface. Extends CDK's {@link CdkDialogContainer} (focus
+ * trap, restore, `aria-modal`) and adds the M3 chrome — docked to the inline
+ * **end** edge, `256–400dp` wide, `corner-large` (16dp) on the inner edge,
+ * `surface-container-low` + `elevation-level1` (Req 10.1, 10.2). The slide-in
+ * animation is disabled under reduced motion (Req 15.2). Side sheets have no
+ * drag gesture; they dismiss via the close affordance, scrim or Escape.
+ */
+@Component({
+  selector: 'gui-side-sheet-container',
+  changeDetection: ChangeDetectionStrategy.Default,
+  imports: [CdkPortalOutlet],
+  template: `
+    <div class="gui-side-sheet-surface">
+      <ng-template cdkPortalOutlet />
+    </div>
+  `,
+  styleUrl: './side-sheet-container.css',
+  host: {
+    class: 'gui-side-sheet-container',
+    tabindex: '-1',
+    '[attr.id]': '_config.id || null',
+    '[attr.role]': '_config.role',
+    '[attr.aria-modal]': '_config.ariaModal',
+    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledByQueue[0]',
+    '[attr.aria-label]': '_config.ariaLabel',
+    '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
+    '[class.gui-no-motion]': 'reducedMotion.prefersReducedMotion()',
+  },
+})
+export class GuiSideSheetContainer extends CdkDialogContainer {
+  protected readonly reducedMotion = inject(GuiReducedMotion);
+}

--- a/libs/ui/side-sheet/src/side-sheet.css
+++ b/libs/ui/side-sheet/src/side-sheet.css
@@ -1,0 +1,36 @@
+/* M3 standard (non-modal) side sheet. Fixed to the inline-end edge, full
+   height; coexists with page content (no scrim). Slides in/out on `open`. */
+
+:host {
+  position: fixed;
+  inset-block: 0;
+  inset-inline-end: 0;
+  z-index: 6;
+  display: block;
+  pointer-events: none;
+}
+
+.gui-side-sheet-surface {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: clamp(256px, 25vw, 400px);
+  height: 100%;
+  pointer-events: auto;
+  background-color: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  border-start-start-radius: var(--md-sys-shape-corner-large);
+  border-end-start-radius: var(--md-sys-shape-corner-large);
+  box-shadow: var(--md-sys-elevation-level1);
+  transform: translateX(100%);
+  transition: transform var(--md-sys-motion-duration-medium4)
+    var(--md-sys-motion-easing-emphasized);
+}
+
+:host([data-open]) .gui-side-sheet-surface {
+  transform: translateX(0);
+}
+
+:host(.gui-no-motion) .gui-side-sheet-surface {
+  transition: none;
+}

--- a/libs/ui/side-sheet/src/side-sheet.service.spec.ts
+++ b/libs/ui/side-sheet/src/side-sheet.service.spec.ts
@@ -1,0 +1,55 @@
+import { ApplicationRef, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { GuiSideSheet } from './side-sheet.service';
+
+@Component({ template: `<button type="button">action</button>` })
+class SheetContent {}
+
+function flush(): void {
+  TestBed.inject(ApplicationRef).tick();
+}
+
+const ESCAPE = 27;
+
+function escape(): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+  Object.defineProperty(event, 'keyCode', { get: () => ESCAPE });
+  return event;
+}
+
+describe('GuiSideSheet (modal)', () => {
+  it('opens an end-anchored modal with scrim + role (Req 10.1, 12.1)', () => {
+    const ref = TestBed.inject(GuiSideSheet).open(SheetContent, {
+      ariaLabel: 'Sheet',
+    });
+    flush();
+    const container = document.querySelector('.gui-side-sheet-container');
+    expect(container?.getAttribute('role')).toBe('dialog');
+    expect(container?.getAttribute('aria-modal')).toBe('true');
+    expect(
+      document.querySelector('.cdk-overlay-backdrop.gui-scrim'),
+    ).not.toBeNull();
+    ref.close();
+    flush();
+  });
+
+  it('closes on Escape and emits the result (Req 10.6, 16.2)', () => {
+    const ref = TestBed.inject(GuiSideSheet).open<string>(SheetContent, {
+      ariaLabel: 'Sheet',
+    });
+    let result: string | undefined;
+    ref.closed.subscribe((r) => (result = r));
+    flush();
+    document.querySelector('.gui-side-sheet-container')?.dispatchEvent(escape());
+    flush();
+    expect(document.querySelector('.gui-side-sheet-container')).toBeNull();
+    // Escape closes with undefined result.
+    expect(result).toBeUndefined();
+  });
+
+  it('throws when opened without content', () => {
+    expect(() =>
+      TestBed.inject(GuiSideSheet).open(null as never),
+    ).toThrowError(/component type or a TemplateRef/);
+  });
+});

--- a/libs/ui/side-sheet/src/side-sheet.service.ts
+++ b/libs/ui/side-sheet/src/side-sheet.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, TemplateRef, inject } from '@angular/core';
+import { ComponentType, Overlay } from '@angular/cdk/overlay';
+import { Dialog, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import {
+  GuiDialogRef,
+  asArray,
+  normalizeModalConfig,
+  wrapDialogRef,
+} from '@ngguide/ui/overlay';
+import { GuiSideSheetConfig } from './side-sheet-config';
+import { GuiSideSheetContainer } from './side-sheet-container';
+
+/**
+ * Opens M3 **modal** side sheets over the headless CDK `Dialog` service: an
+ * end-docked, full-height surface with a scrim, focus trap, focus restore and
+ * Escape (Req 10.1, 12). Returns a {@link GuiDialogRef} whose `closed` emits the
+ * result. For a non-modal side sheet that coexists with the page, use the
+ * standard `<gui-side-sheet variant="standard">` surface instead (Req 10.3).
+ */
+@Injectable({ providedIn: 'root' })
+export class GuiSideSheet {
+  private readonly cdkDialog = inject(Dialog);
+  private readonly overlay = inject(Overlay);
+
+  open<R = unknown, D = unknown, C = unknown>(
+    content: ComponentType<C> | TemplateRef<C>,
+    config?: GuiSideSheetConfig<D>,
+  ): GuiDialogRef<R> {
+    if (content == null) {
+      throw new Error(
+        'GuiSideSheet.open() requires a component type or a TemplateRef.',
+      );
+    }
+
+    const cdkConfig: DialogConfig<D, DialogRef<R, C>> = {
+      ...normalizeModalConfig<D>(config),
+      container: GuiSideSheetContainer,
+      positionStrategy: this.overlay
+        .position()
+        .global()
+        .top('0')
+        .right('0'),
+      height: '100%',
+      maxWidth: config?.maxWidth ?? '400px',
+      panelClass: ['gui-side-sheet-pane', ...asArray(config?.panelClass)],
+    };
+
+    const ref = this.cdkDialog.open<R, D, C>(content, cdkConfig);
+    return wrapDialogRef(ref);
+  }
+}

--- a/libs/ui/side-sheet/src/side-sheet.spec.ts
+++ b/libs/ui/side-sheet/src/side-sheet.spec.ts
@@ -2,19 +2,25 @@ import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   GuiSideSheetActions,
+  GuiSideSheetContent,
   GuiSideSheetHeader,
   GuiSideSheetSurface,
 } from './side-sheet';
 
 @Component({
-  imports: [GuiSideSheetSurface, GuiSideSheetHeader, GuiSideSheetActions],
+  imports: [
+    GuiSideSheetSurface,
+    GuiSideSheetHeader,
+    GuiSideSheetContent,
+    GuiSideSheetActions,
+  ],
   template: `
     <gui-side-sheet [(open)]="open">
       <gui-side-sheet-header>
         Filters
         <button guiSideSheetClose type="button" class="close-btn">×</button>
       </gui-side-sheet-header>
-      <p class="sheet-body">Body</p>
+      <gui-side-sheet-content><p class="sheet-body">Body</p></gui-side-sheet-content>
       <gui-side-sheet-actions>
         <button type="button">Apply</button>
       </gui-side-sheet-actions>
@@ -42,6 +48,15 @@ describe('GuiSideSheetSurface (standard)', () => {
     expect(host.querySelector('gui-side-sheet-header')).not.toBeNull();
     expect(host.querySelector('.close-btn')).not.toBeNull();
     expect(host.querySelector('gui-side-sheet-actions')).not.toBeNull();
+  });
+
+  it('provides a scrollable content region between header and actions (Req 10.6)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.detectChanges();
+    const host = fixture.nativeElement.querySelector('gui-side-sheet');
+    const content = host.querySelector('gui-side-sheet-content');
+    expect(content).not.toBeNull();
+    expect(content.querySelector('.sheet-body')?.textContent).toContain('Body');
   });
 
   it('reflects the open model onto data-open + aria-hidden (Req 10.3)', () => {

--- a/libs/ui/side-sheet/src/side-sheet.spec.ts
+++ b/libs/ui/side-sheet/src/side-sheet.spec.ts
@@ -1,0 +1,55 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  GuiSideSheetActions,
+  GuiSideSheetHeader,
+  GuiSideSheetSurface,
+} from './side-sheet';
+
+@Component({
+  imports: [GuiSideSheetSurface, GuiSideSheetHeader, GuiSideSheetActions],
+  template: `
+    <gui-side-sheet [(open)]="open">
+      <gui-side-sheet-header>
+        Filters
+        <button guiSideSheetClose type="button" class="close-btn">×</button>
+      </gui-side-sheet-header>
+      <p class="sheet-body">Body</p>
+      <gui-side-sheet-actions>
+        <button type="button">Apply</button>
+      </gui-side-sheet-actions>
+    </gui-side-sheet>
+  `,
+})
+class StandardHost {
+  readonly open = signal(true);
+}
+
+describe('GuiSideSheetSurface (standard)', () => {
+  it('renders inline with no scrim, leaving the page interactive (Req 10.3)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.detectChanges();
+    expect(document.querySelector('.cdk-overlay-backdrop')).toBeNull();
+    const host = fixture.nativeElement.querySelector('gui-side-sheet');
+    expect(host.hasAttribute('data-open')).toBe(true);
+    expect(host.querySelector('.sheet-body')?.textContent).toContain('Body');
+  });
+
+  it('renders the header (title + close) and actions slots (Req 10.4)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.detectChanges();
+    const host = fixture.nativeElement.querySelector('gui-side-sheet');
+    expect(host.querySelector('gui-side-sheet-header')).not.toBeNull();
+    expect(host.querySelector('.close-btn')).not.toBeNull();
+    expect(host.querySelector('gui-side-sheet-actions')).not.toBeNull();
+  });
+
+  it('reflects the open model onto data-open + aria-hidden (Req 10.3)', () => {
+    const fixture = TestBed.createComponent(StandardHost);
+    fixture.componentInstance.open.set(false);
+    fixture.detectChanges();
+    const host = fixture.nativeElement.querySelector('gui-side-sheet');
+    expect(host.hasAttribute('data-open')).toBe(false);
+    expect(host.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/libs/ui/side-sheet/src/side-sheet.ts
+++ b/libs/ui/side-sheet/src/side-sheet.ts
@@ -49,6 +49,32 @@ import { GuiReducedMotion } from '@ngguide/ui/interaction';
 })
 export class GuiSideSheetHeader {}
 
+/**
+ * Scrollable content region between the header and the actions (Req 10.6).
+ * Takes the remaining height of the sheet and scrolls its own overflow, so the
+ * header and actions stay pinned. `min-height: 0` lets it shrink inside the
+ * surface's flex column (without it, a flex item refuses to shrink below its
+ * content and would push the actions off-screen).
+ */
+@Component({
+  selector: 'gui-side-sheet-content',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: { class: 'gui-side-sheet-content' },
+  styles: [
+    `
+      :host {
+        display: block;
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow-y: auto;
+        padding: 0 16px;
+      }
+    `,
+  ],
+})
+export class GuiSideSheetContent {}
+
 /** End-aligned action buttons region pinned to the sheet bottom (Req 10.4). */
 @Component({
   selector: 'gui-side-sheet-actions',

--- a/libs/ui/side-sheet/src/side-sheet.ts
+++ b/libs/ui/side-sheet/src/side-sheet.ts
@@ -1,0 +1,104 @@
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  model,
+} from '@angular/core';
+import { GuiReducedMotion } from '@ngguide/ui/interaction';
+
+/**
+ * Side-sheet header (Req 10.4): a title with a trailing close affordance.
+ * Project the close control into `[guiSideSheetClose]`.
+ */
+@Component({
+  selector: 'gui-side-sheet-header',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span class="gui-side-sheet-title"><ng-content /></span>
+    <span class="gui-side-sheet-close"
+      ><ng-content select="[guiSideSheetClose]"
+    /></span>
+  `,
+  host: { class: 'gui-side-sheet-header' },
+  styles: [
+    `
+      :host {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        height: 56px;
+        padding: 0 16px;
+        flex: 0 0 auto;
+      }
+      .gui-side-sheet-title {
+        flex: 1 1 auto;
+        font-family: var(--md-sys-typescale-title-large-font);
+        font-size: var(--md-sys-typescale-title-large-size);
+        font-weight: var(--md-sys-typescale-title-large-weight);
+        line-height: var(--md-sys-typescale-title-large-line-height);
+        letter-spacing: var(--md-sys-typescale-title-large-tracking);
+      }
+      .gui-side-sheet-close {
+        display: flex;
+        flex: 0 0 auto;
+      }
+    `,
+  ],
+})
+export class GuiSideSheetHeader {}
+
+/** End-aligned action buttons region pinned to the sheet bottom (Req 10.4). */
+@Component({
+  selector: 'gui-side-sheet-actions',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: { class: 'gui-side-sheet-actions' },
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 8px;
+        padding: 16px;
+        flex: 0 0 auto;
+        margin-top: auto;
+      }
+    `,
+  ],
+})
+export class GuiSideSheetActions {}
+
+/**
+ * M3 **standard** (non-modal) side sheet (Req 10.3). Rendered inline as a
+ * fixed-position, end-docked surface that coexists with the page — **no scrim
+ * and no focus trap** — so content behind it stays interactive. Toggle it with
+ * the two-way `open` model. For a focus-trapping modal side sheet, use the
+ * {@link GuiSideSheet} service instead.
+ */
+@Component({
+  selector: 'gui-side-sheet',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="gui-side-sheet-surface"><ng-content /></div>`,
+  styleUrl: './side-sheet.css',
+  host: {
+    class: 'gui-side-sheet-host',
+    '[attr.data-variant]': 'variant()',
+    '[attr.data-open]': 'open() ? "" : null',
+    '[attr.aria-hidden]': 'open() ? null : "true"',
+    '[class.gui-no-motion]': 'reducedMotion.prefersReducedMotion()',
+  },
+})
+export class GuiSideSheetSurface {
+  protected readonly reducedMotion = inject(GuiReducedMotion);
+
+  /** Surface mode. The inline component is `standard`; modal sheets use the service. */
+  readonly variant = input<'modal' | 'standard'>('standard');
+  /** Two-way open state (Req 10.3). */
+  readonly open = model(false);
+  /** Reserved for API parity with the modal config. */
+  readonly dismissible = input(true, { transform: booleanAttribute });
+}

--- a/libs/ui/src/styles/scrim.css
+++ b/libs/ui/src/styles/scrim.css
@@ -1,0 +1,18 @@
+/* M3 modal scrim. Applied to the CDK overlay backdrop via
+   `backdropClass: 'gui-scrim'` by the shared modal normalizer. The dim is
+   `--md-sys-color-scrim` at 32% opacity (Req 12.1). The fade in/out is driven
+   by the CDK `.cdk-overlay-backdrop` opacity transition; under reduced motion
+   the dim appears instantly (Req 15.2). */
+.cdk-overlay-backdrop.gui-scrim {
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-scrim) 32%,
+    transparent
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cdk-overlay-backdrop.gui-scrim {
+    transition: none;
+  }
+}

--- a/libs/ui/src/styles/theme.css
+++ b/libs/ui/src/styles/theme.css
@@ -11,3 +11,4 @@
 @import './tokens/_motion.css';
 @import './overlay.css';
 @import './badge.css';
+@import './scrim.css';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
       "@ngguide/ui/chip": ["libs/ui/chip/src/index.ts"],
       "@ngguide/ui/date-picker": ["libs/ui/date-picker/src/index.ts"],
       "@ngguide/ui/datetime": ["libs/ui/datetime/src/index.ts"],
+      "@ngguide/ui/dialog": ["libs/ui/dialog/src/index.ts"],
       "@ngguide/ui/fab": ["libs/ui/fab/src/index.ts"],
       "@ngguide/ui/fab-menu": ["libs/ui/fab-menu/src/index.ts"],
       "@ngguide/ui/forms": ["libs/ui/forms/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,7 @@
       "@ngguide/ui/icon": ["libs/ui/icon/src/index.ts"],
       "@ngguide/ui/icon-button": ["libs/ui/icon-button/src/index.ts"],
       "@ngguide/ui/interaction": ["libs/ui/interaction/src/index.ts"],
+      "@ngguide/ui/list": ["libs/ui/list/src/index.ts"],
       "@ngguide/ui/loading-indicator": [
         "libs/ui/loading-indicator/src/index.ts"
       ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,6 +42,7 @@
       "@ngguide/ui/progress": ["libs/ui/progress/src/index.ts"],
       "@ngguide/ui/radio": ["libs/ui/radio/src/index.ts"],
       "@ngguide/ui/segmented-button": ["libs/ui/segmented-button/src/index.ts"],
+      "@ngguide/ui/side-sheet": ["libs/ui/side-sheet/src/index.ts"],
       "@ngguide/ui/slider": ["libs/ui/slider/src/index.ts"],
       "@ngguide/ui/snackbar": ["libs/ui/snackbar/src/index.ts"],
       "@ngguide/ui/split-button": ["libs/ui/split-button/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,7 @@
       "@ngguide/ui": ["libs/ui/src/index.ts"],
       "@ngguide/ui/badge": ["libs/ui/badge/src/index.ts"],
       "@ngguide/ui/button": ["libs/ui/button/src/index.ts"],
+      "@ngguide/ui/card": ["libs/ui/card/src/index.ts"],
       "@ngguide/ui/button-group": ["libs/ui/button-group/src/index.ts"],
       "@ngguide/ui/checkbox": ["libs/ui/checkbox/src/index.ts"],
       "@ngguide/ui/chip": ["libs/ui/chip/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,7 @@
       "@ngguide/ui/button": ["libs/ui/button/src/index.ts"],
       "@ngguide/ui/card": ["libs/ui/card/src/index.ts"],
       "@ngguide/ui/button-group": ["libs/ui/button-group/src/index.ts"],
+      "@ngguide/ui/bottom-sheet": ["libs/ui/bottom-sheet/src/index.ts"],
       "@ngguide/ui/checkbox": ["libs/ui/checkbox/src/index.ts"],
       "@ngguide/ui/divider": ["libs/ui/divider/src/index.ts"],
       "@ngguide/ui/chip": ["libs/ui/chip/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,6 +19,7 @@
       "@ngguide/ui/badge": ["libs/ui/badge/src/index.ts"],
       "@ngguide/ui/button": ["libs/ui/button/src/index.ts"],
       "@ngguide/ui/card": ["libs/ui/card/src/index.ts"],
+      "@ngguide/ui/carousel": ["libs/ui/carousel/src/index.ts"],
       "@ngguide/ui/button-group": ["libs/ui/button-group/src/index.ts"],
       "@ngguide/ui/bottom-sheet": ["libs/ui/bottom-sheet/src/index.ts"],
       "@ngguide/ui/checkbox": ["libs/ui/checkbox/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
       "@ngguide/ui/card": ["libs/ui/card/src/index.ts"],
       "@ngguide/ui/button-group": ["libs/ui/button-group/src/index.ts"],
       "@ngguide/ui/checkbox": ["libs/ui/checkbox/src/index.ts"],
+      "@ngguide/ui/divider": ["libs/ui/divider/src/index.ts"],
       "@ngguide/ui/chip": ["libs/ui/chip/src/index.ts"],
       "@ngguide/ui/date-picker": ["libs/ui/date-picker/src/index.ts"],
       "@ngguide/ui/datetime": ["libs/ui/datetime/src/index.ts"],


### PR DESCRIPTION
## Summary

Implements the full **M3 containment** family for `@ngguide/ui` — seven new secondary entry points plus the shared modal-overlay primitives — built from scratch (not Angular Material), strictly per m3.material.io. Standalone · OnPush · signals · zoneless · SSR-safe throughout.

This is the complete spec pipeline output for `containment`: requirements → research → design → tasks (27 tasks / 7 groups, all done) → manual test plan → an `agent-browser` dogfood run → fixes for everything it surfaced.

## New entry points

| Package | What |
|---|---|
| `@ngguide/ui/card` | elevated / filled / outlined; whole-surface clickable + primary-action modes |
| `@ngguide/ui/divider` | none / inset / middle-inset; horizontal + vertical; `role=separator` |
| `@ngguide/ui/list` | one component, two ARIA patterns — `action` (`role=list`) and `listbox` (roving focus, selection, type-ahead) |
| `@ngguide/ui/dialog` | basic (centered) + full-screen; service `open()` + declarative `[guiDialogTrigger]`; `fullScreen: never/compact/always` |
| `@ngguide/ui/bottom-sheet` | modal (drag-to-dismiss + scrim fade) + standard (inline, no scrim) |
| `@ngguide/ui/side-sheet` | modal + standard, end-docked; header / **content** / actions slots |
| `@ngguide/ui/carousel` | pure keyline engine + 4 layouts (multi-browse / uncontained / hero / full-screen), `ResizeObserver` re-fit, reduced-motion static sizing |

Plus `@ngguide/ui/overlay` (shared modal config normalizer, `GuiDialogRef` wrapper, `GuiBreakpoint` compact-window signal) and a global `gui-scrim` stylesheet. All seven consume only the `--md-sys-*` token contract and reuse the existing interaction primitives (state-layer / ripple / focus-ring, `createRovingFocus`, `GuiReducedMotion`).

## Shared modal contract (APG Dialog)

Dialog, full-screen dialog, modal bottom sheet, and modal side sheet all extend CDK's headless `Dialog`/`CdkDialogContainer`, so they share: scrim (32% scrim color) that blocks the page, focus trap + restore, Escape / scrim-click dismiss (`disableClose` opt-out), scroll-lock, `role=dialog` + `aria-modal` + accessible name, and CDK overlay stacking.

## Testing

- **299 unit tests** (Vitest 4, zoneless, first-party Angular builder) covering every component + the carousel keyline engine.
- **Manual test plan** (`.specs/containment/test-plan.md`): 56 browser-based cases, executed via `agent-browser` against the demo — driving real drag/keyboard/pointer gestures and reading computed styles, ARIA, and `prefers-reduced-motion`/`prefers-color-scheme` emulation. **Final: 49 pass / 0 fail / 7 skip** (skips need demo props the playground doesn't expose; all covered by unit tests).

### Dogfood found 5 real bugs — all fixed and re-verified in-browser
- **List** supporting text now clamps (`-webkit-line-clamp`) instead of growing the row.
- **Standard bottom sheet** now slides off-screen on drag-dismiss (`CdkDrag.reset()` clears the inline transform that was overriding the CSS close state).
- **Side sheet** gained a scrollable content region (`GuiSideSheetContent`) so overflow scrolls instead of pushing actions off-screen.
- **Uncontained carousel** renders uniform-width items (no keyline morph).
- **Listbox options** show a visible keyboard focus ring (`GuiFocusRingDirective`).
- Bonus: fixed a pre-existing `GuiChip` `getLabel()` gap that made `createRovingFocus` type-ahead throw on every chip-set render.

## Notes
- Build verified: `nx run-many -t lint test build -p ui web` green (library emits all 7 entry points; web app prerenders + hydrates zoneless with no errors).
- No release/verdaccio or Nx release config touched.
- Minor documented deviations: enter animations only (CDK Dialog disposes synchronously); side sheet is LTR-anchored (RTL is a future refinement).
