### PR TITLE
chore(ui): drop duplicate test-setup.ts from tsconfig.lib.json exclude

### DIFF
--- a/libs/ui/tsconfig.lib.json
+++ b/libs/ui/tsconfig.lib.json
@@ -22,8 +22,7 @@
     "**/*.test.js",
     "**/*.spec.js",
     "**/*.test.jsx",
-    "**/*.spec.jsx",
-    "test-setup.ts"
+    "**/*.spec.jsx"
   ],
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Removes the leftover `"test-setup.ts"` entry from the `exclude` array in `libs/ui/tsconfig.lib.json`.

The `ui` library was migrated to Angular's first-party Vitest builder (AnalogJS removed), which no longer uses a `test-setup.ts` file. The exclude entry is therefore dead config — this drops it. The `**/*.spec.ts` / `**/*.test.ts` patterns already cover the actual test files.

## Changes

- `libs/ui/tsconfig.lib.json`: remove the obsolete `test-setup.ts` exclude entry (1 file, +1 −2)

## Test plan

- [ ] `pnpm exec nx build ui` succeeds (library still compiles without the excluded file present)
- [ ] `pnpm exec nx test ui` still discovers and runs specs

https://claude.ai/code/session_01GfQmNz3yrjg4RWr7ZTMGcg