### PR TITLE
fix(ui): add repository metadata for npm provenance

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@ngguide/ui",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ngguide/ui.git"
+  },
+  "homepage": "https://github.com/ngguide/ui#readme",
+  "bugs": {
+    "url": "https://github.com/ngguide/ui/issues"
+  },
+  "license": "MIT",
   "peerDependencies": {
     "@angular/core": "^21.0.0",
     "@angular/cdk": "^21.2.0",


### PR DESCRIPTION
## Problem

The first Publish run failed during provenance verification:

```
422 Unprocessable Entity - PUT https://registry.npmjs.org/@ngguide%2fui
Error verifying sigstore provenance bundle: package.json: "repository.url" is "",
expected to match "https://github.com/ngguide/ui" from provenance
```

npm with `--provenance` rejects the package unless the published `package.json` carries a `repository.url` matching the source repo. The build and auth both succeeded — this was the only failure, and nothing was published.

## Fix

Adds the following to `libs/ui/package.json` (ng-packagr copies these fields into `dist`):
- `repository` -> `git+https://github.com/ngguide/ui.git`
- `homepage`, `bugs`, `license`

Verified: after `nx build ui` the fields are present in `dist/libs/ui/package.json`.

## After merge

The `v0.1.0` tag points at a commit without the fix, and the workflow builds from the tagged commit — so the tag must be moved to the new HEAD and force-pushed to re-trigger publishing:

```bash
git checkout main && git pull
git tag -f v0.1.0
git push -f origin v0.1.0
```
