### PR TITLE
fix(ui): stop <a href> clickable card emitting cardActivate twice on Enter

### DIFF
--- a/apps/web/src/app/gallery/demos/card.demo.ts
+++ b/apps/web/src/app/gallery/demos/card.demo.ts
@@ -155,6 +155,21 @@ import { GALLERY_DEMO_UI } from '../demo-block.component';
             </p>
           </gui-card>
         </app-demo-specimen>
+        <app-demo-specimen label="link (&lt;a href&gt;) · {{ linkCount() }} activations">
+          <a
+            guiCardClickable
+            id="card-link-demo"
+            href="#card-link-demo"
+            (cardActivate)="onLink()"
+            class="card card-link"
+          >
+            <h4 class="card-title">Open article</h4>
+            <p class="card-text">
+              A real link card: keeps its link role, and Enter activates it
+              exactly once while the browser performs the native navigation.
+            </p>
+          </a>
+        </app-demo-specimen>
       </app-demo-block>
 
       <!-- ===== Actionable: primary-action region (Variant B) ===== -->
@@ -308,6 +323,23 @@ import { GALLERY_DEMO_UI } from '../demo-block.component';
       justify-content: flex-end;
       margin-top: 0.25rem;
     }
+    .card-link {
+      /* A whole-surface actionable card built on an <a> element. GuiCard's
+         surface styling is :host-scoped to the gui-card element, so an anchor
+         card recreates the outlined-variant look locally and resets the
+         anchor's default link styling. The state layer / ripple / focus ring
+         still come from [guiCardClickable]. */
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+      padding-inline: 16px;
+      border-radius: var(--md-sys-shape-corner-medium);
+      background-color: var(--md-sys-color-surface);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      color: var(--md-sys-color-on-surface);
+      text-decoration: none;
+      cursor: pointer;
+    }
     .card-primary {
       display: flex;
       flex-direction: column;
@@ -328,6 +360,8 @@ export class CardDemo {
   protected readonly clickCount = signal(0);
   /** Primary-action region activations (Variant B) — from `primaryAction`. */
   protected readonly primaryCount = signal(0);
+  /** Link-role whole-surface activations — from an `<a href>` clickable card. */
+  protected readonly linkCount = signal(0);
 
   protected onActivate(): void {
     this.clickCount.update((n) => n + 1);
@@ -335,6 +369,10 @@ export class CardDemo {
 
   protected onPrimary(): void {
     this.primaryCount.update((n) => n + 1);
+  }
+
+  protected onLink(): void {
+    this.linkCount.update((n) => n + 1);
   }
 
   protected readonly codeVariants = `
@@ -371,7 +409,14 @@ export class CardDemo {
 <gui-card variant="elevated" guiCardClickable (cardActivate)="onActivate()">
   <h4>Tap me</h4>
   <p>role=button, keyboard-activatable, ripples on press.</p>
-</gui-card>`;
+</gui-card>
+
+<!-- Link-role card: put [guiCardClickable] on an <a href>. It keeps the
+     link role (no role=button) and Enter triggers native navigation. -->
+<a guiCardClickable href="/article" (cardActivate)="onLink()">
+  <h4>Open article</h4>
+  <p>Activates once on Enter; the browser navigates natively.</p>
+</a>`;
 
   protected readonly codePrimaryAction = `
 <gui-card variant="elevated">

--- a/libs/ui/card/src/card.spec.ts
+++ b/libs/ui/card/src/card.spec.ts
@@ -124,7 +124,7 @@ describe('GuiCardClickable', () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  it('keeps native Enter navigation on an <a href> card and still emits (Req 2.1)', () => {
+  it('keeps native Enter navigation on an <a href> card and emits exactly once (Req 2.1, #39)', () => {
     const fixture = TestBed.createComponent(AnchorClickableHost);
     fixture.detectChanges();
     const el = fixture.debugElement.query(By.directive(GuiCardClickable))
@@ -133,11 +133,17 @@ describe('GuiCardClickable', () => {
     // An anchor keeps its native link role, not role=button.
     expect(el.getAttribute('role')).toBeNull();
 
-    const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true });
-    el.dispatchEvent(event);
+    // Reproduce the real browser sequence: Enter fires a keydown and then,
+    // because the directive leaves the link's default action intact, the
+    // browser synthesises a follow-on click. jsdom does not do this on its own,
+    // so dispatch both to prove activation fires only once across the pair.
+    const keydown = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true });
+    el.dispatchEvent(keydown);
     // The directive must NOT cancel the link's native Enter navigation...
-    expect(event.defaultPrevented).toBe(false);
-    // ...while still emitting its activation event.
+    expect(keydown.defaultPrevented).toBe(false);
+    el.dispatchEvent(new MouseEvent('click', { cancelable: true }));
+
+    // ...while emitting activation exactly once across the whole sequence (#39).
     expect(fixture.componentInstance.count).toBe(1);
   });
 });

--- a/libs/ui/card/src/card.ts
+++ b/libs/ui/card/src/card.ts
@@ -85,16 +85,21 @@ export class GuiCardClickable {
       return;
     }
     if (event.type === 'keydown') {
-      // Stop Space scrolling the page / Enter activating twice — but let a real
-      // link (`<a href>`) perform its native Enter navigation instead of
-      // cancelling it (Req 2.1: a link-role card must stay keyboard-navigable).
+      // A real link (`<a href>`) natively turns Enter into a follow-on click,
+      // which re-enters this handler through the (click) binding. Emitting on
+      // the keydown as well would fire cardActivate twice (issue #39), so for
+      // that one case defer entirely to the native click: don't preventDefault
+      // (keep the link's keyboard navigation, Req 2.1) and don't emit here.
       const isLinkEnter =
         this.isAnchor &&
         this.el.hasAttribute('href') &&
         (event as KeyboardEvent).key === 'Enter';
-      if (!isLinkEnter) {
-        event.preventDefault();
+      if (isLinkEnter) {
+        return;
       }
+      // Otherwise no native click is synthesised: stop Space scrolling the page
+      // and drive activation from the key.
+      event.preventDefault();
     }
     this.cardActivate.emit(event);
   }


### PR DESCRIPTION
## Problem

`GuiCardClickable` binds `activate()` to both `(click)` and `(keydown.enter)`. For an anchor host it deliberately does not `preventDefault()` on Enter, so the link stays keyboard-navigable — but the browser then synthesises a native `click` on the link, which re-enters `activate()` and emits `cardActivate` a **second** time.

Repro: `<a gui-card guiCardClickable href="/x" (cardActivate)="count = count + 1">`. Focus the card, press Enter → `count` increments by 2. Analytics / dialogs / counters fire twice.

The existing spec only dispatched a `keydown` and asserted `count === 1`; jsdom never synthesises the follow-on `click`, so the second emit was invisible to the suite.

## Fix

For a real link (`anchor + href + Enter`) `activate()` now returns early on the keydown: it does **not** `preventDefault()` (native navigation stays intact, Req 2.1) and does **not** emit — activation is left entirely to the native click that follows, so `cardActivate` fires exactly once. Non-anchor (`role="button"`) cards get no synthesised click, so they keep emitting from the key as before. `GuiCardPrimaryAction` is unaffected (never an anchor).

## Tests

- Rewrote the anchor spec to reproduce the real browser sequence — dispatch the `keydown` **and** the follow-on `click` — asserting a single emit and `defaultPrevented === false`. Verified it is a genuine guard: reverting the source turns it red (`count === 2`).
- `nx run-many -t lint test build -p ui` green (379 specs).

## Demo

The gallery only showed `div` (role=button) clickable cards. Added an `<a href>` link-role specimen with its own activation counter so the fixed path is demonstrable. Dogfooded in the running app: each Enter (keydown + synthesised click) increments the counter by exactly 1, with the link's native Enter navigation preserved.

Closes #39.

https://claude.ai/code/session_01GfQmNz3yrjg4RWr7ZTMGcg