### PR TITLE
chore(release): configure nx release versioning for ui

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -107,8 +107,15 @@
     }
   },
   "release": {
+    "projects": ["ui"],
+    "releaseTagPattern": "v{version}",
     "version": {
-      "preVersionCommand": "pnpm exec nx run-many -t build"
+      "conventionalCommits": true,
+      "preVersionCommand": "pnpm exec nx build ui"
+    },
+    "changelog": {
+      "projectChangelogs": true,
+      "workspaceChangelog": false
     }
   },
   "analytics": false


### PR DESCRIPTION
## Что

Дополняет `release`-блок в `nx.json`, чтобы релиз библиотеки `@ngguide/ui` версионировался и публиковался через Nx release.

- **Conventional Commits** драйвят бамп версии и changelog (`feat`→minor, `fix`→patch, `BREAKING CHANGE`→major)
- `releaseTagPattern: "v{version}"` — теги вида `v1.2.3`; согласуется с `currentVersionResolver: git-tag` в `libs/ui/project.json`
- `changelog.projectChangelogs: true` → `libs/ui/CHANGELOG.md`; `workspaceChangelog: false` (пакет один)
- `preVersionCommand` сужена с `nx run-many -t build` до `nx build ui` — для релиза библиотеки демо-приложение `web` собирать не нужно

`local-registry` (verdaccio) уже был подключён в корневом `project.json`.

## Использование

```bash
# первый релиз (тегов ещё нет)
NX_NO_CLOUD=true pnpm exec nx release 0.1.0 --first-release

# последующие — версия и changelog считаются автоматически от последнего тега
NX_NO_CLOUD=true pnpm exec nx release --dry-run
NX_NO_CLOUD=true pnpm exec nx release
```

## Проверка

`nx release --first-release --dry-run --skip-publish` отрабатывает: версия резолвится из conventional commits, пишется в `dist/libs/ui/package.json`, генерируется CHANGELOG. Изменений в рабочем дереве dry-run не оставляет.