### PR TITLE
docs(readme): drop course roadmap and ng.guide branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Angular UI Kit by [ng.guide](https://ng.guide/ui-kit?utm_source=github&utm_medium=readme&utm_campaign=ui-kit)
+# Angular UI Kit
 
-UI Kit is a modern, modular UI component library for Angular — built **from scratch**, guided by the course [ng.guide](https://ng.guide/ui-kit?utm_source=github&utm_medium=readme&utm_campaign=ui-kit).
+UI Kit is a modern, modular UI component library for Angular — built **from scratch**.
 This is not a wrapper around Angular Material — it's a fresh implementation of Material Design principles with full transparency, customizability, and learning in mind.
 
 ## 🚧 Work in Progress
 
-UI Kit is being built **in public**, component by component, as part of the Angular UI Kit course. The goal is to provide both a reusable component set **and** an educational reference for building high-quality Angular libraries.
+UI Kit is being built **in public**, component by component. The goal is to provide both a reusable component set **and** an educational reference for building high-quality Angular libraries.
 
-> Want to learn and contribute?
-> Join the course or jump into issues and PRs — everyone's welcome.
+> Want to contribute?
+> Jump into issues and PRs — everyone's welcome.
 
 ---
 
@@ -76,7 +76,7 @@ Under the hood, components are built on a set of low-level **building blocks** t
 
 ### Planned
 
-These are genuine Material 3 components not yet built. They have no entry point today and are tracked for future modules:
+These are genuine Material 3 components not yet built. They have no entry point today and are tracked for future work:
 
 - App bars
 - Toolbars
@@ -85,24 +85,6 @@ These are genuine Material 3 components not yet built. They have no entry point 
 - Navigation drawer
 - Tabs
 - Search
-
----
-
-## 🧭 Course Roadmap (Aligned with the Course)
-
-| Module | Focus                               | Status     |
-| ------ | ----------------------------------- | ---------- |
-| 1      | Intro to UI Kits and Design Systems | ✅ Done    |
-| 2      | Project Setup and Structure         | ✅ Done    |
-| 3      | Component Architecture              | 🚧 Ongoing |
-| 4      | Styling & Style Isolation           | ⏳ Planned |
-| 5      | Icon System                         | ⏳ Planned |
-| 6      | Theming with Design Tokens          | ⏳ Planned |
-| 7      | Accessibility (a11y)                | ⏳ Planned |
-| 8      | Testing                             | ⏳ Planned |
-| 9      | Documentation                       | ⏳ Planned |
-| 10     | Build & Publish                     | ⏳ Planned |
-| 11–12  | Tooling: Schematics & ng add/update | ⏳ Bonus   |
 
 ---
 
@@ -121,7 +103,7 @@ These are genuine Material 3 components not yet built. They have no entry point 
 
 ## 🧑‍💻 Contributing
 
-UI Kit is **community-first**. If you're following the course or just want to contribute:
+UI Kit is **community-first**. To contribute:
 
 1. Clone the repo
 2. Run `pnpm install`
@@ -141,12 +123,6 @@ To scaffold a new component (each is a secondary entry point of the single `ui` 
 ```bash
 pnpm exec nx g @nx/angular:library-secondary-entry-point --library=ui --name=<component-name> --skipModule
 ```
-
----
-
-## 📚 Learn as You Build
-
-This library is the backbone of the course **Angular UI Kit** on [ng.guide](https://ng.guide/ui-kit?utm_source=github&utm_medium=readme&utm_campaign=ui-kit) — where you learn to build your own UI system, not just use one.
 
 ---
 


### PR DESCRIPTION
Removes the **Course Roadmap** section and the **Learn as You Build** section, and strips the ng.guide course/branding references (title attribution, "guided by the course" framing). Keeps the live docs link at [ui.ng.guide](https://ui.ng.guide).