### PR TITLE
docs(readme): actualize components, tech stack, and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,92 @@
 # Angular UI Kit by [ng.guide](https://ng.guide/ui-kit?utm_source=github&utm_medium=readme&utm_campaign=ui-kit)
 
-UI Kit is a modern, modular UI component library for Angular — built **from scratch**, guided by the course [ng.guide](https://ng.guide/ui-kit?utm_source=github&utm_medium=readme&utm_campaign=ui-kit).  
-This is not a wrapper around Angular Material — it’s a fresh implementation of Material Design principles with full transparency, customizability, and learning in mind.
+UI Kit is a modern, modular UI component library for Angular — built **from scratch**, guided by the course [ng.guide](https://ng.guide/ui-kit?utm_source=github&utm_medium=readme&utm_campaign=ui-kit).
+This is not a wrapper around Angular Material — it's a fresh implementation of Material Design principles with full transparency, customizability, and learning in mind.
 
 ## 🚧 Work in Progress
 
 UI Kit is being built **in public**, component by component, as part of the Angular UI Kit course. The goal is to provide both a reusable component set **and** an educational reference for building high-quality Angular libraries.
 
-> Want to learn and contribute?  
-> Join the course or jump into issues and PRs — everyone’s welcome.
+> Want to learn and contribute?
+> Join the course or jump into issues and PRs — everyone's welcome.
+
+---
+
+## 🌐 Live Docs
+
+Browse the live documentation at **[ui.ng.guide](https://ui.ng.guide)**. Every component ships with interactive live examples **and** their source code, served from a custom Angular documentation site (no Storybook involved).
 
 ---
 
 ## 📦 Features
 
-- ♻️ **Reusable Angular components**
-- ⚙️ **Built with Angular CLI & Nx**
-- 📦 **ng-packagr & APF-compatible**
+- ♻️ **Reusable Angular components** — standalone, signal-based, zoneless-ready
 - 🧱 **Material Design-inspired, not dependent on Angular Material**
-- 🎨 **Customizable themes & tokens**
-- 🧪 **Tested with Vitest**
+- 📦 **ng-packagr & APF-compatible** publishable package (`@ngguide/ui`)
+- 🎨 **Customizable themes & tokens** powered by an M3 theming layer
+- 🧪 **Tested with Vitest** (Angular's first-party Vitest builder)
+- 🧩 **Per-component entry points** — import only what you use
 
 ---
 
 ## Components
 
-Statuses:
+29 components ship today, each as its own secondary entry point under `@ngguide/ui/*`. All of the components below are available now:
 
-- ✅ done
-- 🛠 in progress
-- ⏳ planned
-- ❌ cancelled
-- 🔧 needs revision
+| Category      | Component           | Import path                    |
+| ------------- | ------------------- | ------------------------------ |
+| Actions       | Buttons             | `@ngguide/ui/button`           |
+| Actions       | FAB / Extended FAB  | `@ngguide/ui/fab`              |
+| Actions       | FAB menu            | `@ngguide/ui/fab-menu`         |
+| Actions       | Icon buttons        | `@ngguide/ui/icon-button`      |
+| Actions       | Button groups       | `@ngguide/ui/button-group`     |
+| Actions       | Segmented buttons   | `@ngguide/ui/segmented-button` |
+| Actions       | Split button        | `@ngguide/ui/split-button`     |
+| Communication | Badges              | `@ngguide/ui/badge`            |
+| Communication | Progress indicators | `@ngguide/ui/progress`         |
+| Communication | Loading indicator   | `@ngguide/ui/loading-indicator`|
+| Communication | Snackbar            | `@ngguide/ui/snackbar`         |
+| Communication | Tooltips            | `@ngguide/ui/tooltip`          |
+| Containment   | Cards               | `@ngguide/ui/card`             |
+| Containment   | Carousel            | `@ngguide/ui/carousel`         |
+| Containment   | Dialogs             | `@ngguide/ui/dialog`           |
+| Containment   | Divider             | `@ngguide/ui/divider`          |
+| Containment   | Lists               | `@ngguide/ui/list`             |
+| Containment   | Bottom sheets       | `@ngguide/ui/bottom-sheet`     |
+| Containment   | Side sheets         | `@ngguide/ui/side-sheet`       |
+| Selection     | Checkbox            | `@ngguide/ui/checkbox`         |
+| Selection     | Radio button        | `@ngguide/ui/radio`            |
+| Selection     | Switch              | `@ngguide/ui/switch`           |
+| Selection     | Chips               | `@ngguide/ui/chip`             |
+| Selection     | Sliders             | `@ngguide/ui/slider`           |
+| Selection     | Menus               | `@ngguide/ui/menu`             |
+| Text inputs   | Text fields         | `@ngguide/ui/text-field`       |
+| Text inputs   | Date pickers        | `@ngguide/ui/date-picker`      |
+| Text inputs   | Time pickers        | `@ngguide/ui/time-picker`      |
+| Foundations   | Icon                | `@ngguide/ui/icon`             |
 
-| Component           | Status |
-| ------------------- | ------ |
-| App bars            | ⏳     |
-| Badges              | ⏳     |
-| Buttons             | 🔧     |
-| Button groups       | ⏳     |
-| Extended FAB        | ⏳     |
-| FAB                 | 🔧     |
-| FAB menu            | ⏳     |
-| Icon buttons        | ⏳     |
-| Segmented buttons   | ⏳     |
-| Split button        | ⏳     |
-| Cards               | ⏳     |
-| Carousel            | ⏳     |
-| Checkbox            | ⏳     |
-| Chips               | ⏳     |
-| Date pickers        | ⏳     |
-| Time pickers        | ⏳     |
-| Dialogs             | ⏳     |
-| Divider             | ⏳     |
-| Lists               | ⏳     |
-| Loading indicator   | ⏳     |
-| Progress indicators | ⏳     |
-| Menus               | ⏳     |
-| Navigation bar      | ⏳     |
-| Navigation drawer   | ⏳     |
-| Navigation rail     | ⏳     |
-| Radio button        | ⏳     |
-| Search              | ⏳     |
-| Bottom sheets       | ⏳     |
-| Side sheets         | ⏳     |
-| Sliders             | ⏳     |
-| Snackbar            | ⏳     |
-| Switch              | ⏳     |
-| Tabs                | ⏳     |
-| Text fields         | ⏳     |
-| Toolbars            | ⏳     |
-| Tooltips            | ⏳     |
+Under the hood, components are built on a set of low-level **building blocks** that ship as their own entry points but are not user-facing components on their own:
+
+- `@ngguide/ui/theme` — `provideM3Theme`, `M3ThemeService`, `generateScheme` (M3 design-token/theming infrastructure)
+- `@ngguide/ui/interaction` — `[guiStateLayer]`, `[guiRipple]`, `[guiFocusRing]` and a11y key managers
+- `@ngguide/ui/overlay` — picker/modal/breakpoint overlay infrastructure
+- `@ngguide/ui/forms` — `[guiFormControl]` ControlValueAccessor bridge for forms integration
+- `@ngguide/ui/datetime` — date models, parsing, and Intl helpers used by the date/time pickers
+- `@ngguide/ui` (base) — shared primitives and types (e.g. the `GuiSize` union)
+
+### Planned
+
+These are genuine Material 3 components not yet built. They have no entry point today and are tracked for future modules:
+
+- App bars
+- Toolbars
+- Navigation bar
+- Navigation rail
+- Navigation drawer
+- Tabs
+- Search
+
+---
 
 ## 🧭 Course Roadmap (Aligned with the Course)
 
@@ -92,14 +108,14 @@ Statuses:
 
 ## 🛠 Tech Stack
 
-- Angular 20
-- Standalone components
-- Signals-based state
-- Tailwind CSS
-- Angular CDK
-- Nx workspace
-- Storybook/Ng Docs
-- Vitest
+- **Angular 21** (standalone components, `ChangeDetectionStrategy.OnPush`)
+- **Signals-based** state and inputs
+- **Zoneless** change detection (no `zone.js`)
+- **Nx 22** monorepo, **pnpm** package manager
+- **ng-packagr** (APF-compatible) for the publishable library, via the `@nx/angular:package` executor
+- **Vitest** (Angular's first-party Vitest builder, jsdom, zoneless) for testing
+- **Custom Angular docs site** hosted at [ui.ng.guide](https://ui.ng.guide) for live examples + code
+- Hand-authored CSS driven by **M3 design tokens** (no CSS framework / utility classes for component styling)
 
 ---
 
@@ -109,12 +125,23 @@ UI Kit is **community-first**. If you're following the course or just want to co
 
 1. Clone the repo
 2. Run `pnpm install`
-3. Use `nx serve [project]` / `nx test [project]` / `nx build [project]` etc.
+3. Use the Nx targets via `pnpm exec`:
+   ```bash
+   pnpm exec nx serve web                         # run the demo / docs playground
+   pnpm exec nx test ui                           # test the library
+   pnpm exec nx build ui                          # build the publishable @ngguide/ui package
+   pnpm exec nx run-many -t lint test build       # everything, both projects
+   ```
 4. Check open issues or suggest improvements
 
 > Every component is developed **with public feedback** — PRs, suggestions, and code reviews are encouraged.
 
-To create a new component, run `nx g @nx/angular:library-secondary-entry-point --library=ui --name=<component-name> --skipModule`.
+To scaffold a new component (each is a secondary entry point of the single `ui` library):
+
+```bash
+pnpm exec nx g @nx/angular:library-secondary-entry-point --library=ui --name=<component-name> --skipModule
+```
+
 ---
 
 ## 📚 Learn as You Build


### PR DESCRIPTION
Actualizes the README against the real codebase (verified via a multi-agent audit of every `libs/ui/*` entry point, the docs registry, `package.json`, and styles).

## Components
- **Removed 7 phantom rows** with no backing entry point: App bars, Navigation bar/rail/drawer, Tabs, Toolbars, Search → moved to a clearly separated **Planned** section.
- Listed the **29 real shipped components** with import paths, grouped by the actual M3 categories (Actions / Communication / Containment / Selection / Text inputs / Foundations).
- Added the missing **Icon** component.
- Documented the low-level **building-block** entry points (`theme`, `interaction`, `overlay`, `forms`, `datetime`, base) instead of mislabeling them as components.

## Tech stack & tooling
- `Angular 20` → **Angular 21**; added **Nx 22**, **pnpm**, **zoneless**.
- Testing stated as **Vitest** (Angular first-party builder).
- Replaced **Storybook/Ng Docs** with the **custom docs site at [ui.ng.guide](https://ui.ng.guide)**.
- Dropped **Tailwind** (unused leftover dep — no `@apply`/`@theme`/`@layer` anywhere; components are hand-authored CSS on M3 tokens).
- Fixed Contributing steps and the secondary-entry-point scaffold command to match `pnpm exec nx` conventions.

The component count (29 = 35 entry points − 6 primitives/utilities) was caught and corrected by an adversarial review pass (draft said 28, table had 29).