### PR TITLE
fix(ui): reset underlines on link controls

### DIFF
--- a/libs/ui/fab/src/extended-fab.css
+++ b/libs/ui/fab/src/extended-fab.css
@@ -12,6 +12,7 @@
   box-sizing: border-box;
   cursor: pointer;
   border: none;
+  text-decoration: none;
   position: relative;
   overflow: hidden;
   color: var(--md-sys-color-primary);

--- a/libs/ui/fab/src/extended-fab.spec.ts
+++ b/libs/ui/fab/src/extended-fab.spec.ts
@@ -31,6 +31,12 @@ class AnchorHostComponent {
   disabled = signal(false);
 }
 
+@Component({
+  template: `<a gui-extended-fab href="/test">Compose</a>`,
+  imports: [ExtendedFabComponent],
+})
+class LinkHostComponent {}
+
 describe('ExtendedFabComponent', () => {
   let fixture: ComponentFixture<ExtendedFabHostComponent>;
   let host: ExtendedFabHostComponent;
@@ -96,5 +102,15 @@ describe('ExtendedFabComponent', () => {
 
     expect(anchor.getAttribute('aria-disabled')).toBe('true');
     expect(anchor.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('removes the browser underline from link hosts', () => {
+    const anchorFixture = TestBed.createComponent(LinkHostComponent);
+    anchorFixture.detectChanges();
+
+    const anchor = anchorFixture.nativeElement.querySelector(
+      'a',
+    ) as HTMLAnchorElement;
+    expect(getComputedStyle(anchor).textDecoration).toBe('none');
   });
 });

--- a/libs/ui/fab/src/fab.css
+++ b/libs/ui/fab/src/fab.css
@@ -11,6 +11,7 @@
   box-sizing: border-box;
   cursor: pointer;
   border: none;
+  text-decoration: none;
   position: relative;
   color: var(--md-sys-color-primary);
   box-shadow: var(--md-sys-elevation-level3);

--- a/libs/ui/fab/src/fab.spec.ts
+++ b/libs/ui/fab/src/fab.spec.ts
@@ -24,6 +24,12 @@ class AnchorHostComponent {
   disabled = false;
 }
 
+@Component({
+  imports: [FabComponent],
+  template: `<a gui-fab href="/test">FAB</a>`,
+})
+class LinkHostComponent {}
+
 describe('FabComponent', () => {
   it('should create', () => {
     const fixture = TestBed.createComponent(FabComponent);
@@ -86,5 +92,13 @@ describe('FabComponent', () => {
     const el: HTMLElement = fixture.nativeElement.querySelector('a');
     expect(el.getAttribute('aria-disabled')).toBe('true');
     expect(el.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('removes the browser underline from link hosts', () => {
+    const fixture = TestBed.createComponent(LinkHostComponent);
+    fixture.detectChanges();
+
+    const el: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(getComputedStyle(el).textDecoration).toBe('none');
   });
 });

--- a/libs/ui/icon-button/src/icon-button.css
+++ b/libs/ui/icon-button/src/icon-button.css
@@ -19,6 +19,7 @@
   padding: 0;
   border: none;
   background: transparent;
+  text-decoration: none;
   cursor: pointer;
   position: relative;
 }

--- a/libs/ui/icon-button/src/icon-button.spec.ts
+++ b/libs/ui/icon-button/src/icon-button.spec.ts
@@ -52,6 +52,12 @@ class AnchorHostComponent {
   selected = signal(false);
 }
 
+@Component({
+  template: `<a gui-icon-button href="/test">☆</a>`,
+  imports: [IconButtonComponent],
+})
+class LinkHostComponent {}
+
 describe('IconButtonComponent', () => {
   let fixture: ComponentFixture<IconButtonHostComponent>;
   let host: IconButtonHostComponent;
@@ -211,5 +217,15 @@ describe('IconButtonComponent', () => {
     anchorFixture.detectChanges();
 
     expect(anchorHost.selected()).toBe(false);
+  });
+
+  it('removes the browser underline from link hosts', () => {
+    const anchorFixture = TestBed.createComponent(LinkHostComponent);
+    anchorFixture.detectChanges();
+
+    const anchor = anchorFixture.nativeElement.querySelector(
+      'a',
+    ) as HTMLAnchorElement;
+    expect(getComputedStyle(anchor).textDecoration).toBe('none');
   });
 });


### PR DESCRIPTION
**Description**

Reset `text-decoration` on the link variants of FAB, extended FAB, and icon button controls so their appearance does not depend on a consumer CSS reset.

**Type of change**

- [x] Bug fix

**How Has This Been Tested?**

- `NX_NO_CLOUD=true pnpm exec nx test ui --include=../fab/src/fab.spec.ts --include=../fab/src/extended-fab.spec.ts --include=../icon-button/src/icon-button.spec.ts`
- `NX_NO_CLOUD=true pnpm exec nx lint ui`
- `NX_NO_CLOUD=true pnpm exec nx build ui`
- Rendered the demo app and verified computed `text-decoration: none` on a live `a[gui-icon-button]`; focused computed-style tests cover all three link variants

**Related issues**

Closes #46