### PR TITLE
fix(ui): dismiss hover-opened tooltips with Escape (WCAG 1.4.13)

### DIFF
--- a/libs/ui/tooltip/src/rich-tooltip.spec.ts
+++ b/libs/ui/tooltip/src/rich-tooltip.spec.ts
@@ -75,19 +75,28 @@ describe('GuiRichTooltip', () => {
     expect(describedBy).toBe(panel()?.id);
   });
 
-  it('closes on Escape', () => {
+  it('closes on Escape even when focus is outside the trigger', () => {
+    // Open by hover with focus parked on another control: a host-scoped Escape
+    // listener would never see the key, so this guards the document-scoped path.
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
     trigger().dispatchEvent(new Event('pointerenter'));
     fixture.detectChanges();
     flush();
     expect(panel()).not.toBeNull();
+    expect(document.activeElement).toBe(outside);
 
-    trigger().dispatchEvent(
+    outside.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
     );
     fixture.detectChanges();
 
     expect(panel()).toBeNull();
     expect(trigger().getAttribute('aria-describedby')).toBeNull();
+
+    outside.remove();
   });
 
   it('closes when the panel is clicked (e.g. an action)', () => {

--- a/libs/ui/tooltip/src/rich-tooltip.ts
+++ b/libs/ui/tooltip/src/rich-tooltip.ts
@@ -13,6 +13,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { GuiOverlayHandle, GuiPickerOverlay } from '@ngguide/ui/overlay';
+import { takeUntil } from 'rxjs';
 import { GuiTooltipPosition, tooltipPositions } from './tooltip';
 
 let nextRichId = 0;
@@ -58,8 +59,9 @@ export class GuiRichTooltip {
 /**
  * Opens a {@link GuiRichTooltip} connected to its host. Persistent: stays open
  * while the pointer is over the trigger OR the panel, closing only after a short
- * grace delay once the pointer is over neither. Escape or a click inside the
- * panel (e.g. an action) closes it. Sets `aria-describedby` while open.
+ * grace delay once the pointer is over neither. Escape — from anywhere, per WCAG
+ * 2.2 SC 1.4.13 (Dismissible) — or a click inside the panel (e.g. an action)
+ * closes it. Sets `aria-describedby` while open.
  */
 @Directive({
   selector: '[guiRichTooltipTrigger]',
@@ -69,7 +71,6 @@ export class GuiRichTooltip {
     '(pointerleave)': 'onTriggerLeave()',
     '(focusin)': 'onTriggerEnter()',
     '(focusout)': 'onTriggerLeave()',
-    '(keydown.escape)': 'close()',
   },
 })
 export class GuiRichTooltipTrigger {
@@ -119,15 +120,27 @@ export class GuiRichTooltipTrigger {
       return;
     }
     const positions: ConnectedPosition[] = tooltipPositions(this.position());
-    this.handle = this.overlay.openConnected(this.panel().createPortal(), {
+    const handle = this.overlay.openConnected(this.panel().createPortal(), {
       origin: this.host.nativeElement,
       positions,
       panelClass: 'gui-rich-tooltip-pane',
     });
-    const el = this.handle.ref.overlayElement;
+    this.handle = handle;
+    const el = handle.ref.overlayElement;
     el.addEventListener('pointerenter', this.panelEnter);
     el.addEventListener('pointerleave', this.panelLeave);
     el.addEventListener('click', this.panelClick);
+    // Escape must close the tooltip even when focus is outside the trigger (e.g.
+    // hover-opened, or focus moved into the panel) — WCAG 1.4.13. The CDK keyboard
+    // dispatcher routes document-level keydowns to the top overlay.
+    handle.ref
+      .keydownEvents()
+      .pipe(takeUntil(handle.closed))
+      .subscribe((event) => {
+        if (event.key === 'Escape') {
+          this.close();
+        }
+      });
     this.open.set(true);
   }
 

--- a/libs/ui/tooltip/src/tooltip.spec.ts
+++ b/libs/ui/tooltip/src/tooltip.spec.ts
@@ -68,10 +68,37 @@ describe('GuiTooltip', () => {
     expect(trigger().getAttribute('aria-describedby')).toBeNull();
   });
 
-  it('Escape hides the tooltip and keeps focus on the trigger', () => {
+  it('Escape dismisses a hover-opened tooltip while focus is elsewhere', () => {
+    fixture.detectChanges();
+    // Focus a control that is NOT the trigger, then open the tooltip by hover:
+    // focus never lands on the trigger, so a host-scoped Escape listener can't fire.
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
+    trigger().dispatchEvent(new Event('pointerenter'));
+    fixture.detectChanges();
+    flush();
+    expect(panel()).not.toBeNull();
+    expect(document.activeElement).toBe(outside);
+
+    outside.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(panel()).toBeNull();
+    expect(trigger().getAttribute('aria-describedby')).toBeNull();
+    // Dismissal must not move focus (WCAG 1.4.13).
+    expect(document.activeElement).toBe(outside);
+
+    outside.remove();
+  });
+
+  it('Escape hides a focus-opened tooltip and keeps focus on the trigger', () => {
     fixture.detectChanges();
     trigger().focus();
-    trigger().dispatchEvent(new Event('pointerenter'));
+    trigger().dispatchEvent(new Event('focusin'));
     fixture.detectChanges();
     flush();
     expect(panel()).not.toBeNull();

--- a/libs/ui/tooltip/src/tooltip.ts
+++ b/libs/ui/tooltip/src/tooltip.ts
@@ -15,6 +15,7 @@ import {
   signal,
 } from '@angular/core';
 import { GuiOverlayHandle, GuiPickerOverlay } from '@ngguide/ui/overlay';
+import { takeUntil } from 'rxjs';
 
 export type GuiTooltipPosition = 'above' | 'below' | 'before' | 'after';
 
@@ -79,8 +80,11 @@ export class GuiTooltipPanel {
 
 /**
  * M3 plain tooltip — a short, non-interactive label shown on hover / focus /
- * long-press. Sets `aria-describedby` on the trigger while visible (APG); Escape
- * hides it without moving focus off the trigger.
+ * long-press. Sets `aria-describedby` on the trigger while visible (APG). Escape
+ * dismisses it from anywhere — even when it was opened by hover and focus sits
+ * elsewhere (WCAG 2.2 SC 1.4.13, Dismissible) — without moving focus. The listener
+ * lives on the overlay (document-scoped via the CDK keyboard dispatcher), not the
+ * host, so the key reaches it regardless of where focus is.
  */
 @Directive({
   selector: '[guiTooltip]',
@@ -92,7 +96,6 @@ export class GuiTooltipPanel {
     '(focusout)': 'hide()',
     '(pointerdown)': 'onPointerDown()',
     '(pointerup)': 'cancelLongPress()',
-    '(keydown.escape)': 'hide()',
   },
 })
 export class GuiTooltip implements OnDestroy {
@@ -186,11 +189,23 @@ export class GuiTooltip implements OnDestroy {
       ],
     });
     const portal = new ComponentPortal(GuiTooltipPanel, null, injector);
-    this.handle = this.overlay.openConnected(portal, {
+    const handle = this.overlay.openConnected(portal, {
       origin: this.host.nativeElement,
       positions: tooltipPositions(this.position()),
       panelClass: 'gui-tooltip-pane',
     });
+    this.handle = handle;
+    // Escape must dismiss the tooltip even when it was hover-opened and focus is
+    // elsewhere (WCAG 1.4.13). The CDK keyboard dispatcher routes document-level
+    // keydowns to the top overlay, so listen here rather than on the host.
+    handle.ref
+      .keydownEvents()
+      .pipe(takeUntil(handle.closed))
+      .subscribe((event) => {
+        if (event.key === 'Escape') {
+          this.close();
+        }
+      });
     this.visible.set(true);
   }
 


### PR DESCRIPTION
## Problem

Both `GuiTooltip` and `GuiRichTooltip` bound Escape on the **trigger host**, so the key only reached them while the trigger held keyboard focus. A tooltip opened by pointer hover therefore could not be dismissed from the keyboard at all — the user had to move the pointer away.

This violates **WCAG 2.2 SC 1.4.13** (Content on Hover or Focus), *Dismissible*: a mechanism must be available to dismiss the additional content **without moving pointer hover or keyboard focus**.

Closes #38.

## Fix

Move Escape handling from the host binding to the CDK overlay's `keydownEvents()` stream. The overlay keyboard dispatcher listens at `document` level and routes keydowns to the top-most overlay regardless of where focus is — the same mechanism already used by `openDocked` / `openModal`. The directives stay the single source of truth for `visible` / `open` state (Escape calls their own close path), and the subscription is torn down via the handle's `closed` observable.

- `tooltip.ts`, `rich-tooltip.ts`: drop `(keydown.escape)` from the host, subscribe to `handle.ref.keydownEvents()` on open.
- Docstrings updated to reference WCAG 1.4.13.

## Tests

- Tightened both specs to dispatch Escape from a **separate focused element** rather than the trigger, so a host-only listener goes red. Verified the new specs fail against the old source and pass with the fix.
- `nx test ui` — 379 passed. `nx run-many -t lint build -p ui` — green.

## Manual verification (real browser, `nx serve web`)

- Plain tooltip, hover-opened with focus elsewhere → Escape dismisses it, focus unchanged.
- Rich tooltip, same flow → dismisses, `aria-describedby` cleared.
- Focus-opened tooltip → Escape dismisses, focus stays on the trigger.
- Tooltip + menu interplay (a trigger that is both `guiTooltip` and `cdk-menu-trigger`): Escape routes to the top overlay (menu), the tooltip's listener does not steal it.
- No console errors; `aria-describedby` (APG) unaffected.

https://claude.ai/code/session_01GfQmNz3yrjg4RWr7ZTMGcg