### PR TITLE
fix(docs): mobile navigation drawer for the component sidebar

### DIFF
--- a/apps/web/src/app/docs/docs-shell.component.css
+++ b/apps/web/src/app/docs/docs-shell.component.css
@@ -52,6 +52,16 @@
 .docs-dark {
   margin: 0 0.25rem;
 }
+/* Hamburger toggles the drawer; only shown on compact viewports. */
+.docs-menu-btn {
+  display: none;
+  margin-right: 0.25rem;
+}
+
+/* Scrim behind the drawer (compact only). */
+.docs-scrim {
+  display: none;
+}
 
 /* ---- Body: sidebar + content ---- */
 .docs-body {
@@ -66,6 +76,8 @@
   align-self: start;
   height: calc(100dvh - 64px);
   overflow-y: auto;
+  /* Keep wheel/touch scrolling inside the sidebar — don't chain to the page. */
+  overscroll-behavior: contain;
   padding: 1rem 0.75rem 2rem;
   border-right: 1px solid var(--md-sys-color-outline-variant, #c8c5d0);
   background: var(--md-sys-color-surface, #fef7ff);
@@ -121,22 +133,55 @@
   border: 1px solid var(--md-sys-color-outline-variant, #c8c5d0);
 }
 
-/* ---- Compact: collapse the sidebar to a scrollable top strip ---- */
+/* ---- Compact: sidebar becomes an off-canvas navigation drawer ---- */
 @media (max-width: 880px) {
+  .docs-menu-btn {
+    display: inline-flex;
+  }
   .docs-body {
     grid-template-columns: 1fr;
   }
+
+  /* The drawer slides in from the left, below the sticky top bar. */
   .docs-sidebar {
-    position: static;
-    height: auto;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    border-right: none;
-    border-bottom: 1px solid var(--md-sys-color-outline-variant, #c8c5d0);
+    position: fixed;
+    top: 64px;
+    left: 0;
+    bottom: 0;
+    z-index: 20;
+    width: min(82vw, 300px);
+    /* Bound the drawer to the viewport so it scrolls internally instead of
+       letting the gesture fall through to the page behind it. */
+    height: calc(100dvh - 64px);
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    box-shadow: var(--md-sys-elevation-2, 0 2px 6px 2px rgba(0, 0, 0, 0.15));
   }
-  .docs-side-group {
-    width: 100%;
-    margin: 0.5rem 0 0;
+  .docs-sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .docs-scrim {
+    display: block;
+    position: fixed;
+    inset: 64px 0 0 0;
+    z-index: 19;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    pointer-events: none;
+    /* Swallow touch gestures so dragging on the backdrop can't scroll the page. */
+    touch-action: none;
+    transition: opacity 0.25s ease;
+  }
+  .docs-scrim.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-sidebar,
+  .docs-scrim {
+    transition: none;
   }
 }

--- a/apps/web/src/app/docs/docs-shell.component.ts
+++ b/apps/web/src/app/docs/docs-shell.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
 import {
   RouterLink,
   RouterLinkActive,
@@ -44,6 +49,19 @@ import { DOC_CATEGORIES } from './component-registry';
   ],
   template: `
     <header class="docs-bar">
+      <button
+        gui-icon-button
+        variant="standard"
+        class="docs-menu-btn"
+        type="button"
+        aria-label="Open navigation"
+        aria-controls="docs-sidebar"
+        [attr.aria-expanded]="drawerOpen()"
+        (click)="drawerOpen.set(!drawerOpen())"
+      >
+        <gui-icon class="sym">{{ drawerOpen() ? 'close' : 'menu' }}</gui-icon>
+      </button>
+
       <a class="docs-brand" routerLink="/ui">
         <span class="docs-brand-mark">M3</span>
         <span class="docs-brand-name">ngguide&nbsp;UI</span>
@@ -86,12 +104,25 @@ import { DOC_CATEGORIES } from './component-registry';
     </header>
 
     <div class="docs-body">
-      <nav class="docs-sidebar" aria-label="Components">
+      <div
+        class="docs-scrim"
+        [class.is-open]="drawerOpen()"
+        (click)="closeDrawer()"
+        aria-hidden="true"
+      ></div>
+
+      <nav
+        class="docs-sidebar"
+        id="docs-sidebar"
+        aria-label="Components"
+        [class.is-open]="drawerOpen()"
+      >
         <a
           class="docs-side-home"
           routerLink="/ui"
           routerLinkActive="is-active"
           [routerLinkActiveOptions]="{ exact: true }"
+          (click)="closeDrawer()"
         >
           <gui-icon class="sym">home</gui-icon>
           Overview
@@ -103,6 +134,7 @@ import { DOC_CATEGORIES } from './component-registry';
               class="docs-side-link"
               [routerLink]="['/ui/components', component.slug]"
               routerLinkActive="is-active"
+              (click)="closeDrawer()"
             >
               {{ component.name }}
             </a>
@@ -130,9 +162,16 @@ import { DOC_CATEGORIES } from './component-registry';
     </ng-template>
   `,
   styleUrl: './docs-shell.component.css',
-  host: { class: 'app-docs-shell' },
+  host: { class: 'app-docs-shell', '(keydown.escape)': 'closeDrawer()' },
 })
 export class DocsShellComponent {
   protected readonly theme = inject(ThemeController);
   protected readonly categories = DOC_CATEGORIES;
+
+  /** Compact-viewport navigation drawer open state (no effect ≥ 881px). */
+  protected readonly drawerOpen = signal(false);
+
+  protected closeDrawer(): void {
+    this.drawerOpen.set(false);
+  }
 }


### PR DESCRIPTION
## Problem
On viewports `≤880px` the docs sidebar became `position: static` and the grid collapsed to one column, so all ~29 component links rendered as a tall wrapped strip **above** the content. On mobile every page load dumped you into that list before reaching the component itself.

## Fix
Replace the compact sidebar with an off-canvas **M3 navigation drawer**:
- Hamburger toggle (☰/✕) in the top bar, shown only on compact.
- Slide-in panel from the left with a scrim backdrop.
- Closes on: selecting a component (+navigates), scrim tap, and **Escape**.
- Drawer is **viewport-bounded and scrolls internally** — `height: calc(100dvh - 64px)`, `overscroll-behavior: contain`, and `touch-action: none` on the scrim — so the gesture no longer scrolls the page behind it.
- Desktop (`>880px`) is unchanged: the static sticky 264px sidebar.
- Added `prefers-reduced-motion` handling and aria (`aria-expanded`/`aria-controls`).

## Verified in preview (375 / 768 / 1280)
default closed + full-width content · open slide-in + scrim · select → navigate + close · scrim-tap close · Escape close · internal scroll without moving the page · desktop layout intact · no console errors.