### PR TITLE
ci(release): tag-triggered npm publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Publish
+
+# The version commit + tag are created locally by the maintainer (`nx release`) and
+# pushed. This workflow only builds and publishes when a v* tag arrives, so it never
+# writes to the repository — `contents` stays read-only.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write # npm provenance
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # tags are needed by the git-tag version resolver
+
+      - uses: pnpm/action-setup@v4 # picks up pnpm version from package.json "packageManager"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build & publish
+        env:
+          NX_NO_CLOUD: 'true'
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # v0.1.0 -> 0.1.0
+          VERSION="${REF_NAME#v}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Tag '$REF_NAME' is not a valid semver version"
+            exit 1
+          fi
+
+          pnpm exec nx build ui
+
+          # The source package.json intentionally stays at 0.0.1 (version lives in git tags),
+          # so stamp the tag's version onto the built manifest before publishing.
+          VERSION="$VERSION" node -e "const fs=require('fs');const f='dist/libs/ui/package.json';const p=JSON.parse(fs.readFileSync(f,'utf8'));p.version=process.env.VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+
+          pnpm exec nx release publish

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -11,6 +11,9 @@
     "@material/material-color-utilities": "^0.4.0"
   },
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     "./styles/theme.css": {
       "style": "./styles/theme.css",


### PR DESCRIPTION
## Что

Добавляет публикацию `@ngguide/ui` в npm из GitHub Actions **без права записи в репозиторий** (вариант «тег локально → CI публикует»).

- **`.github/workflows/release.yml`** (`Publish`): триггер на пуш тега `v*`
  - `permissions: contents: read` (CI ничего не пушит в репо), `id-token: write` (npm provenance)
  - собирает `ui`, записывает версию из тега в `dist/libs/ui/package.json`, затем `nx release publish`
  - версия из тега валидируется как semver перед использованием; ввод идёт через `env` (без shell-инъекции)
- **`libs/ui/package.json`**: `publishConfig.access: "public"` — иначе scoped-пакет npm попытается опубликовать как приватный (поле переносится ng-packagr в `dist`)

Версия в этом репо живёт в git-теге (`currentVersionResolver: git-tag`), исходный `package.json` остаётся `0.0.1` — поэтому стамп версии из тега в `dist` обязателен.

## Требуется от мейнтейнера

1. Секрет `NPM_TOKEN` (npm **Automation** token) в `Settings → Secrets and variables → Actions`.

Права воркфлоу менять не нужно — `contents` остаётся read.

## Релиз (локально)

```bash
# первый раз
NX_NO_CLOUD=true pnpm exec nx release 0.1.0 --first-release --skip-publish
git push --follow-tags origin main   # пуш тега v0.1.0 запускает Publish

# далее
NX_NO_CLOUD=true pnpm exec nx release --skip-publish
git push --follow-tags origin main
```

## Проверка

- Локальный `nx release 0.1.0 --first-release --dry-run --skip-publish` → staging + commit + tag, publish пропущен.
- CI-флоу (build → стамп `0.1.0` в dist → `nx release publish --dry-run`) → `Would publish to https://registry.npmjs.org/ with tag "latest"`.