### PR TITLE
chore(deploy): host docs on cloudflare workers static assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@ngguide/source",
   "version": "0.0.0",
   "license": "MIT",
-  "scripts": {},
+  "scripts": {
+    "deploy:cf": "pnpm exec nx build web --configuration=production && cp dist/apps/web/browser/index.csr.html dist/apps/web/browser/index.html && npx wrangler deploy"
+  },
   "private": true,
   "packageManager": "pnpm@10.33.4",
   "dependencies": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "ngguide-ui",
+  "compatibility_date": "2025-01-01",
+  "account_id": "53683e9c95b74c0aae7b4b9821b8c53f",
+  // Static-assets-only Worker (no `main`) hosting the prerendered Angular build.
+  // Prerendered routes (/ui, /admin/*, /shop/*, /tasks/*) resolve to their own
+  // index.html; everything else (/ui/components/:slug, demo detail routes) falls
+  // through to the client-render shell (index.html) and hydrates on the client.
+  "assets": {
+    "directory": "dist/apps/web/browser",
+    "not_found_handling": "single-page-application"
+  },
+  // Custom domain — wrangler attaches it and creates the DNS record in the
+  // ng.guide zone (same account) on deploy.
+  "routes": [{ "pattern": "ui.ng.guide", "custom_domain": true }]
+}


### PR DESCRIPTION
Deploys the demo/docs app to **Cloudflare Workers Static Assets** (the modern successor to Pages), live at https://ui.ng.guide.

## What
- `wrangler.jsonc` — assets-only Worker serving `dist/apps/web/browser`:
  - `not_found_handling: single-page-application` → prerendered routes (`/ui`, `/admin/*`, `/shop/*`, `/tasks/*`) serve their own `index.html`; dynamic routes (`/ui/components/:slug`, demo detail pages) fall through to the client-render shell and hydrate on the client.
  - `routes` with `custom_domain: true` → `ui.ng.guide` is attached declaratively; `wrangler deploy` creates the proxied DNS record in the (same-account) `ng.guide` zone and provisions the cert.
- `deploy:cf` npm script — builds `web` (production), copies the Angular CSR shell (`index.csr.html` → `index.html`) so the SPA fallback has its entrypoint, then `wrangler deploy`.

## Notes
- Already deployed and verified live: all routes return 200, SPA fallback serves the app shell.
- Requires Cloudflare auth (`wrangler login` or `CLOUDFLARE_API_TOKEN`) to run `pnpm deploy:cf`.
- Not yet wired into CI — this is a manual deploy script for now.